### PR TITLE
Make Step E version-aware and add official XSD validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,8 @@
 pandas>=2.0,<3.0
 python-dotenv>=1.0,<2.0
 
+# Step E — XSD validation of generated .twb files
+lxml>=5.0,<6.0
+
 # PostgreSQL
 psycopg2-binary>=2.9,<3.0

--- a/skill/tableau-dashboard-creator/SKILL.md
+++ b/skill/tableau-dashboard-creator/SKILL.md
@@ -94,11 +94,12 @@ Step D: Implementation Spec ──[user approval]──> Step E: TWB Generation 
 Read [references/step-0-brand-setup.md](references/step-0-brand-setup.md) for detailed instructions.
 
 Summary:
-1. Detect branding source: `branding/` directory (preferred) OR `template.twb` in project root
-2. Extract design tokens from `branding.md` + logo, or from `.twb` XML
-3. If fallback defaults are used for any missing brand decision, call out each fallback decision explicitly in `design-tokens.md`
-4. Generate `design-tokens.md` in the project root
-5. Present `design-tokens.md` to the user for approval
+1. **Ask the user for the minimum target Tableau Desktop version first** (`2024.2 – 2025.x` default, or `2026.1+`). Record the answer in `design-tokens.md` — it controls Step E's XML emission.
+2. Detect branding source: `branding/` directory (preferred) OR `template.twb` in project root
+3. Extract design tokens from `branding.md` + logo, or from `.twb` XML
+4. If fallback defaults are used for any missing brand decision, call out each fallback decision explicitly in `design-tokens.md`
+5. Generate `design-tokens.md` in the project root
+6. Present `design-tokens.md` to the user for approval
 
 ## Step A: Data Exploration
 
@@ -159,7 +160,7 @@ Summary:
 
 ## Step E: TWB Workbook Generation (Experimental)
 
-**Target Tableau Version**: `2025.1.10 (20251.25.1121.1650)` — all snippets are validated against this version.
+**Scaffold build string**: `2025.1.10 (20251.25.1121.1650)` — all snippets are authored against this build. The emitted workbook `version` attribute and the inclusion of `<explain-data>` are driven by the **Target Tableau Version** captured in Step 0. See `references/step-e-twb-generation.md § Tableau Version Targeting`.
 
 Read [references/step-e-twb-generation.md](references/step-e-twb-generation.md) for detailed instructions.
 

--- a/skill/tableau-dashboard-creator/references/step-0-brand-setup.md
+++ b/skill/tableau-dashboard-creator/references/step-0-brand-setup.md
@@ -4,13 +4,19 @@
 
 ## Process
 
-1. **Detect branding source** — check the user's project root for one of:
+1. **Ask the user for the minimum target Tableau Desktop version** — this is the **first thing you do in Step 0**, before any branding work. Use the `AskUserQuestion` tool with these options:
+   - **2024.2 – 2025.x** *(Recommended — broadest installed base)*
+   - **2026.1+** *(only if the user explicitly needs newer features)*
+
+   This single answer drives Step E's TWB emission rules (workbook `version` attribute, manifest tags, and whether `<explain-data>` is required). Save the answer verbatim into `design-tokens.md` under the `## Target Tableau Version` section. If the user is unsure, default to **2024.2 – 2025.x** and note the default in the file.
+
+2. **Detect branding source** — check the user's project root for one of:
    - `branding/` directory — containing `branding.md` and optionally a logo file or `icons/` directory (preferred)
    - `template.twb` — the organization's Tableau template workbook (fallback)
 
-2. **Extract or build design tokens** depending on which source is found
-3. **Generate `design-tokens.md`** in the project root
-4. **Present design-tokens.md to the user for approval** before proceeding to Step A
+3. **Extract or build design tokens** depending on which source is found
+4. **Generate `design-tokens.md`** in the project root
+5. **Present design-tokens.md to the user for approval** before proceeding to Step A
 
 ---
 
@@ -129,6 +135,11 @@ Generate this file in the project root:
 
 **Source**: [template.twb / branding directory / fallback defaults]
 **Derived for**: [Step 0 approval candidate]
+
+## Target Tableau Version
+- **Minimum version**: [2024.2 – 2025.x  |  2026.1+]
+- **Selected by**: [user-confirmed | default]
+- **Affects**: Step E only — controls workbook `version` attribute, manifest tag set, and whether `<explain-data>` is emitted. See `step-e-twb-generation.md § Tableau Version Targeting`.
 
 ## Typography
 - **Font family**: [extracted font]

--- a/skill/tableau-dashboard-creator/references/step-e-twb-generation.md
+++ b/skill/tableau-dashboard-creator/references/step-e-twb-generation.md
@@ -27,8 +27,9 @@ If `design-tokens.md` does not have a `## Target Tableau Version` section, defau
 4. **Locate sample data CSVs** from Step A (in the project root or `sample-data/` directory)
 5. **Read the relevant snippet files and companion docs** (see Assembly Workflow below)
 6. **Assemble `dashboard.twb`** from validated snippet patterns
-7. **Package as `dashboard.twbx`** — a ZIP archive bundling the `.twb` with all sample CSV data files
-8. **Save to** `mock-version/v_N/` (both `.twb` and `.twbx`)
+7. **Run both validators** on the assembled `.twb` (see *Validation* below) — `validate_twb.py` and `validate_twb_xsd.py`. Resolve any failures before continuing.
+8. **Package as `dashboard.twbx`** — a ZIP archive bundling the `.twb` with all sample CSV data files
+9. **Save to** `mock-version/v_N/` (both `.twb` and `.twbx`)
 
 ---
 
@@ -271,10 +272,44 @@ These rules are derived from real Tableau Desktop validation failures.
 
 ---
 
+## Validation
+
+**Always run BOTH validators on every generated `.twb` before packaging the `.twbx`.** They are complementary, not redundant — the XSD covers structural correctness (element nesting, attribute names, value enums, child ordering), and `validate_twb.py` covers cross-section semantic integrity (datasource refs, column-instance refs, filter↔slices, worksheet↔window) that the XSD explicitly skips via `processContents="skip"`.
+
+### Commands
+
+From the project root (replace `v_N` with the actual version dir):
+
+```bash
+# Semantic validation
+python <skill-root>/scripts/validate_twb.py mock-version/v_N/dashboard.twb
+
+# Structural validation against official Tableau XSD
+python <skill-root>/scripts/validate_twb_xsd.py mock-version/v_N/dashboard.twb
+```
+
+`<skill-root>` is `skill/tableau-dashboard-creator/` inside the installed skill. The XSD validator requires `lxml` (in `requirements.txt`).
+
+### Interpreting XSD output
+
+The XSD is the official 2026.1 schema (`references/xsd/twb_2026.1.0.xsd`). When the target is **2024.2 – 2025.x**, expect a small set of version-shifted false positives. Bucket every error you see:
+
+| Bucket | Examples | What to do |
+|---|---|---|
+| **1. Real structural bug** *(most errors fall here)* | Misspelled element, wrong nesting order, missing required attribute, invalid enum value (e.g., `param='vertical'` instead of `'vert'`/`'horz'`), `<zone-style>` not last child of zone, attribute on wrong element | **Fix the workbook.** These would break 2025.x too. |
+| **2. Known 2026.1-only requirement** *(safe to ignore for 2025.x target)* | `Element 'workbook': Missing child element(s). Expected is one of ( external, referenced-extensions, explain-data )` <br><br> `Element 'layout', attribute 'dim-percentage': The attribute 'dim-percentage' is not allowed.` <br><br> `Element 'layout', attribute 'measure-percentage': The attribute 'measure-percentage' is not allowed.` | **Ignore — these are the documented 2026.1 deltas.** A clean 2025.x-targeted workbook will produce exactly **one** such error: the missing `explain-data`/`referenced-extensions`/`external` child. The `dim-percentage` errors should not appear in your output because rule #5 (Datasource Structure) tells you not to emit them. |
+| **3. Unknown 2026.1-only difference** | Anything not in bucket 2 that you suspect is version-related | Investigate: confirm the element/attribute exists in the 2026.1 XSD definition. If the schema has it as required-only-in-26.1 and your target is 2025.x, treat as bucket 2 (ignore, but **add it to bucket 2 in this doc** so future runs don't re-investigate). Otherwise treat as bucket 1. |
+
+> **Pass criterion**: `validate_twb.py` must report **all checks passed**. `validate_twb_xsd.py` may report at most the **single known 2025.x bucket-2 error** above; any additional XSD errors must be resolved or escalated to bucket 3 before approval.
+
+---
+
 ## Validation Checklist
 
 Before saving the `.twb`, verify:
 
+- [ ] `validate_twb.py` reports all checks passed
+- [ ] `validate_twb_xsd.py` reports only the known bucket-2 error (or PASS for a 2026.1+ target)
 - [ ] XML is well-formed (all tags properly closed)
 - [ ] `source-build` is `2025.1.10 (20251.25.1121.1650)`
 - [ ] Manifest tags copied from scaffold (simple names, no FCP prefixes)

--- a/skill/tableau-dashboard-creator/references/step-e-twb-generation.md
+++ b/skill/tableau-dashboard-creator/references/step-e-twb-generation.md
@@ -2,9 +2,22 @@
 
 **Identity**: You are a Tableau XML engineer. Your goal is to generate a valid `.twbx` packaged workbook that can be opened directly in Tableau Desktop, fully implementing the dashboard from Step D's specification.
 
-**Target Version**: `source-build='2025.1.10 (20251.25.1121.1650)'`
+**Default scaffold build string**: `source-build='2025.1.10 (20251.25.1121.1650)'`. All snippets are authored against this build. The actual emitted `version` and content model depend on the user's **Target Tableau Version** (set in Step 0 — see *Tableau Version Targeting* below).
 
 > **Experimental**: This step generates Tableau XML programmatically. The output should be a functional starting point, though minor adjustments in Tableau Desktop may be needed.
+
+---
+
+## Tableau Version Targeting
+
+Read `## Target Tableau Version` from `design-tokens.md` (set in Step 0). Apply the matching emission rules below. Do **not** ask the user again — Step 0 already collected this.
+
+| Target version | Workbook attribute | `<explain-data>` element | Notes |
+|----------------|--------------------|--------------------------|-------|
+| **2024.2 – 2025.x** *(default)* | `version='18.1'` | **Do NOT emit** — Tableau 2025.x rejects this element with error code `D2E8DA72` (`no declaration found for element 'explain-data'`) | Use the scaffold as-is. The 2025.x content model ends with `..., windows, thumbnails?, external?` — anything after `<thumbnails />` other than `<external>` breaks the load. |
+| **2026.1+** | `version='26.1'` | **Required** — emit immediately after `<thumbnails />`:<br>`<explain-data enabled-for-viewer='false' extreme-values-enabled-for-all='false'><explanation-types /></explain-data>` | The official `twb_2026.1.0.xsd` declares `<explain-data>` as a required workbook child. |
+
+If `design-tokens.md` does not have a `## Target Tableau Version` section, default to **2024.2 – 2025.x** and add a `MANUAL_STEPS.md` note that the user should confirm the target.
 
 ## Process
 
@@ -227,7 +240,7 @@ These rules are derived from real Tableau Desktop validation failures.
 
 ### Datasource Structure
 4. **`<relation>` must be plain** — never wrap with FCP wrappers
-5. **`<layout>` requires `dim-percentage` and `measure-percentage`** — always include `dim-percentage='0.5' measure-percentage='0.4'`
+5. **`<layout>` percentages — omit them.** Do NOT include `dim-percentage` / `measure-percentage` attributes on `<layout>`. Tableau 2025.x loads fine without them; the 2026.1 XSD renamed them to `dim-percentage-v2` / `measure-percentage-v2` and rejects the un-suffixed names. Emit only `dim-ordering`, `measure-ordering`, `show-structure`. *(This rule changed — older guidance said these were required. They are not.)*
 6. **`directory='.'` always** — never use subdirectory paths in connections
 7. **Generate as live connection only** — no `<extract>` sections
 8. **4-way column redundancy** — every column must be defined in: `relation > columns`, `metadata-records`, `object-graph > properties > relation > columns`, AND `datasource > column` direct children (see SCAFFOLD.md)
@@ -267,7 +280,8 @@ Before saving the `.twb`, verify:
 - [ ] Manifest tags copied from scaffold (simple names, no FCP prefixes)
 - [ ] All datasource connections use `directory='.'`
 - [ ] All columns defined in all 4 redundancy locations
-- [ ] All `<layout>` elements include `dim-percentage` and `measure-percentage`
+- [ ] `<layout>` elements do NOT contain `dim-percentage` / `measure-percentage` (see Datasource Structure rule #5)
+- [ ] Workbook `version` attribute and `<explain-data>` emission match the *Tableau Version Targeting* table
 - [ ] All `<relation>` elements are plain (no FCP wrappers)
 - [ ] No `<extract>` sections present
 - [ ] All field names match DS-ARCHITECTURE.md

--- a/skill/tableau-dashboard-creator/references/xsd/twb_2026.1.0.xsd
+++ b/skill/tableau-dashboard-creator/references/xsd/twb_2026.1.0.xsd
@@ -1,0 +1,7586 @@
+<!--
+ Tableau Workbook Schema (TWB)
+ Version: 2026.1.0
+ Published: 2026-02-27T19:11:46Z
+ Build: 20261.26.0211.1127
+ This schema validates Tableau workbook (.twb) files for version 2026.1.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:user="http://www.tableausoftware.com/xml/user" elementFormDefault="qualified" version="2026.1.0">
+  <xs:annotation>
+    <xs:documentation>
+      Tableau Workbook Schema for version 2026.1
+      Publication Info:
+      - Generated: 2026-02-27T19:11:46Z
+      - Source Build: 20261.26.0211.1127
+      - Schema Version: 1.0
+    </xs:documentation>
+  </xs:annotation>
+<xs:import namespace="http://www.tableausoftware.com/xml/user" schemaLocation="user.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:attributeGroup name="LinkSpec-AG">
+    <xs:attribute name="caption" type="xs:string" use="required"/>
+    <xs:attribute name="expression" type="xs:string" use="required"/>
+    <xs:attribute name="multi-select" type="xs:boolean"/>
+    <xs:attribute name="delimiter" type="xs:string"/>
+    <xs:attribute name="escape" type="xs:string"/>
+    <xs:attribute name="include-null" type="xs:boolean"/>
+    <xs:attribute name="url-escape" type="xs:boolean"/>
+  </xs:attributeGroup>
+  <xs:group name="ActionSpec-G">
+    <xs:sequence>
+      <xs:element name="action">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attributeGroup ref="LinkSpec-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ActivationMethod-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="explicit"/>
+      <xs:enumeration value="on-select"/>
+      <xs:enumeration value="on-hover"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SourceType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="all"/>
+      <xs:enumeration value="datasource"/>
+      <xs:enumeration value="sheet"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="UrlActionType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="default-zone-or-browser"/>
+      <xs:enumeration value="browser"/>
+      <xs:enumeration value="specific-zone"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="ActionList-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="actions" type="ActionList-ActionList-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Actions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="actions">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="LegacyActions-G"/>
+            <xs:group minOccurs="0" ref="DataSourcesAndDependencies-G"/>
+            <xs:group ref="NavActions-G"/>
+            <xs:group ref="GroupActions-G"/>
+            <xs:group ref="ParameterActions-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ActionsOrActionList-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="actions">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="LegacyActions-G"/>
+            <xs:group minOccurs="0" ref="DataSourcesAndDependencies-G"/>
+            <xs:group ref="NavActions-G"/>
+            <xs:group ref="GroupActions-G"/>
+            <xs:group ref="ParameterActions-G"/>
+          </xs:sequence>
+          <xs:attribute name="brushing-enabled" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="LegacyActions-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="LegacyAction-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="LegacyAction-G">
+    <xs:sequence>
+      <xs:element name="action">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ActionList-ActionActivation-G"/>
+            <xs:group ref="ActionList-ActionSource-G"/>
+            <xs:group minOccurs="0" ref="ActionList-Link-G"/>
+            <xs:group minOccurs="0" ref="ActionList-Command-G"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="ActionList-ActionAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="NavActions-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="NavAction-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GroupActions-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="GroupAction-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ParameterActions-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="ParameterAction-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="NavAction-G">
+    <xs:sequence>
+      <xs:element name="nav-action">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ActionList-ActionActivation-G"/>
+            <xs:group ref="ActionList-ActionSource-G"/>
+            <xs:element minOccurs="0" name="params">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="ActionList-ActionParams-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attributeGroup ref="ActionList-ActionAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GroupAction-G">
+    <xs:sequence>
+      <xs:element name="edit-group-action">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ActionList-ActionActivation-G"/>
+            <xs:group ref="ActionList-ActionSource-G"/>
+            <xs:element minOccurs="0" name="single-select">
+              <xs:complexType>
+                <xs:attribute name="value" type="xs:boolean"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="add-or-remove-marks">
+              <xs:complexType>
+                <xs:attribute name="value" type="ActionList-Modification-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="params">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="ActionList-ActionParams-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attributeGroup ref="ActionList-ActionAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ParameterAction-G">
+    <xs:sequence>
+      <xs:element name="edit-parameter-action">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ActionList-ActionActivation-G"/>
+            <xs:group ref="ActionList-ActionSource-G"/>
+            <xs:element minOccurs="0" name="agg-type">
+              <xs:complexType>
+                <xs:attribute name="type" type="ActionList-Agg-ST"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="clear-option">
+              <xs:complexType>
+                <xs:attribute name="type" type="ActionList-ClearSelectionType-ST"/>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="params">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="ActionList-ActionParams-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attributeGroup ref="ActionList-ActionAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="ActionList-ActionList-CT">
+    <xs:sequence>
+      <xs:group ref="LegacyActions-G"/>
+      <xs:group ref="DataSourcesAndDependencies-G"/>
+      <xs:group ref="NavActions-G"/>
+      <xs:group ref="GroupActions-G"/>
+      <xs:group ref="ParameterActions-G"/>
+    </xs:sequence>
+    <xs:attribute name="brushing-enabled" type="xs:boolean"/>
+  </xs:complexType>
+  <xs:group name="ActionList-ActionActivation-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="activation">
+        <xs:complexType>
+          <xs:attribute name="type" type="ActivationMethod-ST"/>
+          <xs:attribute name="auto-clear" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ActionList-ActionSource-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="source">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="exclude-sheet">
+              <xs:complexType>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="type" type="SourceType-ST" use="required"/>
+          <xs:attribute name="datasource" type="xs:string"/>
+          <xs:attribute name="worksheet" type="xs:string"/>
+          <xs:attribute name="dashboard" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ActionList-Link-G">
+    <xs:sequence>
+      <xs:element name="link">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="url-action-type" type="UrlActionType-ST"/>
+            <xs:element minOccurs="0" name="url-action-target" type="xs:string"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="LinkSpec-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ActionList-Command-G">
+    <xs:sequence>
+      <xs:element name="command">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="param">
+              <xs:complexType>
+                <xs:attribute name="name" type="xs:string"/>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="command" type="ActionList-CommandName-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ActionList-ActionParams-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="param">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="ActionList-ActionAttributes-AG">
+    <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+    <xs:attribute name="enabled" type="xs:boolean"/>
+    <xs:attribute name="caption" type="xs:string"/>
+  </xs:attributeGroup>
+  <xs:simpleType name="ActionList-CommandName-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^:]+:[^:]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ActionList-Agg-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="attr"/>
+      <xs:enumeration value="sum"/>
+      <xs:enumeration value="average"/>
+      <xs:enumeration value="min"/>
+      <xs:enumeration value="max"/>
+      <xs:enumeration value="median"/>
+      <xs:enumeration value="collect"/>
+      <xs:enumeration value="union"/>
+      <xs:enumeration value="count"/>
+      <xs:enumeration value="count-d"/>
+      <xs:enumeration value="std-dev"/>
+      <xs:enumeration value="std-dev-p"/>
+      <xs:enumeration value="var"/>
+      <xs:enumeration value="var-p"/>
+      <xs:enumeration value="concatenate"/>
+      <xs:enumeration value="quart1"/>
+      <xs:enumeration value="quart3"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ActionList-Modification-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="assign"/>
+      <xs:enumeration value="add"/>
+      <xs:enumeration value="remove"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ActionList-ClearSelectionType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="do-nothing"/>
+      <xs:enumeration value="assign-fixed-value"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Extension-String-ST">
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="1000"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Localized-Resource-String-CT">
+    <xs:simpleContent>
+      <xs:extension base="Extension-String-ST">
+        <xs:attribute name="locale" type="Extension-String-ST" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Resource-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="100" name="text" type="Localized-Resource-String-CT"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="Extension-String-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Resources-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="resource" type="Resource-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Limited-Length-URL-ST">
+    <xs:restriction base="xs:anyURI">
+      <xs:maxLength value="2083"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Author-URL-ST">
+    <xs:restriction base="Limited-Length-URL-ST">
+      <xs:pattern value="[Hh][Tt][Tt][Pp][Ss]://.+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Extension-URL-ST">
+    <xs:restriction base="Limited-Length-URL-ST">
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Source-Location-CT">
+    <xs:choice>
+      <xs:element name="url" type="Extension-URL-ST"/>
+    </xs:choice>
+  </xs:complexType>
+  <xs:simpleType name="Version-ST">
+    <xs:restriction base="Extension-String-ST">
+      <xs:pattern value="[0-9]+\.[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Author-CT">
+    <xs:attribute name="email" type="Extension-String-ST" use="required"/>
+    <xs:attribute name="name" type="Extension-String-ST" use="required"/>
+    <xs:attribute name="organization" type="Extension-String-ST"/>
+    <xs:attribute name="website" type="Author-URL-ST" use="required"/>
+  </xs:complexType>
+  <xs:simpleType name="Size-Type-ST">
+    <xs:restriction base="Extension-String-ST">
+      <xs:enumeration value="default"/>
+      <xs:enumeration value="max"/>
+      <xs:enumeration value="min"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Positive-Int-ST">
+    <xs:restriction base="xs:int">
+      <xs:minExclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Size-CT">
+    <xs:attribute name="height" type="Positive-Int-ST" use="required"/>
+    <xs:attribute name="width" type="Positive-Int-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Layout-CT">
+    <xs:all>
+      <xs:element minOccurs="0" name="max-size" type="Size-CT"/>
+      <xs:element minOccurs="0" name="min-size" type="Size-CT"/>
+      <xs:element minOccurs="0" name="default-size" type="Size-CT"/>
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="Localized-Text-CT">
+    <xs:simpleContent>
+      <xs:extension base="Extension-String-ST">
+        <xs:attribute name="resource-id" type="Extension-String-ST"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="Extension-Id-ST">
+    <xs:restriction base="Extension-String-ST">
+      <xs:pattern value="[A-Za-z]{2,6}(\.[A-Za-z0-9\-]{1,63})+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Extension-Icon-ST">
+    <xs:restriction base="xs:base64Binary">
+      <xs:maxLength value="19608"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Extension-Permission-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="full data"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Extension-Permissions-CT">
+    <xs:sequence>
+      <xs:element name="permission" type="Extension-Permission-ST"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Extension-Context-Menu-Configure-ST">
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Extension-Context-Menu-CT">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="configure-context-menu-item" type="Extension-Context-Menu-Configure-ST"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Encoding-Seq-CT">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="encoding" type="Encoding-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Encoding-CT">
+    <xs:attribute name="name" type="Extension-String-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Tableau-Extension-CT">
+    <xs:sequence>
+      <xs:element name="default-locale" type="Extension-String-ST"/>
+      <xs:element name="name" type="Localized-Text-CT"/>
+      <xs:element name="description" type="Localized-Text-CT"/>
+      <xs:element name="author" type="Author-CT"/>
+      <xs:element name="min-api-version" type="Version-ST"/>
+      <xs:element name="source-location" type="Source-Location-CT"/>
+      <xs:element name="icon" type="Extension-Icon-ST"/>
+      <xs:element minOccurs="0" name="permissions" type="Extension-Permissions-CT"/>
+      <xs:element minOccurs="0" name="context-menu" type="Extension-Context-Menu-CT"/>
+      <xs:element minOccurs="0" name="disable-sorting-ui" type="xs:boolean"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="Extension-Id-ST" use="required"/>
+    <xs:attribute name="extension-version" type="Extension-String-ST"/>
+  </xs:complexType>
+  <xs:complexType name="Dashboard-Extension-CT">
+    <xs:complexContent>
+      <xs:extension base="Tableau-Extension-CT">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="layout" type="Layout-CT"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="Data-Type-ST">
+    <xs:restriction base="Extension-String-ST">
+      <xs:enumeration value="numeric"/>
+      <xs:enumeration value="temporal"/>
+      <xs:enumeration value="string"/>
+      <xs:enumeration value="boolean"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Data-Type-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="4" name="data-type" type="Data-Type-ST"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Role-Type-ST">
+    <xs:restriction base="Extension-String-ST">
+      <xs:enumeration value="discrete-dimension"/>
+      <xs:enumeration value="discrete-measure"/>
+      <xs:enumeration value="continuous-dimension"/>
+      <xs:enumeration value="continuous-measure"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Role-Type-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="4" name="role-type" type="Role-Type-ST"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="MaxField-CT">
+    <xs:attribute name="max-count" type="Positive-Int-ST" use="required"/>
+  </xs:complexType>
+  <xs:simpleType name="Image-Type-ST">
+    <xs:restriction base="Extension-String-ST">
+      <xs:enumeration value="color"/>
+      <xs:enumeration value="size"/>
+      <xs:enumeration value="text"/>
+      <xs:enumeration value="sort"/>
+      <xs:enumeration value="shape"/>
+      <xs:enumeration value="wedge"/>
+      <xs:enumeration value="level-of-detail"/>
+      <xs:enumeration value="tooltip"/>
+      <xs:enumeration value="level"/>
+      <xs:enumeration value="level-radial"/>
+      <xs:enumeration value="edge"/>
+      <xs:enumeration value="letter-a"/>
+      <xs:enumeration value="letter-b"/>
+      <xs:enumeration value="letter-c"/>
+      <xs:enumeration value="letter-d"/>
+      <xs:enumeration value="letter-e"/>
+      <xs:enumeration value="letter-f"/>
+      <xs:enumeration value="letter-g"/>
+      <xs:enumeration value="letter-h"/>
+      <xs:enumeration value="letter-i"/>
+      <xs:enumeration value="letter-j"/>
+      <xs:enumeration value="letter-k"/>
+      <xs:enumeration value="letter-l"/>
+      <xs:enumeration value="letter-m"/>
+      <xs:enumeration value="letter-n"/>
+      <xs:enumeration value="letter-o"/>
+      <xs:enumeration value="letter-p"/>
+      <xs:enumeration value="letter-q"/>
+      <xs:enumeration value="letter-r"/>
+      <xs:enumeration value="letter-s"/>
+      <xs:enumeration value="letter-t"/>
+      <xs:enumeration value="letter-u"/>
+      <xs:enumeration value="letter-v"/>
+      <xs:enumeration value="letter-w"/>
+      <xs:enumeration value="letter-x"/>
+      <xs:enumeration value="letter-y"/>
+      <xs:enumeration value="letter-z"/>
+      <xs:enumeration value="digit-0"/>
+      <xs:enumeration value="digit-1"/>
+      <xs:enumeration value="digit-2"/>
+      <xs:enumeration value="digit-3"/>
+      <xs:enumeration value="digit-4"/>
+      <xs:enumeration value="digit-5"/>
+      <xs:enumeration value="digit-6"/>
+      <xs:enumeration value="digit-7"/>
+      <xs:enumeration value="digit-8"/>
+      <xs:enumeration value="digit-9"/>
+      <xs:enumeration value="hash"/>
+      <xs:enumeration value="dollar"/>
+      <xs:enumeration value="percentage"/>
+      <xs:enumeration value="ampersand"/>
+      <xs:enumeration value="exclamation"/>
+      <xs:enumeration value="smaller-than"/>
+      <xs:enumeration value="equal"/>
+      <xs:enumeration value="larger-than"/>
+      <xs:enumeration value="question"/>
+      <xs:enumeration value="at-symbol"/>
+      <xs:enumeration value="function"/>
+      <xs:enumeration value="dot"/>
+      <xs:enumeration value="favorite"/>
+      <xs:enumeration value="filter"/>
+      <xs:enumeration value="flow"/>
+      <xs:enumeration value="forecast"/>
+      <xs:enumeration value="globe"/>
+      <xs:enumeration value="grid"/>
+      <xs:enumeration value="highlight"/>
+      <xs:enumeration value="image"/>
+      <xs:enumeration value="join"/>
+      <xs:enumeration value="link"/>
+      <xs:enumeration value="metric"/>
+      <xs:enumeration value="delta-down"/>
+      <xs:enumeration value="delta-up"/>
+      <xs:enumeration value="three-dots"/>
+      <xs:enumeration value="arrow-down"/>
+      <xs:enumeration value="arrow-up"/>
+      <xs:enumeration value="arrow-left"/>
+      <xs:enumeration value="arrow-right"/>
+      <xs:enumeration value="thumbnail-even"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Encoding-Icon-CT">
+    <xs:simpleContent>
+      <xs:extension base="Extension-Icon-ST">
+        <xs:attribute name="token" type="Image-Type-ST"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Encoding-Custom-CT">
+    <xs:sequence>
+      <xs:element name="display-name" type="Localized-Text-CT"/>
+      <xs:element minOccurs="0" name="data-spec" type="Data-Type-CT"/>
+      <xs:element minOccurs="0" name="role-spec" type="Role-Type-CT"/>
+      <xs:element minOccurs="0" name="fields" type="MaxField-CT"/>
+      <xs:element minOccurs="0" name="encoding-icon" type="Encoding-Icon-CT"/>
+      <xs:element minOccurs="0" name="tooltip" type="Localized-Text-CT"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="Extension-String-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Worksheet-Extension-CT">
+    <xs:complexContent>
+      <xs:extension base="Tableau-Extension-CT">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="4" name="encoding" type="Encoding-Custom-CT"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ExtensionManifest-CT">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DocumentManifest-G"/>
+      <xs:choice>
+        <xs:element name="dashboard-extension" type="Dashboard-Extension-CT"/>
+        <xs:element name="worksheet-extension" type="Worksheet-Extension-CT"/>
+      </xs:choice>
+      <xs:element minOccurs="0" name="resources" type="Resources-CT"/>
+    </xs:sequence>
+    <xs:attribute name="manifest-version" type="Version-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Settings-Value-CT">
+    <xs:attribute name="key" type="xs:string" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Instance-Settings-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" type="Settings-Value-CT" name="setting"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Dashboard-Settings-CT">
+  </xs:complexType>
+  <xs:complexType name="Worksheet-Settings-CT">
+  </xs:complexType>
+  <xs:complexType name="Type-Settings-CT">
+    <xs:choice>
+      <xs:element name="dashboard" type="Dashboard-Settings-CT"/>
+      <xs:element name="worksheet" type="Worksheet-Settings-CT"/>
+    </xs:choice>
+  </xs:complexType>
+  <xs:complexType name="Extension-CT">
+    <xs:sequence>
+      <xs:element name="instance-settings" type="Instance-Settings-CT">
+        <xs:unique name="DemandUniqueKeys">
+          <xs:selector xpath="setting"/>
+          <xs:field xpath="@key"/>
+        </xs:unique>
+      </xs:element>
+      <xs:element name="type-settings" type="Type-Settings-CT"/>
+    </xs:sequence>
+    <xs:attribute name="add-in-id" type="xs:string" use="required"/>
+    <xs:attribute name="instance-id" type="xs:string" use="required"/>
+    <xs:attribute name="extension-version" type="xs:string" use="required"/>
+    <xs:attribute name="extension-url" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:simpleType name="AggType-ST">
+    <xs:restriction base="xs:string">
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="FormattedText-G">
+    <xs:sequence>
+      <xs:element name="formatted-text">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="run">
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="fontname" type="xs:string"/>
+                    <xs:attribute name="fontsize" type="xs:unsignedInt"/>
+                    <xs:attribute name="fontalignment" type="xs:int"/>
+                    <xs:attribute name="bold" type="xs:boolean"/>
+                    <xs:attribute name="italic" type="xs:boolean"/>
+                    <xs:attribute name="underline" type="xs:boolean"/>
+                    <xs:attribute name="fontcolor" type="ColorObject-ST"/>
+                    <xs:attribute name="indent" type="xs:int"/>
+                    <xs:attribute name="lmargin" type="xs:int"/>
+                    <xs:attribute name="rmargin" type="xs:int"/>
+                    <xs:attribute name="hyperlink" type="xs:string"/>
+                    <xs:attribute name="auto-url" type="xs:boolean"/>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="StoryDelta-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="added"/>
+      <xs:enumeration value="edited"/>
+      <xs:enumeration value="removed"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="FieldNames-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="field" type="QualifiedName-ST"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="NodeReference-G">
+    <xs:sequence>
+      <xs:element name="node-reference">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="Reference-NodeReferenceFields-G"/>
+            <xs:element minOccurs="0" name="axis" type="QualifiedName-ST"/>
+          </xs:sequence>
+          <xs:attribute name="duplicate-index" type="xs:unsignedInt"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PageReference-G">
+    <xs:sequence>
+      <xs:element name="page-reference">
+        <xs:complexType>
+          <xs:group minOccurs="0" ref="Reference-PageReferenceFields-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneDescriptor-G">
+    <xs:sequence>
+      <xs:element name="pane-descriptor">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="x-fields">
+              <xs:complexType>
+                <xs:group ref="FieldNames-G"/>
+                <xs:attributeGroup ref="Reference-Indexes-AG"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="y-fields">
+              <xs:complexType>
+                <xs:group ref="FieldNames-G"/>
+                <xs:attributeGroup ref="Reference-Indexes-AG"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attributeGroup ref="Reference-Indexes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="TupleDescriptor-G">
+    <xs:sequence>
+      <xs:element name="tuple-descriptor">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="PaneDescriptor-G"/>
+            <xs:element name="columns">
+              <xs:complexType>
+                <xs:group ref="FieldNames-G"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="TupleReference-G">
+    <xs:sequence>
+      <xs:element name="tuple-reference">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="TupleDescriptor-G"/>
+            <xs:group ref="Tuple-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Reference-NodeReferenceFields-G">
+    <xs:sequence>
+      <xs:element name="fields">
+        <xs:complexType>
+          <xs:group ref="FieldNames-G"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:group ref="MultiBucket-Only-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Reference-PageReferenceFields-G">
+    <xs:sequence>
+      <xs:element name="fields">
+        <xs:complexType>
+          <xs:group ref="FieldNames-G"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:group ref="MultiBucket-Only-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="Reference-Indexes-AG">
+    <xs:attribute name="x-index" type="xs:unsignedInt"/>
+    <xs:attribute name="y-index" type="xs:unsignedInt"/>
+    <xs:attribute name="pane-specification-id" type="xs:integer"/>
+  </xs:attributeGroup>
+  <xs:group name="VisualCoordinate-G">
+    <xs:sequence>
+      <xs:element name="visual-coordinate">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="TupleReference-G"/>
+            <xs:element minOccurs="0" name="x-coord" type="VisualCoordinate-Coord-CT"/>
+            <xs:element minOccurs="0" name="y-coord" type="VisualCoordinate-Coord-CT"/>
+            <xs:group minOccurs="0" ref="PageReference-G"/>
+            <xs:element minOccurs="0" name="projection" type="VisualCoordinate-Projection-CT"/>
+          </xs:sequence>
+          <xs:attribute name="class" type="VisualCoordinate-VisualCoordinateType-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="VisualCoordinate-Coord-CT">
+    <xs:sequence>
+      <xs:group ref="NodeReference-G"/>
+    </xs:sequence>
+    <xs:attribute name="axis-value" type="DataValue-ST"/>
+    <xs:attribute name="cell-offset" type="Float-ST"/>
+  </xs:complexType>
+  <xs:simpleType name="VisualCoordinate-VisualCoordinateType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="axis"/>
+      <xs:enumeration value="mark"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="VisualCoordinate-Projection-CT">
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="u" type="DataValue-ST" use="required"/>
+    <xs:attribute name="v" type="DataValue-ST" use="required"/>
+  </xs:complexType>
+  <xs:simpleType name="Double-ST">
+    <xs:union memberTypes="xs:double XML-RealSpecial-ST"/>
+  </xs:simpleType>
+  <xs:simpleType name="Float-ST">
+    <xs:union memberTypes="xs:float XML-RealSpecial-ST"/>
+  </xs:simpleType>
+  <xs:simpleType name="XML-RealSpecial-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="nan"/>
+      <xs:enumeration value="inf"/>
+      <xs:enumeration value="-inf"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="BoxCoordinate-CT">
+    <xs:attribute name="x" type="Float-ST"/>
+    <xs:attribute name="y" type="Float-ST"/>
+  </xs:complexType>
+  <xs:group name="AnnotationSpecification-G">
+    <xs:sequence>
+      <xs:element name="annotation">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Annotation-FormattedText-G"/>
+            <xs:element minOccurs="0" name="point" type="Annotation-VisualCoordinate-CT"/>
+            <xs:element minOccurs="0" name="body" type="Annotation-XYCoordinate-CT"/>
+            <xs:element minOccurs="0" name="top-left" type="Annotation-VisualCoordinate-CT"/>
+            <xs:element minOccurs="0" name="bottom-right" type="Annotation-VisualCoordinate-CT"/>
+            <xs:element minOccurs="0" name="text" type="BoxCoordinate-CT"/>
+          </xs:sequence>
+          <xs:attribute name="class" type="Annotation-Class-ST" use="required"/>
+          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+          <xs:attribute name="pullback" type="Float-ST"/>
+          <xs:attribute name="mark-position" type="Float-ST"/>
+          <xs:attribute name="text-width" type="xs:int"/>
+          <xs:attribute name="text-width-delta" type="xs:int"/>
+          <xs:attribute name="text-pinx" type="Float-ST"/>
+          <xs:attribute name="text-piny" type="Float-ST"/>
+          <xs:attributeGroup ref="Annotation-DeltaAttrs-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Annotation-FormattedText-G">
+    <xs:sequence>
+      <xs:group ref="FormattedText-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Annotation-VisualCoordinate-CT">
+    <xs:sequence>
+      <xs:group ref="VisualCoordinate-G"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Annotation-XYCoordinate-CT">
+    <xs:attribute name="x" type="xs:int"/>
+    <xs:attribute name="y" type="xs:int"/>
+  </xs:complexType>
+  <xs:simpleType name="Annotation-Class-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="point"/>
+      <xs:enumeration value="area"/>
+      <xs:enumeration value="mark"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:attributeGroup name="Annotation-DeltaAttrs-AG">
+    <xs:attribute name="delta-type" type="StoryDelta-ST"/>
+  </xs:attributeGroup>
+  <xs:group name="SingleValueFieldNode-G">
+    <xs:sequence>
+      <xs:element name="single-value-field-node">
+        <xs:complexType>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="fieldname-input-guid" type="xs:string"/>
+          <xs:attribute name="value-output-guid" type="xs:string"/>
+          <xs:attribute name="fieldname" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DashboardZoneVisibilityNode-G">
+    <xs:sequence>
+      <xs:element name="dashboard-zone-visibility-node">
+        <xs:complexType>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="visibility-input-guid" type="xs:string"/>
+          <xs:attribute name="dashboard-identifier" type="xs:string"/>
+          <xs:attribute name="zone-id" type="xs:nonNegativeInteger"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AxisTitleNode-G">
+    <xs:sequence>
+      <xs:element name="axis-title-node">
+        <xs:complexType>
+          <xs:attribute name="duplicate-index" type="xs:nonNegativeInteger"/>
+          <xs:attribute name="fieldname" type="xs:string"/>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="orientation" type="xs:string"/>
+          <xs:attribute name="sheet-identifier" type="xs:string"/>
+          <xs:attribute name="title-input-guid" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AxisExtentNode-G">
+    <xs:sequence>
+      <xs:element name="axis-extent-node">
+        <xs:complexType>
+          <xs:attribute name="duplicate-index" type="xs:nonNegativeInteger"/>
+          <xs:attribute name="fieldname" type="xs:string"/>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="orientation" type="xs:string"/>
+          <xs:attribute name="sheet-identifier" type="xs:string"/>
+          <xs:attribute name="axis-extent" type="xs:string"/>
+          <xs:attribute name="extent-input-guid" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="QuantitativeColorLegendNode-G">
+    <xs:sequence>
+      <xs:element name="quantitative-color-legend-node">
+        <xs:complexType>
+          <xs:attribute name="fieldname" type="xs:string"/>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="sheet-identifier" type="xs:string"/>
+          <xs:attribute name="range-point" type="xs:string"/>
+          <xs:attribute name="range-input-guid" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ParameterSinkNode-G">
+    <xs:sequence>
+      <xs:element name="parameter-sink-node">
+        <xs:complexType>
+          <xs:attribute name="parameter-name" type="xs:string"/>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="input-guid" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapViewportNode-G">
+    <xs:sequence>
+      <xs:element name="map-viewport-node">
+        <xs:complexType>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="viewport-output-guid" type="xs:string"/>
+          <xs:attribute name="sheet-identifier" type="xs:string"/>
+          <xs:attribute name="dashboard-identifier" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-G">
+    <xs:sequence>
+      <xs:element name="datagraph">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Datagraph-Graph-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-GraphNode-G">
+    <xs:sequence>
+      <xs:element name="graph-node">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Datagraph-Graph-G"/>
+            <xs:group ref="Datagraph-Graph-Nodes-GraphNode-Properties-G"/>
+            <xs:group ref="Datagraph-Graph-Nodes-GraphNode-Inputs-G"/>
+            <xs:group ref="Datagraph-Graph-Nodes-GraphNode-Outputs-G"/>
+          </xs:sequence>
+          <xs:attribute name="guid" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-GraphNode-Properties-G">
+    <xs:sequence>
+      <xs:element name="properties">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="name">
+              <xs:complexType>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="description">
+              <xs:complexType>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-GraphNode-Inputs-G">
+    <xs:sequence>
+      <xs:element name="inputs">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Datagraph-Graph-Nodes-GraphNode-Inputs-Inputs-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-GraphNode-Inputs-Inputs-G">
+    <xs:sequence>
+      <xs:element name="input">
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-GraphNode-Outputs-G">
+    <xs:sequence>
+      <xs:element name="outputs">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Datagraph-Graph-Nodes-GraphNode-Outputs-Output-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-GraphNode-Outputs-Output-G">
+    <xs:sequence>
+      <xs:element name="output">
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-G">
+    <xs:sequence>
+      <xs:element name="graph">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Datagraph-Graph-Properties-G"/>
+            <xs:group ref="Datagraph-Graph-ExecutionSubgraphs-G"/>
+            <xs:group ref="Datagraph-Graph-Nodes-G"/>
+            <xs:group ref="Datagraph-Graph-Edges-G"/>
+            <xs:group ref="Datagraph-Graph-PinValues-G" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Properties-G">
+    <xs:sequence>
+      <xs:element name="properties">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="default-execution-subgraph-guid">
+              <xs:complexType>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-G">
+    <xs:sequence>
+      <xs:element name="nodes">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Datagraph-Graph-Nodes-GraphNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="SingleValueFieldNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="DashboardZoneVisibilityNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="AxisTitleNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="AxisExtentNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="QuantitativeColorLegendNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="ParameterSinkNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="MapViewportNode-G"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Edges-G">
+    <xs:sequence>
+      <xs:element name="edges">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Datagraph-Graph-Edges-Edge-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-ExecutionSubgraphs-G">
+    <xs:sequence>
+      <xs:element name="node-execution-subgraphs">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Datagraph-Graph-ExecutionSubgraphs-Pair-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-ExecutionSubgraphs-Pair-G">
+    <xs:sequence>
+      <xs:element name="pair">
+        <xs:complexType>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="execution-subgraph-guid" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Edges-Edge-G">
+    <xs:sequence>
+      <xs:element name="edge">
+        <xs:complexType>
+          <xs:attribute name="from" type="xs:string"/>
+          <xs:attribute name="to" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-PinValues-G">
+    <xs:sequence>
+      <xs:element name="pin-values">
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="QUUID-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\{[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="SimpleIdentifier-G">
+    <xs:sequence>
+      <xs:element name="simple-id">
+        <xs:complexType>
+          <xs:attribute name="uuid" type="QUUID-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="DataOrientation-Link-CT">
+    <xs:attribute name="text" type="xs:string" use="required"/>
+    <xs:attribute name="url" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="DataOrientation-Item-CT">
+    <xs:sequence>
+      <xs:group ref="SimpleIdentifier-G"/>
+      <xs:element name="desc" type="xs:string" minOccurs="0"/>
+      <xs:element name="video-link" type="DataOrientation-Link-CT" minOccurs="0"/>
+      <xs:element name="additional-resource" type="DataOrientation-Link-CT" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="DataOrientation-G">
+    <xs:sequence>
+      <xs:element name="data-orientation">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="data-orientation-item" type="DataOrientation-Item-CT" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="UniqueDataOrientationItemIdentifier">
+          <xs:selector xpath="data-orientation-item/simple-id"/>
+          <xs:field xpath="@uuid"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="QualifiedName-ST">
+    <xs:restriction base="FullValue-ST"/>
+  </xs:simpleType>
+  <xs:simpleType name="LeafValue-ST">
+    <xs:restriction base="QualifiedName-Component-ST"/>
+  </xs:simpleType>
+  <xs:simpleType name="RootValue-ST">
+    <xs:restriction base="QualifiedName-Component-ST"/>
+  </xs:simpleType>
+  <xs:simpleType name="FullValue-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(\[([^\]]*(\]\])?)*\](\.\[([^\]]*(\]\])?)*\])*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="QualifiedName-Component-ST">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="AnalyticModel-OptionalFields-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="field">
+        <xs:complexType>
+          <xs:attribute name="name" type="FullValue-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="AnalyticModel-Specifications-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="analytic-model-specifications">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="AnalysisFields-G"/>
+            <xs:group ref="FilterFields-G"/>
+            <xs:group ref="LODFields-G"/>
+            <xs:group ref="NumDesiredClusters-G"/>
+            <xs:element minOccurs="0" name="is-dissagregate" type="xs:boolean"/>
+          </xs:sequence>
+          <xs:attribute name="class" type="AnalyticModelSpecificationsClass-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AnalysisFields-G">
+    <xs:sequence>
+      <xs:element name="analysis-fields" type="AnalyticModel-OptionalFields-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="AnalyticModel-NumClusters-ST">
+    <xs:restriction base="xs:int">
+      <xs:minInclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="FilterFields-G">
+    <xs:sequence>
+      <xs:element name="filter-fields" type="AnalyticModel-OptionalFields-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="LODFields-G">
+    <xs:sequence>
+      <xs:element name="lod-fields" type="AnalyticModel-OptionalFields-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="NumDesiredClusters-G">
+    <xs:sequence>
+      <xs:element name="number-of-desired-clusters" type="AnalyticModel-NumClusters-ST"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AnalyticModel-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="analytic-model">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="AnalyticModel-Name-G"/>
+            <xs:group ref="AnalyticModel-Specifications-G"/>
+            <xs:group ref="AnalyticModel-ResultFields-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AnalyticModel-Name-G">
+    <xs:sequence>
+      <xs:element name="name">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="field">
+              <xs:complexType>
+                <xs:attribute name="name" type="QualifiedName-ST"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AnalyticModel-ResultFields-G">
+    <xs:sequence>
+      <xs:element name="result-fields">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="field">
+              <xs:complexType>
+                <xs:attribute name="name" type="FullValue-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DomainType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="any"/>
+      <xs:enumeration value="list"/>
+      <xs:enumeration value="range"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Function-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ancestors"/>
+      <xs:enumeration value="crossjoin"/>
+      <xs:enumeration value="descendants"/>
+      <xs:enumeration value="empty-level"/>
+      <xs:enumeration value="end"/>
+      <xs:enumeration value="except"/>
+      <xs:enumeration value="extract"/>
+      <xs:enumeration value="filter"/>
+      <xs:enumeration value="hierarchy-members"/>
+      <xs:enumeration value="intersection"/>
+      <xs:enumeration value="level-members"/>
+      <xs:enumeration value="member"/>
+      <xs:enumeration value="named-set"/>
+      <xs:enumeration value="order"/>
+      <xs:enumeration value="range"/>
+      <xs:enumeration value="relative-date-range"/>
+      <xs:enumeration value="reference"/>
+      <xs:enumeration value="reorder-dimensionality"/>
+      <xs:enumeration value="tuples"/>
+      <xs:enumeration value="union"/>
+      <xs:enumeration value="visual-totals"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="RelationType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="join"/>
+      <xs:enumeration value="subquery"/>
+      <xs:enumeration value="table"/>
+      <xs:enumeration value="stored-proc"/>
+      <xs:enumeration value="text"/>
+      <xs:enumeration value="union"/>
+      <xs:enumeration value="batch-union"/>
+      <xs:enumeration value="pivot"/>
+      <xs:enumeration value="project"/>
+      <xs:enumeration value="text-transform"/>
+      <xs:enumeration value="collection"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SortDirection-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ASC"/>
+      <xs:enumeration value="DESC"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SortType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="natural"/>
+      <xs:enumeration value="alphabetic"/>
+      <xs:enumeration value="computed"/>
+      <xs:enumeration value="manual"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SubqueryType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="from"/>
+      <xs:enumeration value="group-by"/>
+      <xs:enumeration value="having"/>
+      <xs:enumeration value="order-by"/>
+      <xs:enumeration value="select"/>
+      <xs:enumeration value="where"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ColumnOrdering-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="alphabetic"/>
+      <xs:enumeration value="ordinal"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StatisticalModelClass-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="cluster-k-means"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AnalyticModelSpecificationsClass-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="cluster-specifications"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="ColumnInstance-UtilityMembers-CT">
+    <xs:sequence minOccurs="1">
+      <xs:element name="utility-member" minOccurs="1">
+        <xs:complexType>
+          <xs:attribute name="level" type="QualifiedName-ST"/>
+          <xs:attribute name="member" type="DataValue-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ColumnInstance-MemberProperties-CT">
+    <xs:sequence>
+      <xs:element name="alias" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:attribute name="key" type="xs:string"/>
+          <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:attributeGroup name="ColumnInstance-Attrs-AG">
+    <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+    <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+    <xs:attribute name="type" type="FieldType-ST" use="required"/>
+    <xs:attribute name="pivot" type="PivotStrategy-ST" use="required"/>
+    <xs:attribute name="derivation" type="AggType-ST" use="required"/>
+    <xs:attribute name="forecast-column-type" type="xs:string"/>
+    <xs:attribute name="forecast-column-base" type="xs:string"/>
+    <xs:attribute name="is-adhoc-cluster" type="xs:boolean"/>
+    <xs:attribute name="aggregation-param" type="xs:string"/>
+    <xs:attribute name="visual-totals" type="xs:string"/>
+  </xs:attributeGroup>
+  <xs:group name="ColumnInstance-G">
+    <xs:sequence>
+      <xs:element name="column-instance">
+        <xs:complexType mixed="true">
+          <xs:sequence minOccurs="0">
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="TableCalc-G"/>
+            <xs:element minOccurs="0" name="utility-members" type="ColumnInstance-UtilityMembers-CT"/>
+            <xs:element minOccurs="0" name="aliases" type="ColumnInstance-MemberProperties-CT"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="ColumnInstance-Attrs-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="Collation-AG">
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="charset" type="xs:unsignedShort"/>
+    <xs:attribute name="flag" type="xs:unsignedInt"/>
+  </xs:attributeGroup>
+  <xs:group name="DataValue-G">
+    <xs:sequence>
+      <xs:element name="value" type="DataValue-ST"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Schema-G">
+    <xs:sequence>
+      <xs:element name="schema">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="column" type="QualifiedName-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SchemaWithDataType-G">
+    <xs:sequence>
+      <xs:element name="schema">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Table-G">
+    <xs:sequence>
+      <xs:element name="table">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Schema-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Tuple-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Tuple-G">
+    <xs:sequence>
+      <xs:element name="tuple">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" minOccurs="0" ref="DataValue-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="TupleList-CT">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="Tuple-G"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="TupleSource-G">
+    <xs:sequence>
+      <xs:element name="table">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="schema">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+                    <xs:complexType>
+                      <xs:attribute name="key" type="xs:string"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Tuple-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="QuantitativeDomain-G">
+    <xs:sequence>
+      <xs:element name="quantitative-domain">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="min" type="DataValue-ST"/>
+            <xs:element name="max" type="DataValue-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="CategoricalDomain-G">
+    <xs:sequence>
+      <xs:element name="categorical-domain">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="DataValue-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Domain-G">
+    <xs:sequence>
+      <xs:choice>
+        <xs:group ref="QuantitativeDomain-G"/>
+        <xs:group ref="CategoricalDomain-G"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MultiDomain-G">
+    <xs:sequence>
+      <xs:element name="multidomain">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Tuple-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="RefreshType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="create"/>
+      <xs:enumeration value="increment"/>
+      <xs:enumeration value="add from data source"/>
+      <xs:enumeration value="add from file"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DataConnectionCustomization-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="connection-customization">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Vendor-G"/>
+            <xs:group ref="Driver-G"/>
+            <xs:group ref="Customizations-G"/>
+          </xs:sequence>
+          <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+          <xs:attribute name="class" type="xs:string" use="required"/>
+          <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Vendor-G">
+    <xs:sequence>
+      <xs:element name="vendor">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Driver-G">
+    <xs:sequence>
+      <xs:element name="driver">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Customizations-G">
+    <xs:sequence>
+      <xs:element name="customizations">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="DataConnectionCust-Customizations-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataConnectionCust-Customizations-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="DataConnectionCust-Customization-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataConnectionCust-Customization-G">
+    <xs:sequence>
+      <xs:element name="customization">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="MetadataRecord-Class-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="column"/>
+      <xs:enumeration value="measure"/>
+      <xs:enumeration value="level"/>
+      <xs:enumeration value="dimension"/>
+      <xs:enumeration value="hierarchy"/>
+      <xs:enumeration value="remote-set"/>
+      <xs:enumeration value="granularity"/>
+      <xs:enumeration value="pair-hierarchy"/>
+      <xs:enumeration value="capability"/>
+      <xs:enumeration value="primary-key"/>
+      <xs:enumeration value="foreign-key"/>
+      <xs:enumeration value="sampled-data"/>
+      <xs:enumeration value="unique-constraint"/>
+      <xs:enumeration value="table-statistic"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MetadataRecord-LevelType-EnumBase-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="regular"/>
+      <xs:enumeration value="all"/>
+      <xs:enumeration value="time"/>
+      <xs:enumeration value="time-year"/>
+      <xs:enumeration value="time-semester"/>
+      <xs:enumeration value="time-trimester"/>
+      <xs:enumeration value="time-quarter"/>
+      <xs:enumeration value="time-month"/>
+      <xs:enumeration value="time-period"/>
+      <xs:enumeration value="time-week"/>
+      <xs:enumeration value="time-day"/>
+      <xs:enumeration value="time-hour"/>
+      <xs:enumeration value="time-minute"/>
+      <xs:enumeration value="time-second"/>
+      <xs:enumeration value="time-day-of-week"/>
+      <xs:enumeration value="time-semester-by-year"/>
+      <xs:enumeration value="time-quarter-by-year"/>
+      <xs:enumeration value="time-quarter-by-semester"/>
+      <xs:enumeration value="time-month-by-year"/>
+      <xs:enumeration value="time-month-by-semester"/>
+      <xs:enumeration value="time-month-by-quarter"/>
+      <xs:enumeration value="time-week-by-year"/>
+      <xs:enumeration value="time-week-by-semester"/>
+      <xs:enumeration value="time-week-by-quarter"/>
+      <xs:enumeration value="time-week-by-month"/>
+      <xs:enumeration value="time-day-by-year"/>
+      <xs:enumeration value="time-day-by-semester"/>
+      <xs:enumeration value="time-day-by-quarter"/>
+      <xs:enumeration value="time-day-by-month"/>
+      <xs:enumeration value="time-day-by-week"/>
+      <xs:enumeration value="time-weekend"/>
+      <xs:enumeration value="time-holiday"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MetadataRecord-LevelType-ST">
+    <xs:union memberTypes="xs:int MetadataRecord-LevelType-EnumBase-ST"/>
+  </xs:simpleType>
+  <xs:group name="MetadataRecord-RemoteType-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="remote-type" type="MetadataRecord-LevelType-ST"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MetadataRecord-Statistics-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="statistics">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="statistic" type="Statistic-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Statistic-CT">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="aggregation" type="AggType-ST" use="required"/>
+        <xs:attribute name="datatype" type="DataType-ST" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:group name="MetadataRecord-Attributes-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="attributes">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="attribute" type="Attribute-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Attribute-CT">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="datatype" type="DataType-ST" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="MetadataRecord-ObjectId-ST">
+    <xs:restriction base="QualifiedName-ST"/>
+  </xs:simpleType>
+  <xs:group name="MetadataRecord-G">
+    <xs:sequence>
+      <xs:element name="metadata-record">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element name="remote-name" type="xs:string"/>
+            <xs:group ref="MetadataRecord-RemoteType-G"/>
+            <xs:element minOccurs="0" name="local-name" type="QualifiedName-ST"/>
+            <xs:element minOccurs="0" name="parent-name" type="QualifiedName-ST"/>
+            <xs:element name="remote-alias" type="xs:string"/>
+            <xs:element minOccurs="0" name="ordinal" type="xs:int"/>
+            <xs:element minOccurs="0" name="hidden" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="auto-hidden" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="layered" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="caption" type="xs:string"/>
+            <xs:element minOccurs="0" name="family" type="xs:string"/>
+            <xs:element minOccurs="0" name="local-type" type="DataType-ST"/>
+            <xs:element name="aggregation" type="AggType-ST"/>
+            <xs:element minOccurs="0" name="approx-count" type="xs:int"/>
+            <xs:element minOccurs="0" name="precision" type="xs:int"/>
+            <xs:element minOccurs="0" name="scale" type="xs:int"/>
+            <xs:element minOccurs="0" name="width" type="xs:int"/>
+            <xs:element name="contains-null" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="padded-semantics" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="cast-to-local-type" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="collation">
+              <xs:complexType>
+                <xs:attributeGroup ref="Collation-AG"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="default" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="level-number" type="xs:int"/>
+            <xs:element minOccurs="0" name="layer-number" type="xs:int"/>
+            <xs:element minOccurs="0" name="semantic-role" type="QualifiedName-ST"/>
+            <xs:element minOccurs="0" name="associated-user-geom" type="QualifiedName-ST"/>
+            <xs:element minOccurs="0" name="user-geom-alias" type="QualifiedName-ST"/>
+            <xs:group ref="MetadataRecord-Statistics-G"/>
+            <xs:group ref="MetadataRecord-Attributes-G"/>
+            <xs:element minOccurs="0" name="object-id" type="MetadataRecord-ObjectId-ST"/>
+          </xs:sequence>
+          <xs:attribute name="class" type="MetadataRecord-Class-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="JoinType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="inner"/>
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="right"/>
+      <xs:enumeration value="full"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Relation-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="relation">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element minOccurs="0" name="database-filter">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group minOccurs="0" ref="SQLExpression-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="table-filter">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group minOccurs="0" ref="SQLExpression-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:group minOccurs="0" ref="RelationColumns-G"/>
+            <xs:element minOccurs="0" name="clause">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="SQLExpression-G"/>
+                </xs:sequence>
+                <xs:attribute fixed="join" name="type" type="RelationType-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:group minOccurs="0" ref="SQLSubquery-G"/>
+            <xs:group minOccurs="0" ref="RelationActualParameters-G"/>
+            <xs:element minOccurs="0" name="tag">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="value">
+                    <xs:complexType>
+                      <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="groups">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="group">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="field">
+                          <xs:complexType>
+                            <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                      <xs:attribute name="name" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="bindings">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="binding">
+                    <xs:complexType>
+                      <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+                      <xs:attribute name="expression" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Relation-G"/>
+          </xs:sequence>
+          <xs:attribute name="type" type="RelationType-ST" use="required"/>
+          <xs:attribute name="join" type="JoinType-ST"/>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="table" type="QualifiedName-ST"/>
+          <xs:attributeGroup ref="ConnectionName-AG"/>
+          <xs:attribute name="stored-proc" type="QualifiedName-ST"/>
+          <xs:attribute name="all" type="xs:boolean"/>
+          <xs:attribute name="path" type="xs:string"/>
+          <xs:attribute name="is-recursive" type="xs:boolean"/>
+          <xs:attribute name="include-siblings" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="RelationNames-G">
+    <xs:sequence>
+      <xs:element name="cols">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="map">
+              <xs:complexType>
+                <xs:attribute name="key" type="QualifiedName-ST"/>
+                <xs:attribute name="value" type="QualifiedName-ST"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SQLSubquery-G">
+    <xs:sequence>
+      <xs:element name="subquery">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="6" minOccurs="0" name="clause">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="expression">
+                    <xs:complexType>
+                      <xs:sequence minOccurs="0">
+                        <xs:group maxOccurs="unbounded" minOccurs="0" ref="SQLExpression-G"/>
+                      </xs:sequence>
+                      <xs:attribute name="op" type="Op-ST"/>
+                      <xs:attribute name="name" type="xs:string"/>
+                      <xs:attribute name="expression" type="xs:string"/>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:group minOccurs="0" ref="Relation-G"/>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="sort">
+                    <xs:complexType>
+                      <xs:attribute name="expression" type="xs:string" use="required"/>
+                      <xs:attribute name="direction" type="SortDirection-ST" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+                <xs:attribute name="type" type="SubqueryType-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="into" type="xs:boolean" use="required"/>
+          <xs:attribute name="count" type="Float-ST" use="required"/>
+          <xs:attribute name="units" type="SortUnits-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="RelationColumns-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="columns">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+              <xs:complexType>
+                <xs:anyAttribute namespace="##local" processContents="skip"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="RelationActualParameters-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="actual-parameters">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+              <xs:complexType>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="ordinal" type="xs:unsignedInt" use="required"/>
+                <xs:attribute name="parameter" type="QualifiedName-ST"/>
+                <xs:attribute name="value" type="DataValue-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="ConnectionName-AG">
+    <xs:attribute name="connection" type="xs:string" use="optional"/>
+  </xs:attributeGroup>
+  <xs:group name="SchemaSelections-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="semistruct-schemas">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="SchemaSelection-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SchemaSelection-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="semistruct-schema">
+        <xs:complexType>
+          <xs:group ref="SemiStructSchema-SchemaNodeSelection-G"/>
+          <xs:attribute name="table" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SemiStructSchema-SchemaNodeSelection-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="map">
+        <xs:complexType>
+          <xs:attribute name="key" type="xs:string" use="required"/>
+          <xs:attribute name="value" type="xs:boolean" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Connection-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="connection" type="DataConnection-Connection-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MaterialisedCalcs-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="calculations">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="calculation" type="DataConnection-MaterializedCalc-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Refresh-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="refresh">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="1" minOccurs="0" name="subrange-refresh" type="SubrangeRefresh-CT"/>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="refresh-event" type="DataConnection-RefreshEvent-CT"/>
+          </xs:sequence>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Metadata-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="metadata-records">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="MetadataRecord-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MDXConnection-G">
+    <xs:sequence>
+      <xs:group ref="Connection-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SQLConnection-G">
+    <xs:sequence>
+      <xs:group ref="Connection-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="NonTransactedState-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="nontransacted-state">
+        <xs:complexType>
+          <xs:attribute name="forced-slow" type="DataSource-YesNo-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="DataConnection-Connection-CT">
+    <xs:sequence>
+      <xs:any maxOccurs="unbounded" minOccurs="0" namespace="##local" processContents="skip"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##local" processContents="skip"/>
+  </xs:complexType>
+  <xs:complexType name="DataConnection-RefreshEvent-CT">
+    <xs:attribute name="refresh-type" type="RefreshType-ST" use="required"/>
+    <xs:attribute name="timestamp-start">
+      <xs:simpleType>
+        <xs:union memberTypes="DateFormat_5-ST DateFormat_11-ST"/>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="rows-inserted" type="xs:long" use="required"/>
+    <xs:attribute name="add-from-file-path" type="xs:string" use="required"/>
+    <xs:attribute name="increment-value" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="DataConnection-MaterializedCalc-CT">
+    <xs:attribute name="column" type="QualifiedName-ST"/>
+    <xs:attribute name="formula" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="SubrangeRefresh-CT">
+    <xs:attribute name="period-type-v2" type="PeriodTypeV2-ST" use="required"/>
+    <xs:attribute name="range" type="xs:int" use="required"/>
+  </xs:complexType>
+  <xs:simpleType name="DataSource-YesNo-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="no"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:attributeGroup name="DateOptions-AG">
+    <xs:attribute name="start-of-week">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="seven-day-period"/>
+          <xs:enumeration value="sunday"/>
+          <xs:enumeration value="monday"/>
+          <xs:enumeration value="tuesday"/>
+          <xs:enumeration value="wednesday"/>
+          <xs:enumeration value="thursday"/>
+          <xs:enumeration value="friday"/>
+          <xs:enumeration value="saturday"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="fiscal-year-start">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="january"/>
+          <xs:enumeration value="february"/>
+          <xs:enumeration value="march"/>
+          <xs:enumeration value="april"/>
+          <xs:enumeration value="may"/>
+          <xs:enumeration value="june"/>
+          <xs:enumeration value="july"/>
+          <xs:enumeration value="august"/>
+          <xs:enumeration value="september"/>
+          <xs:enumeration value="october"/>
+          <xs:enumeration value="november"/>
+          <xs:enumeration value="december"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:group name="DateOptions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="date-options">
+        <xs:complexType>
+          <xs:attributeGroup ref="DateOptions-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ObjectModelRelationship-ObjectId-ST">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="EndPointAttributes-G">
+    <xs:sequence>
+      <xs:element name="first-end-point">
+        <xs:complexType>
+          <xs:attribute name="unique-key" type="xs:string"/>
+          <xs:attribute name="guaranteed-value" type="xs:string"/>
+          <xs:attribute name="is-db-set-unique-key" type="xs:boolean"/>
+          <xs:attribute name="is-db-set-guaranteed-value" type="xs:boolean"/>
+          <xs:attribute name="object-id" type="ObjectModelRelationship-ObjectId-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="second-end-point">
+        <xs:complexType>
+          <xs:attribute name="unique-key" type="xs:string"/>
+          <xs:attribute name="guaranteed-value" type="xs:string"/>
+          <xs:attribute name="is-db-set-unique-key" type="xs:boolean"/>
+          <xs:attribute name="is-db-set-guaranteed-value" type="xs:boolean"/>
+          <xs:attribute name="object-id" type="ObjectModelRelationship-ObjectId-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ObjectModelRelationship-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="relationship">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="SQLExpression-G"/>
+            <xs:group ref="EndPointAttributes-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceTree-Parents-G">
+    <xs:sequence>
+      <xs:element name="parents">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="DataSourceTreeNode-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceTree-ObjectModelRelationships-G">
+    <xs:sequence>
+      <xs:element name="relationships">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="ObjectModelRelationship-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceTreeNode-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="pds">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="DataSourceTree-Parents-G"/>
+            <xs:group minOccurs="0" ref="DataSourceTree-ObjectModelRelationships-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="datasource-url" type="xs:string"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="name-in-immediate-child" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceTree-NamePersistenceMaps-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="name-persistence-map">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="relation-alias-map">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="1" maxOccurs="unbounded" name="map">
+                    <xs:complexType>
+                      <xs:attribute name="current-alias" type="xs:string" use="required"/>
+                      <xs:attribute name="alias-in-genesis-datasource" type="xs:string" use="required"/>
+                      <xs:attribute name="genesis-datasource-name" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="object-id-map">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="1" maxOccurs="unbounded" name="map">
+                    <xs:complexType>
+                      <xs:attribute name="current-id" type="xs:string" use="required"/>
+                      <xs:attribute name="id-in-genesis-datasource" type="xs:string" use="required"/>
+                      <xs:attribute name="genesis-datasource-name" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="user-created-column-name-map">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="1" maxOccurs="unbounded" name="map">
+                    <xs:complexType>
+                      <xs:attribute name="current-name" type="xs:string" use="required"/>
+                      <xs:attribute name="name-in-origin-datasource" type="xs:string" use="required"/>
+                      <xs:attribute name="origin-datasource-name" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="parameter-name-map">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="1" maxOccurs="unbounded" name="map">
+                    <xs:complexType>
+                      <xs:attribute name="current-name" type="xs:string" use="required"/>
+                      <xs:attribute name="name-in-origin-datasource" type="xs:string" use="required"/>
+                      <xs:attribute name="origin-datasource-name" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="database-column-name-map">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="1" maxOccurs="unbounded" name="map">
+                    <xs:complexType>
+                      <xs:attribute name="current-name" type="xs:string" use="required"/>
+                      <xs:attribute name="name-in-remote-database" type="xs:string" use="required"/>
+                      <xs:attribute name="relation-current-alias" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceTree-Wrapper-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="data-source-tree">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="DataSourceTreeNode-G"/>
+            <xs:group minOccurs="0" ref="DataSourceTree-NamePersistenceMaps-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="FieldRole-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="dimension"/>
+      <xs:enumeration value="measure"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PivotStrategy-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="key"/>
+      <xs:enumeration value="alias"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AliasType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="alias-key"/>
+      <xs:enumeration value="alias-key-name"/>
+      <xs:enumeration value="alias-key-medname"/>
+      <xs:enumeration value="alias-key-longname"/>
+      <xs:enumeration value="alias-name"/>
+      <xs:enumeration value="alias-name-key"/>
+      <xs:enumeration value="alias-medname"/>
+      <xs:enumeration value="alias-medname-key"/>
+      <xs:enumeration value="alias-longname"/>
+      <xs:enumeration value="alias-longname-key"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FolderRole-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="dimensions"/>
+      <xs:enumeration value="measures"/>
+      <xs:enumeration value="groups"/>
+      <xs:enumeration value="parameters"/>
+      <xs:enumeration value="common"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FolderItemType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="field"/>
+      <xs:enumeration value="drillpath"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FieldOrderType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="datasource-order"/>
+      <xs:enumeration value="alpha-per-table"/>
+      <xs:enumeration value="alphabetical-order"/>
+      <xs:enumeration value="custom-order"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SortOrder-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ascending"/>
+      <xs:enumeration value="descending"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Filter-G">
+    <xs:sequence>
+      <xs:element name="filter">
+        <xs:complexType>
+          <xs:sequence minOccurs="0">
+            <xs:element minOccurs="0" name="min" type="DataValue-ST"/>
+            <xs:element minOccurs="0" name="max" type="DataValue-ST"/>
+            <xs:group minOccurs="0" ref="SetFunction-G"/>
+            <xs:group ref="Filter-FilterPresets-G"/>
+            <xs:group ref="Filter-FilterTargets-G"/>
+          </xs:sequence>
+          <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="context" type="xs:boolean"/>
+          <xs:attribute name="filter-group" type="xs:int"/>
+          <xs:attribute name="affect-totals" type="xs:boolean"/>
+          <xs:attribute name="class" type="Filter-Class-ST" use="required"/>
+          <xs:attribute name="included-values" type="Filter-Include-ST"/>
+          <xs:attribute name="period-type-v2" type="PeriodTypeV2-ST"/>
+          <xs:attribute name="period-anchor" type="DataValue-ST"/>
+          <xs:attribute name="first-period" type="xs:int"/>
+          <xs:attribute name="last-period" type="xs:int"/>
+          <xs:attribute name="include-future" type="xs:boolean"/>
+          <xs:attribute name="include-null" type="xs:boolean"/>
+          <xs:attribute name="logical-table-scoped" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="HideDataFilter-G">
+    <xs:sequence>
+      <xs:element name="filter">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="SetFunction-G"/>
+          </xs:sequence>
+          <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="kind" type="Filter-Kind-ST" use="required"/>
+          <xs:attribute name="class" type="Filter-Class-ST" use="required"/>
+          <xs:attribute name="logical-table-scoped" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="FilterOrHideDataFilter-G">
+    <xs:sequence>
+      <xs:element name="filter">
+        <xs:complexType>
+          <xs:sequence minOccurs="0">
+            <xs:element minOccurs="0" name="min" type="DataValue-ST"/>
+            <xs:element minOccurs="0" name="max" type="DataValue-ST"/>
+            <xs:group minOccurs="0" ref="SetFunction-G"/>
+            <xs:group ref="Filter-FilterPresets-G"/>
+            <xs:group ref="Filter-FilterTargets-G"/>
+          </xs:sequence>
+          <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="context" type="xs:boolean"/>
+          <xs:attribute name="filter-group" type="xs:int"/>
+          <xs:attribute name="affect-totals" type="xs:boolean"/>
+          <xs:attribute name="class" type="Filter-Class-ST" use="required"/>
+          <xs:attribute name="included-values" type="Filter-Include-ST"/>
+          <xs:attribute name="period-type-v2" type="PeriodTypeV2-ST"/>
+          <xs:attribute name="period-anchor" type="DataValue-ST"/>
+          <xs:attribute name="first-period" type="xs:int"/>
+          <xs:attribute name="last-period" type="xs:int"/>
+          <xs:attribute name="include-future" type="xs:boolean"/>
+          <xs:attribute name="include-null" type="xs:boolean"/>
+          <xs:attribute name="kind" type="Filter-Kind-ST"/>
+          <xs:attribute name="logical-table-scoped" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ClearFilter-G">
+    <xs:sequence>
+      <xs:element name="clear-filter">
+        <xs:complexType>
+          <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Filter-Class-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="categorical"/>
+      <xs:enumeration value="quantitative"/>
+      <xs:enumeration value="relative-date"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Filter-Include-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="all"/>
+      <xs:enumeration value="non-null"/>
+      <xs:enumeration value="null"/>
+      <xs:enumeration value="in-range"/>
+      <xs:enumeration value="in-range-or-null"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Filter-Kind-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="hide"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FilterScope-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="pervasive"/>
+      <xs:enumeration value="logical-tables"/>
+      <xs:enumeration value="datasource-scoped"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Filter-FilterTargets-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="target">
+        <xs:complexType>
+          <xs:attribute name="field" type="QualifiedName-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Filter-FilterPresets-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="preset">
+        <xs:complexType>
+          <xs:attribute name="type" type="PresetType-ST" use="required"/>
+          <xs:attribute name="applied" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GeocodingEnhancement-AddressColumns-G">
+    <xs:sequence>
+      <xs:element name="address-columns" minOccurs="1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="address-column" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+                <xs:attribute name="caption" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GeocodingEnhancement-G">
+    <xs:sequence>
+      <xs:element name="geocoding-enhancement">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="GeocodingEnhancement-AddressColumns-G"/>
+          </xs:sequence>
+          <xs:attribute name="instance-id" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MappedImage-Mapping-G">
+    <xs:sequence>
+      <xs:element name="mapping">
+        <xs:complexType>
+          <xs:attribute name="x" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="y" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="left" type="DataValue-ST" use="required"/>
+          <xs:attribute name="right" type="DataValue-ST" use="required"/>
+          <xs:attribute name="top" type="DataValue-ST" use="required"/>
+          <xs:attribute name="bottom" type="DataValue-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MappedImage-Options-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="image-options">
+        <xs:complexType>
+          <xs:attribute name="lock-aspect-ratio" type="xs:boolean"/>
+          <xs:attribute name="show-entire-image" type="xs:boolean"/>
+          <xs:attribute name="desaturate-image" type="xs:boolean"/>
+          <xs:attribute name="desaturate-pct" type="Float-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MappedImage-Predicates-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="SetFunction-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MappedImageSpec-G">
+    <xs:sequence>
+      <xs:element name="mapped-image">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="MappedImage-Mapping-G"/>
+            <xs:group ref="MappedImage-Options-G"/>
+            <xs:group ref="MappedImage-Predicates-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="caption" type="xs:string" use="required"/>
+          <xs:attribute name="expression" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ObjectId-ST">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="ObjectGraphNode-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="object">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="properties">
+              <xs:complexType>
+                <xs:choice minOccurs="0">
+                  <xs:group ref="Relation-G"/>
+                  <xs:group ref="AnalyticsExtensionObjectNode-G"/>
+                </xs:choice>
+                <xs:attribute name="context" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="table-description">
+              <xs:complexType>
+                <xs:group ref="FormattedText-G"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="id" type="ObjectId-ST" use="required"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="origin-pds" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AnalyticsExtensionObjectNode-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="analytics-extension-object-node">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="script-code" type="xs:string"/>
+            <xs:element name="input">
+              <xs:complexType>
+                <xs:sequence minOccurs="0">
+                  <xs:group ref="Relation-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="output">
+              <xs:complexType>
+                <xs:sequence minOccurs="1">
+                  <xs:group ref="Relation-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ObjectGraph-ObjectNodes-G">
+    <xs:sequence>
+      <xs:element name="objects">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="ObjectGraphNode-G"/>
+          </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="UniqueObjectId">
+          <xs:selector xpath="object"/>
+          <xs:field xpath="@id"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ObjectGraph-ObjectModelRelationships-G">
+    <xs:sequence>
+      <xs:element name="relationships">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="ObjectModelRelationship-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ObjectGraph-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="object-graph">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="ObjectGraph-ObjectNodes-G"/>
+            <xs:group minOccurs="0" ref="ObjectGraph-ObjectModelRelationships-G"/>
+          </xs:sequence>
+          <xs:attribute name="is-legacy" type="xs:boolean"/>
+          <xs:attribute name="semantic-layer" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Descendants-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="SELF"/>
+      <xs:enumeration value="AFTER"/>
+      <xs:enumeration value="SELF-AND-AFTER"/>
+      <xs:enumeration value="BEFORE"/>
+      <xs:enumeration value="SELF-AND_BEFORE"/>
+      <xs:enumeration value="BEFORE-AND-AFTER"/>
+      <xs:enumeration value="SELF_BEFORE-AFTER"/>
+      <xs:enumeration value="LEAVES"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Include-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="all"/>
+      <xs:enumeration value="non-null"/>
+      <xs:enumeration value="null"/>
+      <xs:enumeration value="in-range"/>
+      <xs:enumeration value="in-range-or-null"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PeriodType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="year"/>
+      <xs:enumeration value="quarter"/>
+      <xs:enumeration value="month"/>
+      <xs:enumeration value="week"/>
+      <xs:enumeration value="day"/>
+      <xs:enumeration value="hour"/>
+      <xs:enumeration value="minute"/>
+      <xs:enumeration value="second"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PeriodTypeV2-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="year"/>
+      <xs:enumeration value="iso-year"/>
+      <xs:enumeration value="quarter"/>
+      <xs:enumeration value="iso-quarter"/>
+      <xs:enumeration value="month"/>
+      <xs:enumeration value="week"/>
+      <xs:enumeration value="iso-week"/>
+      <xs:enumeration value="day"/>
+      <xs:enumeration value="hour"/>
+      <xs:enumeration value="minute"/>
+      <xs:enumeration value="second"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PresetType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="last-values"/>
+      <xs:enumeration value="current-values"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="SetFunction-G">
+    <xs:sequence>
+      <xs:element name="groupfilter">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="projection" type="Dimensionality-CT"/>
+            <xs:element minOccurs="0" name="perspective" type="SetFunction-Perspective-CT"/>
+            <xs:element minOccurs="0" name="tuples" type="TupleList-CT"/>
+            <xs:element minOccurs="0" name="dimensionality" type="Dimensionality-CT"/>
+            <xs:element minOccurs="0" name="cols" type="SetFunction-NameBindings-CT"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="SetFunction-G"/>
+            <xs:element minOccurs="0" name="order" type="Dimensionality-CT"/>
+          </xs:sequence>
+          <xs:attribute name="function" type="Function-ST" use="required"/>
+          <xs:attribute name="level" type="QualifiedName-ST"/>
+          <xs:attribute name="flag" type="Descendants-ST"/>
+          <xs:attribute name="slice" type="xs:boolean"/>
+          <xs:attribute name="member" type="SetFunction-Member-ST"/>
+          <xs:attribute name="end" type="SortEnd-ST"/>
+          <xs:attribute name="count" type="Expression-ST"/>
+          <xs:attribute name="units" type="SortUnits-ST"/>
+          <xs:attribute name="expression" type="Expression-ST"/>
+          <xs:attribute name="perspective-type" type="SetFunction-PerspectiveType-ST"/>
+          <xs:attribute name="hierarchy" type="QualifiedName-ST"/>
+          <xs:attribute name="name" type="QualifiedName-ST"/>
+          <xs:attribute name="remote-expression" type="Expression-ST"/>
+          <xs:attribute name="evaluation-context" type="EvaluationContext-ST"/>
+          <xs:attribute name="direction" type="SetFunction-OrderSortDirection-ST"/>
+          <xs:attribute name="from" type="DataValue-ST"/>
+          <xs:attribute name="to" type="DataValue-ST"/>
+          <xs:attribute name="period-type-v2" type="PeriodTypeV2-ST"/>
+          <xs:attribute name="first-period" type="xs:int"/>
+          <xs:attribute name="last-period" type="xs:int"/>
+          <xs:attribute name="include-future" type="xs:boolean"/>
+          <xs:attribute name="period-anchor" type="DataValue-ST"/>
+          <xs:attribute name="field" type="QualifiedName-ST"/>
+          <xs:attribute name="keep-duplicates" type="xs:boolean"/>
+          <xs:attributeGroup ref="user:UserAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="SortEnd-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="top"/>
+      <xs:enumeration value="bottom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SortUnits-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="percent"/>
+      <xs:enumeration value="records"/>
+      <xs:enumeration value="sample-percent"/>
+      <xs:enumeration value="sample-records"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EvaluationContext-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="static"/>
+      <xs:enumeration value="dynamic"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="LevelFlags-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[01]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Dimensionality-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="hierarchy">
+        <xs:complexType>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="level-flags" type="LevelFlags-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Expression-ST">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="SetFunction-Member-ST">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="SetFunction-PerspectiveType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="reality"/>
+      <xs:enumeration value="first"/>
+      <xs:enumeration value="last"/>
+      <xs:enumeration value="custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="SetFunction-BoundsTuple-CT">
+    <xs:sequence>
+      <xs:group ref="Tuple-G"/>
+    </xs:sequence>
+    <xs:attribute name="indep-dim" type="QualifiedName-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="SetFunction-Perspective-CT">
+    <xs:sequence maxOccurs="unbounded" minOccurs="0">
+      <xs:element name="start" type="SetFunction-BoundsTuple-CT"/>
+      <xs:element name="end" type="SetFunction-BoundsTuple-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SetFunction-NameBindings-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="map">
+        <xs:complexType>
+          <xs:attribute name="key" type="QualifiedName-ST"/>
+          <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="SetFunction-OrderSortDirection-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ASC"/>
+      <xs:enumeration value="DESC"/>
+      <xs:enumeration value="BASC"/>
+      <xs:enumeration value="BDESC"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Bucket-G">
+    <xs:sequence>
+      <xs:element name="bucket">
+        <xs:simpleType>
+          <xs:restriction base="DataValue-ST"/>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="BucketList-CT">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="Bucket-G"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="MultiBucket-Only-G">
+    <xs:sequence>
+      <xs:element name="multibucket" type="BucketList-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MultiBucket-Or-Bucket-G">
+    <xs:choice>
+      <xs:group ref="MultiBucket-Only-G"/>
+      <xs:group ref="Bucket-G"/>
+    </xs:choice>
+  </xs:group>
+  <xs:simpleType name="Op-ST">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:group name="SQLExpression-G">
+    <xs:sequence>
+      <xs:element name="expression">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="SQLExpression-G"/>
+          </xs:sequence>
+          <xs:attribute name="op" type="Op-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Sort-G">
+    <xs:choice>
+      <xs:group ref="Sort-ComputedSort-G"/>
+      <xs:group ref="Sort-ManualSort-G"/>
+      <xs:group ref="Sort-Natural-G"/>
+      <xs:group ref="Sort-Alphabetic-G"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="ClearSort-G">
+    <xs:sequence>
+      <xs:element name="clear-sort">
+        <xs:complexType>
+          <xs:attribute name="column" type="Sort-FieldName-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Sort-ComputedSort-G">
+    <xs:sequence>
+      <xs:element name="computed-sort">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="SetFunction-G"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="Sort-CommonAttributes-AG"/>
+          <xs:attribute name="using" type="Sort-FieldName-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Sort-ManualSort-G">
+    <xs:sequence>
+      <xs:element name="manual-sort">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="dictionary" type="BucketList-CT"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="Sort-CommonAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Sort-Natural-G">
+    <xs:sequence>
+      <xs:element name="natural-sort">
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Sort-Alphabetic-G">
+    <xs:sequence>
+      <xs:element name="alphabetic-sort">
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Sort-FieldName-ST">
+    <xs:restriction base="QualifiedName-ST"/>
+  </xs:simpleType>
+  <xs:attributeGroup name="Sort-CommonAttributes-AG">
+    <xs:attribute name="column" type="Sort-FieldName-ST" use="required"/>
+    <xs:attribute name="direction" type="SortDirection-ST" use="required"/>
+  </xs:attributeGroup>
+  <xs:simpleType name="DataScaling-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="standardized"/>
+      <xs:enumeration value="normalized"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Fields-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+        <xs:complexType>
+          <xs:attribute name="name" type="FullValue-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="StatisticalModel-NumClusters-ST">
+    <xs:restriction base="xs:int">
+      <xs:minInclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="UnsupervisedModel-G">
+    <xs:sequence>
+      <xs:element name="model-specification">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="analysis-fields" type="Fields-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StatisticalModel-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="statistical-model">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="UnsupervisedModel-G"/>
+            <xs:element name="model-summary">
+              <xs:complexType>
+                <xs:sequence minOccurs="0">
+                  <xs:group ref="StatisticalModel-Clusters-G"/>
+                  <xs:group ref="StatisticalModel-ANOVA-G"/>
+                </xs:sequence>
+                <xs:attribute name="num-rows" type="xs:int"/>
+                <xs:attribute name="num-cols" type="xs:int"/>
+                <xs:attribute name="num-desired-clusters" type="StatisticalModel-NumClusters-ST" use="required"/>
+                <xs:attribute name="num-clusters" type="xs:int"/>
+                <xs:attribute name="num-outliers" type="xs:int"/>
+                <xs:attribute name="num-not-clustered" type="xs:int"/>
+                <xs:attribute name="between-group-sum-of-squared" type="Double-ST"/>
+                <xs:attribute name="within-group-sum-of-squares" type="Double-ST"/>
+                <xs:attribute name="total-sum-of-squares" type="Double-ST"/>
+                <xs:attribute name="estimate-nulls" type="xs:boolean"/>
+                <xs:attribute name="scaling" type="DataScaling-ST"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="class" type="StatisticalModelClass-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StatisticalModel-Clusters-G">
+    <xs:sequence>
+      <xs:element name="clusters">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="StatisticalModel-Cluster-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StatisticalModel-Cluster-G">
+    <xs:sequence>
+      <xs:element name="cluster">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="derivedcolumn">
+              <xs:complexType>
+                <xs:attribute name="mean" type="Double-ST" use="required"/>
+                <xs:attribute name="std-dev" type="Double-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="size" type="xs:int" use="required"/>
+          <xs:attribute name="outlier-cutoff" type="Double-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StatisticalModel-ANOVA-G">
+    <xs:sequence>
+      <xs:element name="anova">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="derivedcolumn">
+              <xs:complexType>
+                <xs:attribute name="cluster-df" type="xs:int" use="required"/>
+                <xs:attribute name="cluster-ss" type="Double-ST" use="required"/>
+                <xs:attribute name="cluster-ms" type="Double-ST" use="required"/>
+                <xs:attribute name="error-df" type="xs:int" use="required"/>
+                <xs:attribute name="error-ss" type="Double-ST" use="required"/>
+                <xs:attribute name="error-ms" type="Double-ST" use="required"/>
+                <xs:attribute name="f-statistic" type="Double-ST" use="required"/>
+                <xs:attribute name="p-value" type="Double-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="TCType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None"/>
+      <xs:enumeration value="CumTotal"/>
+      <xs:enumeration value="WindowTotal"/>
+      <xs:enumeration value="Difference"/>
+      <xs:enumeration value="PctDiff"/>
+      <xs:enumeration value="PctValue"/>
+      <xs:enumeration value="PctTotal"/>
+      <xs:enumeration value="Rank"/>
+      <xs:enumeration value="PctRank"/>
+      <xs:enumeration value="Custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="OrderingType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None"/>
+      <xs:enumeration value="Table"/>
+      <xs:enumeration value="TableCol"/>
+      <xs:enumeration value="Rows"/>
+      <xs:enumeration value="Columns"/>
+      <xs:enumeration value="Pane"/>
+      <xs:enumeration value="PaneCol"/>
+      <xs:enumeration value="RowInPane"/>
+      <xs:enumeration value="ColumnInPane"/>
+      <xs:enumeration value="CellInPane"/>
+      <xs:enumeration value="Field"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="WindowOptions-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="IncludeCurrent"/>
+      <xs:enumeration value="NullIfIncomplete"/>
+      <xs:enumeration value="IncludeCurrent,NullIfIncomplete"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DifferenceOptions-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(Fixed|Relative)(,(Parameter|Compounded))*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PctTotalOptions-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="IncludePages"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="RankOptions-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(Unique|Competition|ModifiedCompetition|Dense),(Ascending|Descending)"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CustomOptions-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(UsePartitionDomain|Parameter|Fixed|NullIfIncomplete|IncludePages)(,(UsePartitionDomain|Parameter|Fixed|NullIfIncomplete|IncludePages))*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="TableCalc-G">
+    <xs:sequence>
+      <xs:element name="table-calc">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="TableCalcProp-OrderingFields-G"/>
+            <xs:group minOccurs="0" ref="TableCalcProp-Address-G"/>
+          </xs:sequence>
+          <xs:attribute name="field" type="QualifiedName-ST"/>
+          <xs:attribute name="ordering-type" type="OrderingType-ST" use="required"/>
+          <xs:attribute name="ordering-field" type="QualifiedName-ST"/>
+          <xs:attribute name="level-break" type="QualifiedName-ST"/>
+          <xs:attribute name="level-address" type="QualifiedName-ST"/>
+          <xs:attribute name="aggregation" type="AggType-ST"/>
+          <xs:attribute name="type" type="TCType-ST"/>
+          <xs:attribute name="from" type="DataValue-ST"/>
+          <xs:attribute name="to" type="DataValue-ST"/>
+          <xs:attribute name="window-options" type="WindowOptions-ST"/>
+          <xs:attribute name="diff-options" type="DifferenceOptions-ST"/>
+          <xs:attribute name="pcttotal-options" type="PctTotalOptions-ST"/>
+          <xs:attribute name="rank-options" type="RankOptions-ST"/>
+          <xs:attribute name="tc-options" type="CustomOptions-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="TableCalcProp-OrderingFields-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="order">
+        <xs:complexType>
+          <xs:attribute name="field" type="QualifiedName-ST"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element minOccurs="0" name="sort">
+        <xs:complexType>
+          <xs:attribute name="using" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="direction" type="SortDirection-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="TableCalcProp-Address-G">
+    <xs:sequence>
+      <xs:element name="address">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="value" type="DataValue-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="OSShortName-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="win"/>
+      <xs:enumeration value="mac"/>
+      <xs:enumeration value="linux"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Group-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="group">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="SetFunction-G"/>
+            <xs:element minOccurs="0" name="desc">
+              <xs:complexType>
+                <xs:group ref="FormattedText-G"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:group minOccurs="0" ref="DataSource-Aliases-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="name-style"/>
+          <xs:attribute name="delimiter" type="xs:string"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="pivot" type="PivotStrategy-ST"/>
+          <xs:attribute name="descend" type="xs:boolean"/>
+          <xs:attribute name="hidden" type="xs:boolean"/>
+          <xs:attribute name="auto-hidden" type="xs:boolean"/>
+          <xs:attribute name="layered" type="xs:boolean"/>
+          <xs:attributeGroup ref="user:UserAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Groups-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="Group-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Aliases-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="aliases">
+        <xs:complexType>
+          <xs:attribute name="enabled" type="DataSource-YesNo-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Column-G">
+    <xs:sequence>
+      <xs:element name="column">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="DataSource-LocalizedServerCaptions-G"/>
+            <xs:group minOccurs="0" ref="DataSource-Calculation-G"/>
+            <xs:group minOccurs="0" ref="DataSource-UtilityDimension-G"/>
+            <xs:group minOccurs="0" ref="DataSource-Aliases-G"/>
+            <xs:group minOccurs="0" ref="StatisticalModel-G"/>
+            <xs:group minOccurs="0" ref="DataSource-SemanticRole-G"/>
+            <xs:group minOccurs="0" ref="DataSource-UserDescription-G"/>
+            <xs:choice minOccurs="0">
+              <xs:group ref="ParameterList-G"/>
+              <xs:group ref="ParameterRange-G"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="role" type="FieldRole-ST" use="required"/>
+          <xs:attribute name="default-role" type="FieldRole-ST"/>
+          <xs:attribute name="aggregation" type="AggType-ST"/>
+          <xs:attribute name="aggregation-param" type="DataValue-ST"/>
+          <xs:attribute name="visual-totals" type="xs:string"/>
+          <xs:attribute name="type" type="FieldType-ST" use="required"/>
+          <xs:attribute name="default-type" type="FieldType-ST"/>
+          <xs:attribute name="datatype" type="DataType-ST" use="required"/>
+          <xs:attribute name="datatype-customized" type="xs:boolean"/>
+          <xs:attribute name="user-datatype" type="DataType-ST"/>
+          <xs:attribute name="default-format" type="xs:string"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="pivot" type="PivotStrategy-ST"/>
+          <xs:attribute name="hidden" type="xs:boolean"/>
+          <xs:attribute name="auto-hidden" type="xs:boolean"/>
+          <xs:attribute name="layered" type="xs:boolean"/>
+          <xs:attribute name="is-adhoc-cluster" type="xs:boolean"/>
+          <xs:attribute name="fiscal-year-start" type="xs:unsignedInt"/>
+          <xs:attribute name="semantic-role" type="QualifiedName-ST"/>
+          <xs:attribute name="semantic-layer" type="xs:boolean"/>
+          <xs:attribute name="parent-model" type="xs:string"/>
+          <xs:attribute name="alias-types-defined" type="xs:int"/>
+          <xs:attribute name="aliastype" type="AliasType-ST"/>
+          <xs:attribute name="approximate-count" type="xs:long"/>
+          <xs:attribute name="source-field" type="QualifiedName-ST"/>
+          <xs:attribute name="param-domain-type" type="DomainType-ST"/>
+          <xs:attribute name="value" type="DataValue-ST"/>
+          <xs:attribute name="alias" type="xs:string"/>
+          <xs:attribute name="folder-name" type="xs:string"/>
+          <xs:attribute name="default-value-field" type="QualifiedName-ST"/>
+          <xs:attribute name="aggregate-role-from" type="QualifiedName-ST"/>
+          <xs:attribute name="is-auto-gen-lod-field" type="xs:boolean"/>
+          <xs:attributeGroup ref="user:UserAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="MemberProperty-CT">
+    <xs:attribute name="key" type="DataValue-ST" use="required"/>
+    <xs:attribute name="value" type="DataValue-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="MemberProperty-WithStringValue-CT">
+    <xs:attribute name="key" type="DataValue-ST" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:group name="CalculatedMembers-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="calculated-members">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="DataSource-CalculatedMember-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Columns-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="Column-G"/>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="ColumnInstance-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceInline-G">
+    <xs:sequence>
+      <xs:element name="datasource" type="DataSource-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-ObjectGraph-G">
+    <xs:sequence>
+      <xs:group ref="ObjectGraph-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-DataSourceTree-G">
+    <xs:sequence>
+      <xs:group ref="DataSourceTree-Wrapper-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="DataSource-CT">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DocumentManifest-G"/>
+      <xs:group ref="RepositoryLocation-G"/>
+      <xs:group minOccurs="0" ref="Connection-G"/>
+      <xs:group ref="UtilityDimension-G"/>
+      <xs:group ref="Dimensions-G"/>
+      <xs:group ref="OverridableSettings-G"/>
+      <xs:group ref="Aliases-G"/>
+      <xs:group ref="Columns-G"/>
+      <xs:group ref="Groups-G"/>
+      <xs:group ref="MappedImages-G"/>
+      <xs:group ref="DrillPaths-G"/>
+      <xs:element minOccurs="0" name="folders-common" type="FieldFolders-CT"/>
+      <xs:element minOccurs="0" name="folders-parameters" type="FieldFolders-CT"/>
+      <xs:group ref="DataSource-Actions-G"/>
+      <xs:group ref="CalculatedMembers-G"/>
+      <xs:group ref="Extract-G"/>
+      <xs:group ref="Layout-G"/>
+      <xs:group ref="Styles-G"/>
+      <xs:group ref="SemanticRoleDefaults-G"/>
+      <xs:group ref="DataSource-DateOptions-G"/>
+      <xs:group ref="DefaultDateFormat-G"/>
+      <xs:group ref="DefaultSorts-G"/>
+      <xs:group ref="FieldSortInfo-G"/>
+      <xs:group ref="DataSourceDependencies-G"/>
+      <xs:group ref="Explainability-G"/>
+      <xs:group ref="DataSourceFilters-G"/>
+      <xs:group ref="AnalyticModel-G"/>
+      <xs:group minOccurs="0" ref="DataSource-ObjectGraph-G"/>
+      <xs:group ref="DefaultCalendarType-G"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="caption" type="xs:string"/>
+    <xs:attribute name="formatted-name" type="xs:string"/>
+    <xs:attribute ref="xml:base"/>
+    <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+    <xs:attribute fixed="true" name="inline" type="xs:boolean" use="required"/>
+    <xs:attribute name="hasconnection" type="xs:boolean"/>
+    <xs:attribute name="source-platform" type="OSShortName-ST"/>
+  </xs:complexType>
+  <xs:group name="OverridableSettings-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="overridable-settings">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="DateOptions-G"/>
+            <xs:element name="default-date-format" type="xs:string"/>
+            <xs:element name="default-calendar-type" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Extract-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="extract">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Connection-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Filter-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="DataSource-Aggregation-G"/>
+          </xs:sequence>
+          <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+          <xs:attribute name="units" type="SortUnits-ST" use="required"/>
+          <xs:attribute name="count" type="Float-ST" use="required"/>
+          <xs:attribute name="object-id" type="xs:string" use="required"/>
+          <xs:attribute name="type" type="Extract-Type-ST"/>
+          <xs:attribute name="user-specific" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Extract-Type-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="normalized"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="MappedImages-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="mapped-images">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="MappedImageSpec-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GeocodingEnhancements-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="geocoding-enhancements">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="GeocodingEnhancement-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DrillPaths-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="drill-paths">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="DrillPath-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element minOccurs="0" name="unlinked-server-hierarchies">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="hierarchy">
+              <xs:complexType>
+                <xs:attribute name="server-id" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DrillPath-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="drill-path">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="field" type="QualifiedName-ST"/>
+            <xs:element minOccurs="0" name="desc">
+              <xs:complexType>
+                <xs:group ref="FormattedText-G"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="server-id" type="xs:string"/>
+          <xs:attribute name="layered" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="FolderItems-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="folder-item">
+        <xs:complexType>
+          <xs:attribute name="type" type="FolderItemType-ST" use="required"/>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="FieldFolders-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="folder" type="FieldFolder-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="FieldFolder-CT">
+    <xs:group ref="FolderItems-G"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="layered" type="xs:boolean"/>
+  </xs:complexType>
+  <xs:group name="DataSource-Actions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="actions">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="ActionSpec-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceLink-G">
+    <xs:sequence>
+      <xs:element name="datasource">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="caption" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceInlineOrLink-G">
+    <xs:sequence>
+      <xs:element name="datasource">
+        <xs:complexType>
+          <xs:sequence minOccurs="0">
+            <xs:group ref="RepositoryLocation-G"/>
+            <xs:group minOccurs="0" ref="Connection-G"/>
+            <xs:group ref="UtilityDimension-G"/>
+            <xs:group ref="Dimensions-G"/>
+            <xs:group ref="OverridableSettings-G"/>
+            <xs:group ref="Aliases-G"/>
+            <xs:group ref="Columns-G"/>
+            <xs:group ref="Groups-G"/>
+            <xs:group ref="MappedImages-G"/>
+            <xs:group ref="DrillPaths-G"/>
+            <xs:element minOccurs="0" name="folders-common" type="FieldFolders-CT"/>
+            <xs:element minOccurs="0" name="folders-parameters" type="FieldFolders-CT"/>
+            <xs:group ref="DataSource-Actions-G"/>
+            <xs:group ref="CalculatedMembers-G"/>
+            <xs:group ref="Extract-G"/>
+            <xs:group ref="Layout-G"/>
+            <xs:group ref="Styles-G"/>
+            <xs:group ref="SemanticRoleDefaults-G"/>
+            <xs:group ref="DataSource-DateOptions-G"/>
+            <xs:group ref="DefaultDateFormat-G"/>
+            <xs:group ref="DefaultSorts-G"/>
+            <xs:group ref="FieldSortInfo-G"/>
+            <xs:group ref="DataSourceDependencies-G"/>
+            <xs:group ref="Explainability-G"/>
+            <xs:group ref="DataSourceFilters-G"/>
+            <xs:group ref="AnalyticModel-G"/>
+            <xs:group minOccurs="0" ref="DataSource-ObjectGraph-G"/>
+            <xs:group ref="DefaultCalendarType-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="formatted-name" type="xs:string"/>
+          <xs:attribute ref="xml:base"/>
+          <xs:attribute name="version" type="VersionNumber-ST"/>
+          <xs:attribute name="inline" type="xs:boolean"/>
+          <xs:attribute name="hasconnection" type="xs:boolean"/>
+          <xs:attribute name="source-platform" type="OSShortName-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ConnectionInfo-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Connection-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Hierarchy-G">
+    <xs:sequence>
+      <xs:element name="hierarchy">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="default-member">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="Tuple-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="hidden" type="xs:boolean"/>
+          <xs:attribute name="layered" type="xs:boolean"/>
+          <xs:attribute name="pivot" type="PivotStrategy-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Dimensions-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="dimension">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Hierarchy-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="default-hierarchy" type="QualifiedName-ST"/>
+          <xs:attribute name="shared-members" type="DataSource-YesNo-ST" use="required"/>
+          <xs:attribute name="aliastype" type="AliasType-ST"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="hidden" type="xs:boolean"/>
+          <xs:attribute name="layered" type="xs:boolean"/>
+          <xs:attribute name="pivot" type="PivotStrategy-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="LayoutPercentages-AG">
+    <xs:attribute name="dim-percentage-v2" type="Float-ST"/>
+    <xs:attribute name="measure-percentage-v2" type="Float-ST"/>
+    <xs:attribute name="common-percentage" type="Float-ST"/>
+    <xs:attribute name="group-percentage" type="Float-ST"/>
+    <xs:attribute name="parameter-percentage" type="Float-ST"/>
+    <xs:attribute name="user-set-layout-v2" type="xs:boolean"/>
+  </xs:attributeGroup>
+  <xs:group name="Layout-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="layout">
+        <xs:complexType>
+          <xs:attributeGroup ref="LayoutPercentages-AG"/>
+          <xs:attribute name="dim-ordering" type="ColumnOrdering-ST" use="required"/>
+          <xs:attribute name="measure-ordering" type="ColumnOrdering-ST" use="required"/>
+          <xs:attribute name="show-structure" type="xs:boolean" use="required"/>
+          <xs:attribute name="show-hidden-fields" type="xs:boolean"/>
+          <xs:attribute name="auto-hide-new-columns" type="xs:boolean"/>
+          <xs:attribute name="show-aliased-fields" type="xs:boolean"/>
+          <xs:attribute name="rowDisplayCount" type="xs:positiveInteger"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Styles-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Stylesheet-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SemanticRoleDefaults-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="semantic-values">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="semantic-value">
+              <xs:complexType>
+                <xs:attribute name="key" type="QualifiedName-ST" use="required"/>
+                <xs:attribute name="value" type="DataValue-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-DateOptions-G">
+    <xs:sequence>
+      <xs:group ref="DateOptions-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DefaultCalendarType-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="default-calendar-type" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DefaultDateFormat-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="default-date-format" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DefaultSorts-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="default-sorts">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="Sort-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="UtilityDimension-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="utility-dimensions">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="utility-dimension">
+              <xs:complexType>
+                <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ParameterList-G">
+    <xs:sequence>
+      <xs:element name="members">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="member">
+              <xs:complexType>
+                <xs:attribute name="value" type="DataValue-ST" use="required"/>
+                <xs:attribute name="alias" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ParameterRange-G">
+    <xs:sequence>
+      <xs:element name="range">
+        <xs:complexType>
+          <xs:attribute name="min" type="DataValue-ST"/>
+          <xs:attribute name="max" type="DataValue-ST"/>
+          <xs:attribute name="granularity" type="DataValue-ST"/>
+          <xs:attribute name="period-type-v2" type="PeriodTypeV2-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceDependencies-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="datasource-dependencies">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded" minOccurs="0">
+              <xs:group ref="Column-G"/>
+              <xs:group ref="ColumnInstance-G"/>
+              <xs:group minOccurs="0" ref="Stylesheet-G"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="datasource" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Explainability-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="explainability">
+        <xs:complexType>
+          <xs:sequence maxOccurs="unbounded" minOccurs="0">
+            <xs:element name="explainability-field">
+              <xs:complexType>
+                <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+                <xs:attribute name="used" type="xs:boolean" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourcesAndDependencies-G">
+    <xs:sequence>
+      <xs:sequence minOccurs="0">
+        <xs:element name="datasources">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:group maxOccurs="unbounded" minOccurs="0" ref="DataSourceLink-G"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:group ref="DataSourceDependencies-G"/>
+      </xs:sequence>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceFilters-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="Filter-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="FieldSortInfo-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="field-sort-info">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="field-sort-custom-order">
+              <xs:complexType>
+                <xs:attribute name="field" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="field-sort-order-type" type="FieldOrderType-ST"/>
+          <xs:attribute name="field-sort-order" type="SortOrder-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-UserDescription-G">
+    <xs:sequence>
+      <xs:element name="desc">
+        <xs:complexType>
+          <xs:group ref="FormattedText-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-SemanticRole-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="semantic-values">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="semantic-value" type="MemberProperty-CT"/>
+          </xs:sequence>
+          <xs:attribute name="semantic-role" type="QualifiedName-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-LocalizedServerCaptions-G">
+    <xs:sequence>
+      <xs:element name="server-captions">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="caption">
+              <xs:complexType mixed="true">
+                <xs:attribute name="locale" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-Calculation-G">
+    <xs:sequence>
+      <xs:element name="calculation">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="TableCalc-G"/>
+            <xs:group minOccurs="0" ref="DataSource-Bins-G"/>
+          </xs:sequence>
+          <xs:attribute name="class" type="DataSource-CalculationType-ST" use="required"/>
+          <xs:attribute name="formula" type="xs:string"/>
+          <xs:attribute name="scope-isolation" type="xs:boolean"/>
+          <xs:attribute name="solve-order" type="xs:string"/>
+          <xs:attribute name="peg" type="Float-ST"/>
+          <xs:attribute name="decimals" type="xs:int"/>
+          <xs:attribute name="size-parameter" type="QualifiedName-ST"/>
+          <xs:attribute name="size" type="Float-ST"/>
+          <xs:attribute name="new-bin" type="xs:boolean"/>
+          <xs:attribute name="column" type="QualifiedName-ST"/>
+          <xs:attribute name="default" type="DataValue-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DataSource-CalculationType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="tableau"/>
+      <xs:enumeration value="passthrough"/>
+      <xs:enumeration value="bin"/>
+      <xs:enumeration value="categorical-bin"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DataSource-Bins-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="bin">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="value" type="DataValue-ST"/>
+          </xs:sequence>
+          <xs:attribute name="value" type="DataValue-ST" use="required"/>
+          <xs:attribute name="default-name" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-UtilityDimension-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="utility-members">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="utility-member">
+              <xs:complexType>
+                <xs:attribute name="level" type="QualifiedName-ST" use="required"/>
+                <xs:attribute name="default-member" type="DataValue-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-CalculatedMember-G">
+    <xs:sequence>
+      <xs:element name="calculated-member">
+        <xs:complexType>
+          <xs:attribute name="type" type="DataSource-CalculatedMemberType-ST"/>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="solve-order" type="xs:unsignedInt"/>
+          <xs:attribute name="scope-isolation" type="xs:boolean"/>
+          <xs:attribute name="formula" type="xs:string"/>
+          <xs:attribute name="parent" type="DataValue-ST"/>
+          <xs:attribute name="field" type="QualifiedName-ST"/>
+          <xs:attribute name="dialect" type="DataSource-DAX-ST"/>
+          <xs:attribute name="from" type="QualifiedName-ST"/>
+          <xs:attribute name="aggregation" type="AggType-ST"/>
+          <xs:attribute name="enabled" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DataSource-CalculatedMemberType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="member"/>
+      <xs:enumeration value="measure"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DataSource-Aggregation-G">
+    <xs:sequence>
+      <xs:element name="aggregation">
+        <xs:complexType>
+          <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="derivation" type="AggType-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-Aliases-G">
+    <xs:sequence>
+      <xs:element name="aliases">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="alias" type="MemberProperty-WithStringValue-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DataSource-DAX-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="DAX"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DataSourceRelationships-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DataSourceDependencies-G"/>
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="DataSourceRelationship-DataSourceRelationship-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ColumnMapping-G">
+    <xs:sequence>
+      <xs:element name="column-mapping">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="map">
+              <xs:complexType>
+                <xs:attribute name="key" type="QualifiedName-ST"/>
+                <xs:attribute name="value" type="QualifiedName-ST"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceRelationship-DataSourceRelationship-G">
+    <xs:sequence>
+      <xs:element name="datasource-relationship">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ColumnMapping-G"/>
+          </xs:sequence>
+          <xs:attribute name="source" type="xs:string" use="required"/>
+          <xs:attribute name="target" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DateFormat_5-ST">
+    <xs:restriction base="DateFormat_5-Base-ST">
+      <xs:pattern value="[^#].*[^#]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_6-ST">
+    <xs:restriction base="DateFormat_6-Base-ST">
+      <xs:pattern value="[^#].*[^#]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_11-ST">
+    <xs:restriction base="DateFormat_11-Base-ST">
+      <xs:pattern value="[^#].*[^#]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_13-ST">
+    <xs:restriction base="DateFormat_13-Base-ST">
+      <xs:pattern value="[^#].*[^#]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_19-ST">
+    <xs:restriction base="DateFormat_19-Base-ST">
+      <xs:pattern value="[^#].*[^#]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_5-Base-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#?[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}#?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_6-Base-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#?[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}#?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_11-Base-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#?[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}#?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_13-Base-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#?[0-9]{2}:[0-9]{2}:[0-9]{2}#?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_19-Base-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#?[0-9]{4}-[0-9]{2}-[0-9]{2}#?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataValue-ST">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="DataType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="unknown"/>
+      <xs:enumeration value="integer"/>
+      <xs:enumeration value="real"/>
+      <xs:enumeration value="string"/>
+      <xs:enumeration value="datetime"/>
+      <xs:enumeration value="date"/>
+      <xs:enumeration value="boolean"/>
+      <xs:enumeration value="tuple"/>
+      <xs:enumeration value="spatial"/>
+      <xs:enumeration value="table"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Special-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="%null%"/>
+      <xs:enumeration value="%all%"/>
+      <xs:enumeration value="%wildcard%"/>
+      <xs:enumeration value="%skipped%"/>
+      <xs:enumeration value="%no-access%"/>
+      <xs:enumeration value="%ragged%"/>
+      <xs:enumeration value="%error%"/>
+      <xs:enumeration value="%many-values%"/>
+      <xs:enumeration value="%missing%"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Date-ST">
+    <xs:restriction base="DateFormat_19-Base-ST">
+      <xs:pattern value="#.*#"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateTime-ST">
+    <xs:union memberTypes="DataValue-DateFormat_5-Hashes-ST DataValue-DateFormat_6-Hashes-ST DataValue-DateFormat_11-Hashes-ST DataValue-DateFormat_13-Hashes-ST"/>
+  </xs:simpleType>
+  <xs:simpleType name="String-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="&quot;.*&quot;"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Tuple-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\(.*\)"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Spatial-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="POINT"/>
+      <xs:enumeration value="LINESTRING"/>
+      <xs:enumeration value="POLYGON"/>
+      <xs:enumeration value="MULTIPOINT"/>
+      <xs:enumeration value="MULTILINESTRING"/>
+      <xs:enumeration value="MULTIPOLYGON"/>
+      <xs:enumeration value="MIXED"/>
+      <xs:enumeration value="UNKNOWN"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataValue-DateFormat_5-Hashes-ST">
+    <xs:restriction base="DateFormat_5-Base-ST">
+      <xs:pattern value="#.*#"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataValue-DateFormat_6-Hashes-ST">
+    <xs:restriction base="DateFormat_6-Base-ST">
+      <xs:pattern value="#.*#"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataValue-DateFormat_11-Hashes-ST">
+    <xs:restriction base="DateFormat_11-Base-ST">
+      <xs:pattern value="#.*#"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataValue-DateFormat_13-Hashes-ST">
+    <xs:restriction base="DateFormat_13-Base-ST">
+      <xs:pattern value="#.*#"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DensificationFillType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="fill-missing"/>
+      <xs:enumeration value="fill-zero"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="DocumentManifest-CT">
+    <xs:sequence>
+      <xs:any maxOccurs="unbounded" minOccurs="0" processContents="skip"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="DocumentManifest-G">
+    <xs:sequence>
+      <xs:element name="document-format-change-manifest" type="DocumentManifest-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ColorObject-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#[0-9A-Fa-f]{6}|#[0-9A-Fa-f]{8}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="MapProvider-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="connection">
+        <xs:complexType>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="UnknownMapProvider-G">
+    <xs:sequence>
+      <xs:group ref="MapProvider-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapProvider-Connection-G">
+    <xs:sequence>
+      <xs:group ref="MapProvider-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapSourceDefaults-G">
+    <xs:sequence>
+      <xs:element name="mapsource-defaults">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Stylesheet-G"/>
+          </xs:sequence>
+          <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+          <xs:attribute name="source-platform" type="OSShortName-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Layer-G">
+    <xs:sequence>
+      <xs:element name="layer">
+        <xs:complexType>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Layers-G">
+    <xs:sequence>
+      <xs:element name="layers">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" minOccurs="0" ref="Layer-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Language-G">
+    <xs:sequence>
+      <xs:element name="language">
+        <xs:complexType>
+          <xs:attribute name="iso" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Languages-G">
+    <xs:sequence>
+      <xs:element name="languages">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" minOccurs="0" ref="Language-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapStyle-G">
+    <xs:sequence>
+      <xs:element name="map-style">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="map-layer-style">
+              <xs:complexType>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="request-string" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="display-name" type="xs:string" use="required"/>
+          <xs:attribute name="wait-tile-color" type="ColorObject-ST" use="required"/>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapStyles-G">
+    <xs:sequence>
+      <xs:element name="map-styles">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" minOccurs="0" ref="MapStyle-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="UserAttributes-G">
+    <xs:sequence>
+      <xs:element name="properties">
+        <xs:complexType>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapSourceInline-G">
+    <xs:sequence>
+      <xs:group ref="MapSource-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapSource-G">
+    <xs:sequence>
+      <xs:element name="mapsource" type="MapSource-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="MapSource-CT">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DocumentManifest-G"/>
+      <xs:group ref="MapProvider-Connection-G"/>
+      <xs:group minOccurs="0" ref="Languages-G"/>
+      <xs:group minOccurs="0" ref="Layers-G"/>
+      <xs:group minOccurs="0" ref="UserAttributes-G"/>
+      <xs:group minOccurs="0" ref="MapStyles-G"/>
+      <xs:group ref="Defaults-G"/>
+      <xs:group minOccurs="0" ref="MapAttribution-G"/>
+      <xs:group minOccurs="0" ref="MapAttribution2-G"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+    <xs:attribute name="inline" type="xs:boolean" use="required"/>
+    <xs:attribute name="source-platform" type="OSShortName-ST"/>
+  </xs:complexType>
+  <xs:group name="MapSourceLink-G">
+    <xs:sequence>
+      <xs:element name="mapsource">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapSourceInlineOrLink-G">
+    <xs:sequence>
+      <xs:element name="mapsource">
+        <xs:complexType>
+          <xs:sequence minOccurs="0">
+            <xs:group ref="MapProvider-Connection-G"/>
+            <xs:group ref="Languages-G"/>
+            <xs:group minOccurs="0" ref="Layers-G"/>
+            <xs:group minOccurs="0" ref="UserAttributes-G"/>
+            <xs:group ref="MapStyles-G"/>
+            <xs:group ref="Defaults-G"/>
+            <xs:group minOccurs="0" ref="MapAttribution-G"/>
+            <xs:group minOccurs="0" ref="MapAttribution2-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="version" type="VersionNumber-ST"/>
+          <xs:attribute name="inline" type="xs:boolean"/>
+          <xs:attribute name="source-platform" type="OSShortName-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Defaults-G">
+    <xs:sequence>
+      <xs:group ref="MapSourceDefaults-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapAttribution-G">
+    <xs:sequence>
+      <xs:element name="map-attribution">
+        <xs:complexType>
+          <xs:attribute name="copyright-string" type="xs:string" use="required"/>
+          <xs:attribute name="short-copyright-string" type="xs:string" use="required"/>
+          <xs:attribute name="copyright-url" type="xs:string" use="required"/>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapAttribution2-G">
+    <xs:sequence>
+      <xs:element name="map-attribution2">
+        <xs:complexType>
+          <xs:attribute name="copyright-string" type="xs:string" use="required"/>
+          <xs:attribute name="short-copyright-string" type="xs:string" use="required"/>
+          <xs:attribute name="copyright-url" type="xs:string" use="required"/>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="PaletteType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="regular"/>
+      <xs:enumeration value="ordered-diverging"/>
+      <xs:enumeration value="ordered-sequential"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="ColorPalette-G">
+    <xs:sequence>
+      <xs:element name="color-palette">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="color" type="ColorObject-ST"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="type" type="PaletteType-ST" use="required"/>
+          <xs:attribute name="not-reference-band" type="xs:boolean"/>
+          <xs:attribute name="not-filled" type="xs:boolean"/>
+          <xs:attribute name="not-categorical" type="xs:boolean"/>
+          <xs:attribute name="not-quantitative" type="xs:boolean"/>
+          <xs:attribute name="custom" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Preferences-G">
+    <xs:sequence>
+      <xs:element name="preferences">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Preference-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="ColorPalette-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Preference-G">
+    <xs:sequence>
+      <xs:element name="preference">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="ReferencedView-CT">
+    <xs:sequence maxOccurs="1"/>
+    <xs:attribute name="instances" type="xs:int" use="required"/>
+    <xs:attribute name="viewId" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ReferencedViews-CT">
+    <xs:sequence maxOccurs="unbounded">
+      <xs:element name="referenced-view" type="ReferencedView-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ReferencedExtension-CT">
+    <xs:sequence maxOccurs="1">
+      <xs:element name="manifest" type="ExtensionManifest-CT"/>
+      <xs:element name="referenced-views" type="ReferencedViews-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ReferencedExtensions-CT">
+    <xs:sequence maxOccurs="unbounded">
+      <xs:element name="referenced-extension" type="ReferencedExtension-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="RepositoryLocation-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="repository-location">
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:string" use="required"/>
+          <xs:attribute name="path" type="xs:string" use="required"/>
+          <xs:attribute name="revision" type="xs:string" use="required"/>
+          <xs:attribute name="server-base" type="xs:string"/>
+          <xs:attribute name="site" type="xs:string"/>
+          <xs:attribute name="derived-from" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ShapeType-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="([^/]*/)?[^/]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Shapes-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="external">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="shapes">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="shape">
+                    <xs:complexType>
+                      <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                          <xs:attribute name="name" type="ShapeType-ST"/>
+                        </xs:extension>
+                      </xs:simpleContent>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="FieldType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="nominal"/>
+      <xs:enumeration value="ordinal"/>
+      <xs:enumeration value="quantitative"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TickSpacingUnits-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="years"/>
+      <xs:enumeration value="iso-years"/>
+      <xs:enumeration value="quarters"/>
+      <xs:enumeration value="iso-quarters"/>
+      <xs:enumeration value="months"/>
+      <xs:enumeration value="weeks"/>
+      <xs:enumeration value="iso-weeks"/>
+      <xs:enumeration value="days"/>
+      <xs:enumeration value="hours"/>
+      <xs:enumeration value="minutes"/>
+      <xs:enumeration value="seconds"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ScaleType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="linear"/>
+      <xs:enumeration value="log"/>
+      <xs:enumeration value="symlog"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="RangeTypeEncodings-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="automatic"/>
+      <xs:enumeration value="independent"/>
+      <xs:enumeration value="uniform"/>
+      <xs:enumeration value="fixed"/>
+      <xs:enumeration value="fixedmin"/>
+      <xs:enumeration value="fixedmax"/>
+      <xs:enumeration value="fixedminindependentmax"/>
+      <xs:enumeration value="fixedmaxindependentmin"/>
+      <xs:enumeration value="fixedminuniformmax"/>
+      <xs:enumeration value="fixedmaxuniformmin"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:attributeGroup name="EncodingTagAttributes-AG">
+    <xs:attribute name="type" type="StyleEncodingType-ST"/>
+    <xs:attribute name="attr" type="StyleAttribute-ST"/>
+    <xs:attribute name="class" type="xs:string"/>
+    <xs:attribute name="field" type="xs:string"/>
+    <xs:attribute name="pseudo-class" type="StylePseudoClass-ST"/>
+    <xs:attribute name="scope" type="StyleFieldScope-ST"/>
+    <xs:attribute name="field-type" type="FieldType-ST"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="Encoding-AG">
+  </xs:attributeGroup>
+  <xs:group name="Map-G">
+    <xs:sequence>
+      <xs:element name="map">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="MultiBucket-Or-Bucket-G"/>
+          </xs:sequence>
+          <xs:attribute name="to" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapPri-G">
+    <xs:sequence>
+      <xs:element name="map-pri">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Bucket-G"/>
+          </xs:sequence>
+          <xs:attribute name="to" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Encoding-G">
+    <xs:sequence>
+      <xs:element name="encoding">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="ColorPalette-G"/>
+            <xs:choice maxOccurs="unbounded" minOccurs="0">
+              <xs:group ref="Map-G"/>
+              <xs:group ref="MapPri-G"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attributeGroup ref="EncodingTagAttributes-AG"/>
+          <xs:attribute name="center" type="DataValue-ST"/>
+          <xs:attribute name="domain-expand" type="xs:boolean"/>
+          <xs:attribute name="fold" type="xs:boolean"/>
+          <xs:attribute name="include-totals" type="xs:boolean"/>
+          <xs:attribute name="major-origin" type="DataValue-ST"/>
+          <xs:attribute name="major-show" type="xs:boolean"/>
+          <xs:attribute name="major-spacing" type="DataValue-ST"/>
+          <xs:attribute name="major-units" type="TickSpacingUnits-ST"/>
+          <xs:attribute name="max" type="DataValue-ST"/>
+          <xs:attribute name="max-size" type="Double-ST"/>
+          <xs:attribute name="min" type="DataValue-ST"/>
+          <xs:attribute name="min-size" type="Double-ST"/>
+          <xs:attribute name="minor-origin" type="DataValue-ST"/>
+          <xs:attribute name="minor-show" type="xs:boolean"/>
+          <xs:attribute name="minor-spacing" type="DataValue-ST"/>
+          <xs:attribute name="minor-units" type="TickSpacingUnits-ST"/>
+          <xs:attribute name="num-steps" type="xs:int"/>
+          <xs:attribute name="palette" type="xs:string"/>
+          <xs:attribute name="projection" type="xs:string"/>
+          <xs:attribute name="range-type" type="RangeTypeEncodings-ST"/>
+          <xs:attribute name="reverse" type="xs:boolean"/>
+          <xs:attribute name="scale" type="ScaleType-ST"/>
+          <xs:attribute name="symmetric" type="xs:boolean"/>
+          <xs:attribute name="synchronized" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Stylesheet-G">
+    <xs:sequence>
+      <xs:element name="style">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="style-rule">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group maxOccurs="unbounded" minOccurs="0" ref="Attribute-G"/>
+                </xs:sequence>
+                <xs:attribute name="element" type="StyleElement-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="delta-type" type="StoryDelta-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Attribute-G">
+    <xs:sequence>
+      <xs:choice minOccurs="0">
+        <xs:group ref="Format-G"/>
+        <xs:group ref="Encoding-G"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Format-G">
+    <xs:sequence>
+      <xs:element name="format">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="FormattedText-G"/>
+          </xs:sequence>
+          <xs:attribute name="attr" type="StyleAttribute-ST" use="required"/>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+          <xs:attribute name="class" type="xs:string"/>
+          <xs:attribute name="id" type="xs:string"/>
+          <xs:attribute name="data-class" type="StyleDataClass-ST"/>
+          <xs:attribute name="scope" type="StyleFieldScope-ST"/>
+          <xs:attribute name="field" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="StyleElement-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="animation"/>
+      <xs:enumeration value="axis"/>
+      <xs:enumeration value="cell"/>
+      <xs:enumeration value="datalabel"/>
+      <xs:enumeration value="dropspot"/>
+      <xs:enumeration value="header"/>
+      <xs:enumeration value="field-labels"/>
+      <xs:enumeration value="field-labels-decoration"/>
+      <xs:enumeration value="field-labels-spanner"/>
+      <xs:enumeration value="label"/>
+      <xs:enumeration value="mark"/>
+      <xs:enumeration value="page-card-body"/>
+      <xs:enumeration value="pane"/>
+      <xs:enumeration value="table"/>
+      <xs:enumeration value="worksheet"/>
+      <xs:enumeration value="basesheet"/>
+      <xs:enumeration value="dashboard"/>
+      <xs:enumeration value="storyboard"/>
+      <xs:enumeration value="caption"/>
+      <xs:enumeration value="dropline"/>
+      <xs:enumeration value="refline"/>
+      <xs:enumeration value="refband"/>
+      <xs:enumeration value="refboxplot"/>
+      <xs:enumeration value="gridline"/>
+      <xs:enumeration value="zeroline"/>
+      <xs:enumeration value="trendline"/>
+      <xs:enumeration value="table-div"/>
+      <xs:enumeration value="header-div"/>
+      <xs:enumeration value="mapped-image"/>
+      <xs:enumeration value="action"/>
+      <xs:enumeration value="title"/>
+      <xs:enumeration value="legend"/>
+      <xs:enumeration value="legend-title"/>
+      <xs:enumeration value="legend-title-text"/>
+      <xs:enumeration value="axis-title"/>
+      <xs:enumeration value="annotation"/>
+      <xs:enumeration value="dash-title"/>
+      <xs:enumeration value="dash-subtitle"/>
+      <xs:enumeration value="dash-text"/>
+      <xs:enumeration value="dash-zone"/>
+      <xs:enumeration value="dash-container"/>
+      <xs:enumeration value="scrollbar"/>
+      <xs:enumeration value="map-layer"/>
+      <xs:enumeration value="map"/>
+      <xs:enumeration value="map-data-layer"/>
+      <xs:enumeration value="quick-filter"/>
+      <xs:enumeration value="quick-filter-title"/>
+      <xs:enumeration value="data-highlighter"/>
+      <xs:enumeration value="data-highlighter-title"/>
+      <xs:enumeration value="parameter-ctrl"/>
+      <xs:enumeration value="parameter-ctrl-title"/>
+      <xs:enumeration value="page-card-title"/>
+      <xs:enumeration value="story-title"/>
+      <xs:enumeration value="story-description"/>
+      <xs:enumeration value="story-point-caption"/>
+      <xs:enumeration value="tooltip"/>
+      <xs:enumeration value="all"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StyleAttribute-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="alternate-text"/>
+      <xs:enumeration value="alt-mark-color"/>
+      <xs:enumeration value="animation-on"/>
+      <xs:enumeration value="animation-duration"/>
+      <xs:enumeration value="animation-style"/>
+      <xs:enumeration value="aspect"/>
+      <xs:enumeration value="auto-subtitle"/>
+      <xs:enumeration value="background-color"/>
+      <xs:enumeration value="background-transparency"/>
+      <xs:enumeration value="band-size"/>
+      <xs:enumeration value="band-color"/>
+      <xs:enumeration value="band-level"/>
+      <xs:enumeration value="body-type"/>
+      <xs:enumeration value="border-color"/>
+      <xs:enumeration value="border-color-top"/>
+      <xs:enumeration value="border-color-right"/>
+      <xs:enumeration value="border-color-bottom"/>
+      <xs:enumeration value="border-color-left"/>
+      <xs:enumeration value="border-style"/>
+      <xs:enumeration value="border-style-top"/>
+      <xs:enumeration value="border-style-right"/>
+      <xs:enumeration value="border-style-bottom"/>
+      <xs:enumeration value="border-style-left"/>
+      <xs:enumeration value="border-width"/>
+      <xs:enumeration value="border-width-top"/>
+      <xs:enumeration value="border-width-right"/>
+      <xs:enumeration value="border-width-bottom"/>
+      <xs:enumeration value="border-width-left"/>
+      <xs:enumeration value="break-on-special"/>
+      <xs:enumeration value="cell"/>
+      <xs:enumeration value="cell-w"/>
+      <xs:enumeration value="cell-h"/>
+      <xs:enumeration value="cell-q"/>
+      <xs:enumeration value="cell-qmark"/>
+      <xs:enumeration value="color"/>
+      <xs:enumeration value="color-mode"/>
+      <xs:enumeration value="col-levels"/>
+      <xs:enumeration value="col-vert-levels"/>
+      <xs:enumeration value="col-horiz-height"/>
+      <xs:enumeration value="col-vert-height"/>
+      <xs:enumeration value="col-height"/>
+      <xs:enumeration value="col-width"/>
+      <xs:enumeration value="content"/>
+      <xs:enumeration value="corner-radius"/>
+      <xs:enumeration value="corner-radius-top-left"/>
+      <xs:enumeration value="corner-radius-top-right"/>
+      <xs:enumeration value="corner-radius-bottom-right"/>
+      <xs:enumeration value="corner-radius-bottom-left"/>
+      <xs:enumeration value="density-color"/>
+      <xs:enumeration value="density-kernel-size"/>
+      <xs:enumeration value="density-intensity"/>
+      <xs:enumeration value="density-max-value"/>
+      <xs:enumeration value="display-field-labels"/>
+      <xs:enumeration value="display"/>
+      <xs:enumeration value="display-alternate-text"/>
+      <xs:enumeration value="div-level"/>
+      <xs:enumeration value="enabled"/>
+      <xs:enumeration value="fill-above"/>
+      <xs:enumeration value="fill-below"/>
+      <xs:enumeration value="fill-color"/>
+      <xs:enumeration value="fog-bg-color"/>
+      <xs:enumeration value="fog-desaturation-without-selection"/>
+      <xs:enumeration value="fog-desaturation-with-selection"/>
+      <xs:enumeration value="font-family"/>
+      <xs:enumeration value="font-size"/>
+      <xs:enumeration value="font-style"/>
+      <xs:enumeration value="font-weight"/>
+      <xs:enumeration value="geo-area-type"/>
+      <xs:enumeration value="halign"/>
+      <xs:enumeration value="halo-color"/>
+      <xs:enumeration value="halo-color-selected"/>
+      <xs:enumeration value="has-label"/>
+      <xs:enumeration value="has-fill"/>
+      <xs:enumeration value="has-stroke"/>
+      <xs:enumeration value="has-halo"/>
+      <xs:enumeration value="height"/>
+      <xs:enumeration value="height-header"/>
+      <xs:enumeration value="highlight-legend"/>
+      <xs:enumeration value="hnaxis"/>
+      <xs:enumeration value="hnlabel"/>
+      <xs:enumeration value="in-tooltip"/>
+      <xs:enumeration value="line-end"/>
+      <xs:enumeration value="line-end-size"/>
+      <xs:enumeration value="line-interpolation"/>
+      <xs:enumeration value="line-marker-position"/>
+      <xs:enumeration value="line-pattern"/>
+      <xs:enumeration value="line-pattern-only"/>
+      <xs:enumeration value="line-visibility"/>
+      <xs:enumeration value="map"/>
+      <xs:enumeration value="map-style"/>
+      <xs:enumeration value="map-snap-zoom"/>
+      <xs:enumeration value="margin"/>
+      <xs:enumeration value="margin-top"/>
+      <xs:enumeration value="margin-right"/>
+      <xs:enumeration value="margin-bottom"/>
+      <xs:enumeration value="margin-left"/>
+      <xs:enumeration value="mark-color"/>
+      <xs:enumeration value="mark-transparency"/>
+      <xs:enumeration value="mark-markers-mode"/>
+      <xs:enumeration value="mark-labels-show"/>
+      <xs:enumeration value="mark-labels-mode"/>
+      <xs:enumeration value="mark-labels-cull"/>
+      <xs:enumeration value="mark-labels-line-first"/>
+      <xs:enumeration value="mark-labels-line-last"/>
+      <xs:enumeration value="mark-labels-range-min"/>
+      <xs:enumeration value="mark-labels-range-max"/>
+      <xs:enumeration value="mark-labels-range-scope"/>
+      <xs:enumeration value="mark-labels-range-field"/>
+      <xs:enumeration value="mark-line-pattern"/>
+      <xs:enumeration value="maxheight"/>
+      <xs:enumeration value="max-font-size"/>
+      <xs:enumeration value="max-stroke-width"/>
+      <xs:enumeration value="maxwidth"/>
+      <xs:enumeration value="middle-stroke-width"/>
+      <xs:enumeration value="minheight"/>
+      <xs:enumeration value="min-font-size"/>
+      <xs:enumeration value="min-stroke-width"/>
+      <xs:enumeration value="minwidth"/>
+      <xs:enumeration value="nonhighlight-color"/>
+      <xs:enumeration value="min-length"/>
+      <xs:enumeration value="min-map-size"/>
+      <xs:enumeration value="min-size"/>
+      <xs:enumeration value="omit-on-special"/>
+      <xs:enumeration value="orientation"/>
+      <xs:enumeration value="padding"/>
+      <xs:enumeration value="padding-top"/>
+      <xs:enumeration value="padding-right"/>
+      <xs:enumeration value="padding-bottom"/>
+      <xs:enumeration value="padding-left"/>
+      <xs:enumeration value="palette"/>
+      <xs:enumeration value="render-fold-reversed"/>
+      <xs:enumeration value="reverse-palette"/>
+      <xs:enumeration value="rounding"/>
+      <xs:enumeration value="row-horiz-levels"/>
+      <xs:enumeration value="row-horiz-width"/>
+      <xs:enumeration value="row-levels"/>
+      <xs:enumeration value="row-vert-width"/>
+      <xs:enumeration value="separator"/>
+      <xs:enumeration value="shape"/>
+      <xs:enumeration value="show-labels"/>
+      <xs:enumeration value="show-null-value-warning"/>
+      <xs:enumeration value="size"/>
+      <xs:enumeration value="size-bar"/>
+      <xs:enumeration value="smart-auto-align"/>
+      <xs:enumeration value="space"/>
+      <xs:enumeration value="stroke-color"/>
+      <xs:enumeration value="stroke-size"/>
+      <xs:enumeration value="subtitle"/>
+      <xs:enumeration value="text-align"/>
+      <xs:enumeration value="text-align-default"/>
+      <xs:enumeration value="text-decoration"/>
+      <xs:enumeration value="text-indent"/>
+      <xs:enumeration value="text-orientation"/>
+      <xs:enumeration value="text-format"/>
+      <xs:enumeration value="tick-color"/>
+      <xs:enumeration value="tick-length"/>
+      <xs:enumeration value="tick-spacing"/>
+      <xs:enumeration value="total-label"/>
+      <xs:enumeration value="title"/>
+      <xs:enumeration value="washout"/>
+      <xs:enumeration value="width"/>
+      <xs:enumeration value="width-header"/>
+      <xs:enumeration value="wrap"/>
+      <xs:enumeration value="valign"/>
+      <xs:enumeration value="vertical-align"/>
+      <xs:enumeration value="vertical-align-default"/>
+      <xs:enumeration value="vnaxis"/>
+      <xs:enumeration value="vnlabel"/>
+      <xs:enumeration value="zoom"/>
+      <xs:enumeration value="whisker-stroke-size"/>
+      <xs:enumeration value="whisker-stroke-color"/>
+      <xs:enumeration value="whisker-end"/>
+      <xs:enumeration value="boxplot-style"/>
+      <xs:enumeration value="opacity"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StylePseudoClass-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="selected"/>
+      <xs:enumeration value="highlighted"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StyleEncodingType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="diverging"/>
+      <xs:enumeration value="palette"/>
+      <xs:enumeration value="interpolated"/>
+      <xs:enumeration value="shape"/>
+      <xs:enumeration value="space"/>
+      <xs:enumeration value="catsize"/>
+      <xs:enumeration value="cat-highlight"/>
+      <xs:enumeration value="quantsize"/>
+      <xs:enumeration value="rangesize"/>
+      <xs:enumeration value="centersize"/>
+      <xs:enumeration value="text"/>
+      <xs:enumeration value="custom-interpolated"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StyleDataClass-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="total"/>
+      <xs:enumeration value="subtotal"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StyleFieldScope-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="rows"/>
+      <xs:enumeration value="cols"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StyleSwatch-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="light"/>
+      <xs:enumeration value="dark"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StyleTheme-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="classic"/>
+      <xs:enumeration value="modern"/>
+      <xs:enumeration value="clean"/>
+      <xs:enumeration value="smooth"/>
+      <xs:enumeration value="custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Verbosity-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="high"/>
+      <xs:enumeration value="low"/>
+      <xs:enumeration value="medium"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="InsightType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="NONE"/>
+      <xs:enumeration value="RISKY_MONOPOLY"/>
+      <xs:enumeration value="TOP_DRIVERS"/>
+      <xs:enumeration value="CURRENT_TREND"/>
+      <xs:enumeration value="NEW_TREND"/>
+      <xs:enumeration value="TOP_DIMENSION_MEMBER_MOVERS"/>
+      <xs:enumeration value="METRIC_FORECAST"/>
+      <xs:enumeration value="BOTTOM_CONTRIBUTORS"/>
+      <xs:enumeration value="TOP_DETRACTORS"/>
+      <xs:enumeration value="UNUSUAL_CHANGE"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="TabAgentConfig-ExcludedSheets-CT">
+    <xs:sequence>
+      <xs:group ref="SimpleIdentifier-G" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TabAgentConfig-Item-CT">
+    <xs:sequence>
+      <xs:group ref="SimpleIdentifier-G"/>
+      <xs:element name="summary-enabled" type="xs:boolean" minOccurs="0"/>
+      <xs:element name="insight-enabled" type="xs:boolean" minOccurs="0"/>
+      <xs:element name="verbosity" type="Verbosity-ST" minOccurs="0"/>
+      <xs:element name="excluded-insight-type" type="InsightType-ST" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="excluded-sheets" type="TabAgentConfig-ExcludedSheets-CT" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="TabAgentConfig-G">
+    <xs:sequence>
+      <xs:element name="tab-agent-config">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="tab-agent-config-item" type="TabAgentConfig-Item-CT" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="UniqueTabAgentItemIdentifier">
+          <xs:selector xpath="tab-agent-config-item/simple-id"/>
+          <xs:field xpath="@uuid"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Thumbnail-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="thumbnail">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="name" type="xs:string" use="required"/>
+              <xs:attribute name="width" type="xs:int" use="required"/>
+              <xs:attribute name="height" type="xs:int" use="required"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="VersionNumber-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(\d+)((\.)(\d+))*((-)(\d+))*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Perspective-G">
+    <xs:sequence>
+      <xs:element name="perspectives">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="perspective">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="perspective-dimension">
+                    <xs:complexType>
+                      <xs:group ref="Tuple-G"/>
+                      <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+                <xs:attribute name="perspective-type" type="Perspective-Type-ST" use="required"/>
+                <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Perspective-Type-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="reality"/>
+      <xs:enumeration value="first"/>
+      <xs:enumeration value="last"/>
+      <xs:enumeration value="custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="ShelfSorts-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="ShelfSortLists-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSort-G">
+    <xs:sequence>
+      <xs:element name="shelf-sort">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ShelfSortInfo-DimensionList-G"/>
+            <xs:group ref="ShelfSortInfo-FilterInfo-G"/>
+          </xs:sequence>
+          <xs:attribute name="direction" type="SortDirection-ST" use="required"/>
+          <xs:attribute name="measure-to-sort-by" type="QualifiedName-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortLists-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="ShelfSortList-G"/>
+      <xs:group minOccurs="0" ref="SingleValuePerNestShelfSortList-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortList-G">
+    <xs:sequence>
+      <xs:element name="shelf-sorts">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="shelf-sort-v2" type="ShelfSortInfo-ShelfSort-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SingleValuePerNestShelfSortList-G">
+    <xs:sequence>
+      <xs:element name="single-value-per-nest-shelf-sorts">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="single-value-per-nest-shelf-sort" type="ShelfSortInfo-ShelfSort-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="ShelfSortInfo-ShelfSort-CT">
+    <xs:sequence>
+      <xs:group ref="ShelfSortInfo-FilterInfo-G"/>
+    </xs:sequence>
+    <xs:attribute name="dimension-to-sort" type="QualifiedName-ST" use="required"/>
+    <xs:attribute name="direction" type="SortDirection-ST" use="required"/>
+    <xs:attribute name="is-on-innermost-dimension" type="xs:boolean"/>
+    <xs:attribute name="measure-to-sort-by" type="QualifiedName-ST" use="required"/>
+    <xs:attribute name="shelf" type="ShelfSortInfo-ShelfType-ST" use="required"/>
+  </xs:complexType>
+  <xs:group name="ShelfSortInfo-DimensionList-G">
+    <xs:sequence>
+      <xs:element name="dimensions-to-sort">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="dimension" type="QualifiedName-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortInfo-FilterInfo-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="sort-filter-info">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="sort-filter">
+              <xs:complexType>
+                <xs:attribute name="level-name" type="QualifiedName-ST" use="required"/>
+                <xs:attribute name="member-value" type="DataValue-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ShelfSortInfo-ShelfType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="columns"/>
+      <xs:enumeration value="rows"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="ViewSpec-ShelfSorts-G">
+    <xs:sequence>
+      <xs:group ref="ShelfSorts-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ViewSpec-HideSortControls-G">
+    <xs:sequence>
+      <xs:element name="hide-sort-controls"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ViewSpecification-G">
+    <xs:sequence>
+      <xs:sequence maxOccurs="unbounded" minOccurs="0">
+        <xs:group maxOccurs="2" minOccurs="0" ref="FilterOrHideDataFilter-G"/>
+        <xs:group minOccurs="0" ref="Sort-G"/>
+      </xs:sequence>
+      <xs:group minOccurs="0" ref="Perspective-G"/>
+      <xs:group minOccurs="0" ref="ViewSpec-ShelfSorts-G"/>
+      <xs:group minOccurs="0" ref="ViewSpec-HideSortControls-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="SelectionRelaxationOption-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="selection-relaxation-allow"/>
+      <xs:enumeration value="selection-relaxation-disallow"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PrimitiveType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Automatic"/>
+      <xs:enumeration value="Text"/>
+      <xs:enumeration value="Icon"/>
+      <xs:enumeration value="Shape"/>
+      <xs:enumeration value="Rectangle"/>
+      <xs:enumeration value="Bar"/>
+      <xs:enumeration value="GanttBar"/>
+      <xs:enumeration value="Square"/>
+      <xs:enumeration value="Circle"/>
+      <xs:enumeration value="Heatmap"/>
+      <xs:enumeration value="PolyLine"/>
+      <xs:enumeration value="Line"/>
+      <xs:enumeration value="Polygon"/>
+      <xs:enumeration value="Area"/>
+      <xs:enumeration value="Pie"/>
+      <xs:enumeration value="Multipolygon"/>
+      <xs:enumeration value="VizExtension"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DropWhen-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="never"/>
+      <xs:enumeration value="always"/>
+      <xs:enumeration value="selected"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StackingMode-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="off"/>
+      <xs:enumeration value="on"/>
+      <xs:enumeration value="auto"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MarkSizingSetting-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="marks-scaling-automatic"/>
+      <xs:enumeration value="marks-scaling-on"/>
+      <xs:enumeration value="marks-scaling-off"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MarkAlignment-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="mark-alignment-left"/>
+      <xs:enumeration value="mark-alignment-center"/>
+      <xs:enumeration value="mark-alignment-right"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TrendLineFitType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="linear"/>
+      <xs:enumeration value="polynomial"/>
+      <xs:enumeration value="log"/>
+      <xs:enumeration value="exp"/>
+      <xs:enumeration value="power"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineScopeType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="per-cell"/>
+      <xs:enumeration value="per-pane"/>
+      <xs:enumeration value="per-table"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineLabelType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="automatic"/>
+      <xs:enumeration value="value"/>
+      <xs:enumeration value="computation"/>
+      <xs:enumeration value="custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineTooltipType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="automatic"/>
+      <xs:enumeration value="custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineShowLines-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="both"/>
+      <xs:enumeration value="upper"/>
+      <xs:enumeration value="lower"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineStDevType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="sample"/>
+      <xs:enumeration value="population"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineFormulaType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="constant"/>
+      <xs:enumeration value="total"/>
+      <xs:enumeration value="sum"/>
+      <xs:enumeration value="min"/>
+      <xs:enumeration value="max"/>
+      <xs:enumeration value="average"/>
+      <xs:enumeration value="median"/>
+      <xs:enumeration value="quantiles"/>
+      <xs:enumeration value="percentile"/>
+      <xs:enumeration value="stdev"/>
+      <xs:enumeration value="confidence"/>
+      <xs:enumeration value="medianconfidence"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineBoxplotWhiskerType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="standard"/>
+      <xs:enumeration value="minmax"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="PaneSpecification-G">
+    <xs:sequence>
+      <xs:element name="pane">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="PaneSpecification-View-G"/>
+            <xs:group ref="PaneSpecification-Mark-G"/>
+            <xs:group ref="PaneSpecification-MarkSizing-G"/>
+            <xs:element minOccurs="0" name="add-in" type="Extension-CT"/>
+            <xs:element minOccurs="0" name="encodings">
+              <xs:complexType>
+                <xs:group ref="PaneSpecification-MarkEncodings-G"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:group ref="PaneSpecification-HiddenFields-G"/>
+            <xs:group ref="PaneSpecification-DropLine-G"/>
+            <xs:group ref="PaneSpecification-Trendline-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="ReferenceLine-G"/>
+            <xs:group minOccurs="0" ref="PaneSpecification-CustomTooltip-G"/>
+            <xs:group minOccurs="0" ref="PaneSpecification-CustomLabel-G"/>
+            <xs:group minOccurs="0" ref="Stylesheet-G"/>
+          </xs:sequence>
+          <xs:attribute name="decimalplaces" type="xs:integer"/>
+          <xs:attribute name="id" type="xs:integer"/>
+          <xs:attribute name="title" type="xs:string"/>
+          <xs:attribute name="generated-title" type="xs:string"/>
+          <xs:attribute name="ignore-extent" type="xs:boolean"/>
+          <xs:attribute name="inert" type="xs:boolean"/>
+          <xs:attribute name="hidden" type="xs:boolean"/>
+          <xs:attribute name="x-axis-name" type="QualifiedName-ST"/>
+          <xs:attribute name="x-index" type="xs:integer"/>
+          <xs:attribute name="y-axis-name" type="QualifiedName-ST"/>
+          <xs:attribute name="y-index" type="xs:integer"/>
+          <xs:attribute name="selection-relaxation-option" type="SelectionRelaxationOption-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ReferenceLine-G">
+    <xs:sequence>
+      <xs:element name="reference-line">
+        <xs:complexType>
+          <xs:sequence minOccurs="0">
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="reference-line-value">
+              <xs:complexType>
+                <xs:attribute name="percentile" type="Float-ST"/>
+                <xs:attribute name="factor" type="Float-ST"/>
+                <xs:attribute name="percentage" type="Float-ST"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="id" type="xs:string" use="required"/>
+          <xs:attribute name="axis-column" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="value-column" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="scope" type="ReferenceLineScopeType-ST" use="required"/>
+          <xs:attribute name="label-type" type="ReferenceLineLabelType-ST" use="required"/>
+          <xs:attribute name="z-order" type="xs:integer" use="required"/>
+          <xs:attribute name="boxplot-whisker-type" type="ReferenceLineBoxplotWhiskerType-ST"/>
+          <xs:attribute name="boxplot-mark-exclusion" type="xs:boolean"/>
+          <xs:attribute name="reference-parameter" type="QualifiedName-ST"/>
+          <xs:attribute name="paired-id" type="xs:string"/>
+          <xs:attribute name="paired-distribution-id" type="xs:string"/>
+          <xs:attribute name="symmetric" type="xs:boolean"/>
+          <xs:attribute name="fill-above" type="xs:boolean"/>
+          <xs:attribute name="fill-below" type="xs:boolean"/>
+          <xs:attribute name="label" type="xs:string"/>
+          <xs:attribute name="formula" type="ReferenceLineFormulaType-ST" use="required"/>
+          <xs:attribute name="tooltip-type" type="ReferenceLineTooltipType-ST"/>
+          <xs:attribute name="tooltip" type="xs:string"/>
+          <xs:attribute name="value" type="DataValue-ST"/>
+          <xs:attribute name="probability" type="Float-ST"/>
+          <xs:attribute name="tile-count" type="xs:integer"/>
+          <xs:attribute name="type" type="ReferenceLineStDevType-ST"/>
+          <xs:attribute name="show-lines" type="ReferenceLineShowLines-ST"/>
+          <xs:attribute name="percentage-bands" type="xs:boolean"/>
+          <xs:attribute name="enable-instant-analytics" type="xs:boolean" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-View-G">
+    <xs:sequence>
+      <xs:element name="view">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="breakdown">
+              <xs:complexType>
+                <xs:attribute name="value" type="StackingMode-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-Mark-G">
+    <xs:sequence>
+      <xs:element name="mark">
+        <xs:complexType>
+          <xs:attribute name="class" type="PrimitiveType-ST" use="required"/>
+          <xs:attribute name="orientation" type="PaneSpecification-MarkOrientation-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="PaneSpecification-MarkOrientation-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="x"/>
+      <xs:enumeration value="y"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="PaneSpecification-MarkEncoding-CT">
+    <xs:attribute name="column" type="QualifiedName-ST"/>
+    <xs:attribute name="separate-domains" type="xs:boolean"/>
+    <xs:attribute name="encoding-id" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="PaneSpecification-CustomMarkEncoding-CT">
+    <xs:complexContent>
+      <xs:extension base="PaneSpecification-MarkEncoding-CT">
+        <xs:attribute name="custom-type-name" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:group name="PaneSpecification-MarkEncodings-G">
+    <xs:sequence>
+      <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="color" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="size" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="text" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="shape" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="wedge-size" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="lod" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="geometry" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="image" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="tooltip" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="path" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="level" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="edge" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="custom" type="PaneSpecification-CustomMarkEncoding-CT"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-MarkSizing-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="mark-sizing">
+        <xs:complexType>
+          <xs:attribute name="mark-sizing-setting" type="MarkSizingSetting-ST" use="required"/>
+          <xs:attribute name="use-custom-mark-size" type="xs:boolean"/>
+          <xs:attribute name="mark-alignment" type="MarkAlignment-ST"/>
+          <xs:attribute name="custom-mark-size-in-axis-units" type="DataValue-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-HiddenFields-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="label-data">
+        <xs:complexType>
+          <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-DropLine-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="dropline">
+        <xs:complexType>
+          <xs:attribute name="x-axis" type="xs:boolean" use="required"/>
+          <xs:attribute name="y-axis" type="xs:boolean" use="required"/>
+          <xs:attribute name="drop-when" type="DropWhen-ST" use="required"/>
+          <xs:attribute name="haslabel" type="xs:boolean" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-Trendline-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="trendline">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="excluded-factors">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" name="column" type="QualifiedName-ST"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+          <xs:attribute name="fit" type="TrendLineFitType-ST" use="required"/>
+          <xs:attribute name="exclude-intercept" type="xs:boolean" use="required"/>
+          <xs:attribute name="enable-confidence-bands" type="xs:boolean" use="required"/>
+          <xs:attribute name="exclude-color" type="xs:boolean" use="required"/>
+          <xs:attribute name="enable-instant-analytics" type="xs:boolean"/>
+          <xs:attribute name="enable-tooltips" type="xs:boolean"/>
+          <xs:attribute name="degree" type="xs:integer"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-CustomTooltip-G">
+    <xs:sequence>
+      <xs:element name="customized-tooltip">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="FormattedText-G"/>
+          </xs:sequence>
+          <xs:attribute name="show-buttons" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-CustomLabel-G">
+    <xs:sequence>
+      <xs:element name="customized-label">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="FormattedText-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-VisualSpecification-G">
+    <xs:sequence>
+      <xs:element name="table">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="view">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="Workbook-DataSources-G"/>
+                  <xs:group minOccurs="0" ref="Workbook-MapSources-G"/>
+                  <xs:group ref="DataSourceDependencies-G"/>
+                  <xs:group ref="Workbook-ViewSpecification-G"/>
+                  <xs:element minOccurs="0" name="slices" type="Workbook-Fields-CT"/>
+                  <xs:element name="aggregation">
+                    <xs:complexType>
+                      <xs:attribute name="value" type="xs:boolean"/>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element minOccurs="0" name="calcs-on-densified-marks">
+                    <xs:complexType>
+                      <xs:attribute name="value" type="xs:boolean"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:group ref="Workbook-Stylesheet-G"/>
+            <xs:element name="panes">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group maxOccurs="unbounded" minOccurs="0" ref="PaneSpecification-G"/>
+                </xs:sequence>
+                <xs:attribute name="customization-axis" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:group ref="Workbook-MarkLayout-G"/>
+            <xs:element name="rows">
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="include-empty" type="xs:boolean"/>
+                    <xs:attribute name="total" type="xs:boolean"/>
+                    <xs:attribute name="onTop" type="xs:boolean"/>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="cols">
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="include-empty" type="xs:boolean"/>
+                    <xs:attribute name="total" type="xs:boolean"/>
+                    <xs:attribute name="onLeft" type="xs:boolean"/>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="table-calc-densification">
+              <xs:complexType>
+                <xs:attribute fixed="false" name="enabled" type="xs:boolean"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="pages">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" name="column" type="QualifiedName-ST"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="join-lod-include-overrides" type="Workbook-Fields-CT"/>
+            <xs:element minOccurs="0" name="join-lod-exclude-overrides" type="Workbook-Fields-CT"/>
+            <xs:element minOccurs="0" name="subtotals">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" name="column" type="QualifiedName-ST"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="table-calculations">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="partitionable-measures">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element maxOccurs="unbounded" name="column" type="QualifiedName-ST"/>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="show-full-range">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" name="column" type="QualifiedName-ST"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="extend-time-series">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" name="extended-column">
+                    <xs:complexType>
+                      <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+                      <xs:attribute name="num-periods" type="xs:int" use="required"/>
+                      <xs:attribute name="period-type" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="consider-zeros-empty">
+              <xs:complexType>
+                <xs:attribute name="value" type="xs:boolean" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="percentages">
+              <xs:complexType>
+                <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+                <xs:attribute name="mode" type="PercentMode-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="mark-labels">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" name="mark-label">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:group ref="TupleReference-G"/>
+                        <xs:element minOccurs="0" name="label-position" type="BoxCoordinate-CT"/>
+                      </xs:sequence>
+                      <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                      <xs:attribute name="label-state" type="Workbook-OnOff-ST"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="annotations">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group maxOccurs="unbounded" ref="AnnotationSpecification-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:group ref="Workbook-PageTrailOptions-G"/>
+            <xs:element minOccurs="0" name="trail-overrides">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="trail-override">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:group ref="TupleReference-G"/>
+                      </xs:sequence>
+                      <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                      <xs:attribute name="state" type="Workbook-OnOff-ST" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="tooltip-style">
+              <xs:complexType>
+                <xs:attribute name="tooltip-mode" type="TooltipMode-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:group ref="Workbook-ForecastSpecification-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DashboardSizingMode-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="unspecified"/>
+      <xs:enumeration value="automatic"/>
+      <xs:enumeration value="fixed"/>
+      <xs:enumeration value="range"/>
+      <xs:enumeration value="vscroll"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="VizLayoutOptions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="layout-options">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="title">
+              <xs:complexType>
+                <xs:group ref="FormattedText-G"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="caption">
+              <xs:complexType>
+                <xs:group ref="FormattedText-G"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="alt-text">
+              <xs:complexType>
+                <xs:group ref="FormattedText-G"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="filter-alt-text">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="0" maxOccurs="unbounded" name="filter">
+                    <xs:complexType>
+                      <xs:attribute name="field" type="xs:string" use="required"/>
+                      <xs:attribute name="alt-text" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attributeGroup ref="VizLayoutOptions-Attributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="VizLayoutOptions-Attributes-AG">
+    <xs:attribute name="export-no-title" type="xs:boolean"/>
+    <xs:attribute name="export-no-caption" type="xs:boolean"/>
+    <xs:attribute name="export-all-view-pages" type="xs:boolean"/>
+    <xs:attribute name="export-margin-left" type="Float-ST"/>
+    <xs:attribute name="export-margin-right" type="Float-ST"/>
+    <xs:attribute name="export-margin-top" type="Float-ST"/>
+    <xs:attribute name="export-margin-bottom" type="Float-ST"/>
+    <xs:attribute name="export-per-page-headers" type="xs:boolean"/>
+    <xs:attribute name="export-smart-breaks" type="xs:boolean"/>
+    <xs:attribute name="export-scale-mode-auto" type="xs:boolean"/>
+    <xs:attribute name="export-scale-fitpage" type="xs:boolean"/>
+    <xs:attribute name="export-scale-percent" type="xs:int"/>
+    <xs:attribute name="export-pages-across" type="xs:int"/>
+    <xs:attribute name="export-pages-down" type="xs:int"/>
+    <xs:attribute name="export-center-horz" type="xs:boolean"/>
+    <xs:attribute name="export-center-vert" type="xs:boolean"/>
+    <xs:attribute name="export-visual" type="xs:boolean"/>
+    <xs:attribute name="export-color-legend" type="xs:boolean"/>
+    <xs:attribute name="export-shape-legend" type="xs:boolean"/>
+    <xs:attribute name="export-size-legend" type="xs:boolean"/>
+    <xs:attribute name="export-map-legend" type="xs:boolean"/>
+    <xs:attribute name="export-orientation" type="PageOrientation-ST"/>
+    <xs:attribute name="export-legend-location" type="LegendLayoutLocation-ST"/>
+    <xs:attribute name="export-legend-direction" type="LegendLayoutDirection-ST"/>
+    <xs:attribute name="tooltip-mark-announcement" type="xs:boolean"/>
+  </xs:attributeGroup>
+  <xs:simpleType name="EdgeLocation-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="right"/>
+      <xs:enumeration value="top"/>
+      <xs:enumeration value="bottom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Cards-G">
+    <xs:sequence>
+      <xs:element name="cards">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" minOccurs="0" ref="Edge-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Edge-G">
+    <xs:sequence>
+      <xs:element name="edge">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Strip-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="EdgeLocation-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Strip-G">
+    <xs:sequence>
+      <xs:element name="strip">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Card-G"/>
+          </xs:sequence>
+          <xs:attribute name="size" type="xs:int" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Card-G">
+    <xs:sequence>
+      <xs:element name="card">
+        <xs:complexType>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Button-Format-CT">
+    <xs:attribute name="attr" type="StyleAttribute-ST" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:attributeGroup name="ButtonZone-ButtonCaptionFontStyleAttributes-AG">
+    <xs:attribute name="fontname" type="xs:string"/>
+    <xs:attribute name="fontcolor" type="xs:string"/>
+    <xs:attribute name="fontsize" type="xs:int"/>
+    <xs:attribute name="bold" type="xs:boolean"/>
+    <xs:attribute name="italic" type="xs:boolean"/>
+    <xs:attribute name="underline" type="xs:boolean"/>
+  </xs:attributeGroup>
+  <xs:complexType name="Button-Caption-Font-Style-CT">
+    <xs:attributeGroup ref="ButtonZone-ButtonCaptionFontStyleAttributes-AG"/>
+  </xs:complexType>
+  <xs:complexType name="Button-Visual-State-CT">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="caption" type="xs:string"/>
+      <xs:element minOccurs="0" name="image-path" type="xs:string"/>
+      <xs:element minOccurs="0" name="tooltip-text" type="xs:string"/>
+      <xs:element minOccurs="0" name="button-caption-font-style" type="Button-Caption-Font-Style-CT"/>
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="format" type="Button-Format-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Button-CT">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="toggle-action" type="xs:string"/>
+      <xs:element minOccurs="0" name="export-button-action" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" name="button-visual-state" type="Button-Visual-State-CT"/>
+    </xs:sequence>
+    <xs:attribute name="action" type="xs:string" use="required"/>
+    <xs:attribute name="button-type" type="xs:string"/>
+    <xs:attribute name="active-visual-state-index" type="xs:string"/>
+    <xs:attribute name="button-click-action-metadata" type="xs:string"/>
+  </xs:complexType>
+  <xs:simpleType name="AnchorPoint-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="begin"/>
+      <xs:enumeration value="end"/>
+      <xs:enumeration value="size"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AnchorType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="relative"/>
+      <xs:enumeration value="fixed"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="FlexibleLayoutRoot-AnchoringRule-CT">
+    <xs:attribute name="anchor-point" type="AnchorPoint-ST" use="required"/>
+    <xs:attribute name="anchor-type" type="AnchorType-ST" use="required"/>
+    <xs:attribute name="value" type="xs:float" use="required"/>
+    <xs:attribute name="user-provided" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="FlexibleLayoutRoot-DimensionAnchoringRules-CT">
+    <xs:sequence>
+      <xs:element name="first-rule" type="FlexibleLayoutRoot-AnchoringRule-CT"/>
+      <xs:element name="second-rule" type="FlexibleLayoutRoot-AnchoringRule-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="FlexibleLayoutRoot-AnchoringProperties-G">
+    <xs:sequence>
+      <xs:element name="anchoring-properties">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="horizontal-rules" type="FlexibleLayoutRoot-DimensionAnchoringRules-CT"/>
+            <xs:element name="vertical-rules" type="FlexibleLayoutRoot-DimensionAnchoringRules-CT"/>
+          </xs:sequence>
+          <xs:attribute name="zone-id" type="xs:unsignedInt" use="required"/>
+          <xs:attribute name="anchored-to-zoneid" type="xs:unsignedInt" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="FlexibleLayoutRoot-G">
+    <xs:sequence>
+      <xs:element name="anchored-zones">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="FlexibleLayoutRoot-AnchoringProperties-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortDelta-G">
+    <xs:sequence>
+      <xs:element name="shelf-sort-delta">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:choice>
+              <xs:group ref="ShelfSortDelta-ClearShelfSort-G"/>
+              <xs:group ref="ShelfSort-G"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="shelf" type="ShelfSortDelta-ShelfType-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortDeltas-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="shelf-sort-deltas">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="ShelfSortLists-G"/>
+            <xs:group minOccurs="0" ref="ShelfSortDelta-ClearShelfSorts-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortDelta-ClearShelfSort-G">
+    <xs:sequence>
+      <xs:element name="clear-shelf-sort"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortDelta-ClearShelfSorts-G">
+    <xs:sequence>
+      <xs:element name="clear-shelf-sorts">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="ShelfSortDelta-ClearShelfSort-V2-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortDelta-ClearShelfSort-V2-G">
+    <xs:sequence>
+      <xs:element name="clear-shelf-sort-v2">
+        <xs:complexType>
+          <xs:attribute name="dimension" type="QualifiedName-ST"/>
+          <xs:attribute name="is-on-innermost-dimension" type="xs:boolean"/>
+          <xs:attribute name="shelf" type="ShelfSortDelta-ShelfType-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ShelfSortDelta-ShelfType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="columns"/>
+      <xs:enumeration value="rows"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Flipboard-FlipboardNavType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="caption"/>
+      <xs:enumeration value="number"/>
+      <xs:enumeration value="dot"/>
+      <xs:enumeration value="arrowonly"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="WorksheetDeltas-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Flipboard-DatasourceDependencies-G"/>
+      <xs:element minOccurs="0" name="columns" type="Flipboard-TableColumns-CT"/>
+      <xs:element minOccurs="0" name="rows" type="Flipboard-TableColumns-CT"/>
+      <xs:group minOccurs="0" ref="Flipboard-FilterSettings-G"/>
+      <xs:group minOccurs="0" ref="Flipboard-Sorting-G"/>
+      <xs:group minOccurs="0" ref="Flipboard-Annotations-G"/>
+      <xs:group minOccurs="0" ref="Flipboard-Stylesheet-G"/>
+      <xs:group minOccurs="0" ref="ShelfSortDeltas-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="OneDelta-G">
+    <xs:sequence>
+      <xs:sequence maxOccurs="unbounded" minOccurs="0">
+        <xs:element minOccurs="0" name="worksheet">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:group minOccurs="0" ref="WorksheetDeltas-G"/>
+              <xs:group minOccurs="0" ref="Flipboard-VizDeltas-G"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element minOccurs="0" name="dashboard">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:group ref="Flipboard-DashboardDeltas-G"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:element minOccurs="0" name="datasource">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Flipboard-ParameterDeltas-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Deltas-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="currentDeltas">
+        <xs:complexType>
+          <xs:group ref="OneDelta-G"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element minOccurs="0" name="capturedDeltas">
+        <xs:complexType>
+          <xs:group ref="OneDelta-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StoryPoint-G">
+    <xs:sequence>
+      <xs:element name="story-point">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="Deltas-G"/>
+          </xs:sequence>
+          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+          <xs:attribute name="captured-sheet" type="xs:string" use="required"/>
+          <xs:attribute name="current-sheet" type="xs:string"/>
+          <xs:attribute name="caption" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="FlipboardDoc-G">
+    <xs:sequence>
+      <xs:element name="flipboard">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="story-points">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group maxOccurs="unbounded" minOccurs="0" ref="StoryPoint-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="active-id" type="xs:unsignedInt"/>
+          <xs:attribute name="nav-type" type="Flipboard-FlipboardNavType-ST"/>
+          <xs:attribute name="show-nav-arrows" type="xs:boolean" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Flipboard-TableColumns-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+        <xs:complexType>
+          <xs:attribute name="field" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="delta-type" type="StoryDelta-ST" use="required"/>
+          <xs:attribute name="index" type="xs:unsignedInt"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="Flipboard-DatasourceDependencies-G">
+    <xs:sequence>
+      <xs:element name="datasource-dependencies">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Column-G"/>
+            <xs:group maxOccurs="unbounded" ref="ColumnInstance-G"/>
+          </xs:sequence>
+          <xs:attribute name="datasource" type="RootValue-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-FilterSettings-G">
+    <xs:sequence>
+      <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="filter">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+            </xs:sequence>
+            <xs:anyAttribute processContents="skip"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-Sorting-G">
+    <xs:sequence>
+      <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:group ref="ClearSort-G"/>
+        <xs:group ref="Sort-G"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-Annotations-G">
+    <xs:sequence>
+      <xs:element name="annotations">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="annotation">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:any maxOccurs="unbounded" minOccurs="0" namespace="##local" processContents="skip"/>
+                </xs:sequence>
+                <xs:anyAttribute namespace="##local" processContents="skip"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-Stylesheet-G">
+    <xs:sequence>
+      <xs:group maxOccurs="2" minOccurs="0" ref="Stylesheet-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-ShelfSortDelta-G">
+    <xs:sequence>
+      <xs:group maxOccurs="2" minOccurs="0" ref="ShelfSortDelta-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Flipboard-FilterKind-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="hide"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Flipboard-VizDeltas-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="current-page">
+        <xs:complexType>
+          <xs:group ref="MultiBucket-Only-G"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:group minOccurs="0" ref="SelectionCollection-G"/>
+      <xs:group minOccurs="0" ref="HighlightSpecification-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-DashboardDeltas-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="zone">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="FormattedText-G"/>
+          </xs:sequence>
+          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-ParameterDeltas-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+        <xs:complexType>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="value" type="DataValue-ST" use="required"/>
+          <xs:attribute name="alias" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GroupLayout-GroupChildProperties-G">
+    <xs:sequence>
+      <xs:element name="group-child-properties">
+        <xs:complexType>
+          <xs:attribute name="child-id" type="xs:unsignedInt" use="required"/>
+          <xs:attribute name="left" type="xs:float" use="required"/>
+          <xs:attribute name="right" type="xs:float" use="required"/>
+          <xs:attribute name="top" type="xs:float" use="required"/>
+          <xs:attribute name="bottom" type="xs:float" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GroupLayout-G">
+    <xs:sequence>
+      <xs:element name="group-layout">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="GroupLayout-GroupChildProperties-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GridLayout-Proportions-G">
+    <xs:sequence>
+      <xs:element name="proportions">
+        <xs:complexType>
+          <xs:attribute name="left" type="xs:float" use="required"/>
+          <xs:attribute name="right" type="xs:float" use="required"/>
+          <xs:attribute name="top" type="xs:float" use="required"/>
+          <xs:attribute name="bottom" type="xs:float" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GridLayout-GridChild-G">
+    <xs:sequence>
+      <xs:element name="grid-child">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="GridLayout-Proportions-G"/>
+            <xs:group ref="Zone-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GridLayout-G">
+    <xs:sequence>
+      <xs:element name="grid-layout">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="GridLayout-GridChild-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StackLayout-Automatic-G">
+    <xs:sequence>
+      <xs:element name="automatic">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:maxLength value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StackLayout-FixedSize-G">
+    <xs:sequence>
+      <xs:element name="fixed-size">
+        <xs:complexType>
+          <xs:attribute name="value" type="xs:unsignedInt" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StackLayout-ProportionalRatio-G">
+    <xs:sequence>
+      <xs:element name="proportional-ratio">
+        <xs:complexType>
+          <xs:attribute name="value" type="Float-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StackLayout-ResizingProperties-G">
+    <xs:choice>
+      <xs:group ref="StackLayout-Automatic-G"/>
+      <xs:group ref="StackLayout-FixedSize-G"/>
+      <xs:group ref="StackLayout-ProportionalRatio-G"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="StackLayout-StackChild-G">
+    <xs:sequence>
+      <xs:element name="stack-child">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="StackLayout-ResizingProperties-G"/>
+            <xs:group ref="Zone-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StackLayout-Direction-G">
+    <xs:sequence>
+      <xs:element name="direction">
+        <xs:complexType>
+          <xs:attribute name="value" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="horizontal"/>
+                <xs:enumeration value="vertical"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StackLayout-G">
+    <xs:sequence>
+      <xs:element name="stack-layout">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="StackLayout-Direction-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="StackLayout-StackChild-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ZoneLayoutType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="basic"/>
+      <xs:enumeration value="free-form"/>
+      <xs:enumeration value="flow"/>
+      <xs:enumeration value="distribute-evenly"/>
+      <xs:enumeration value="trivial"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ZoneType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="invalid"/>
+      <xs:enumeration value="visual"/>
+      <xs:enumeration value="color"/>
+      <xs:enumeration value="shape"/>
+      <xs:enumeration value="size"/>
+      <xs:enumeration value="map"/>
+      <xs:enumeration value="highlighter"/>
+      <xs:enumeration value="filter"/>
+      <xs:enumeration value="currpage"/>
+      <xs:enumeration value="empty"/>
+      <xs:enumeration value="title"/>
+      <xs:enumeration value="text"/>
+      <xs:enumeration value="bitmap"/>
+      <xs:enumeration value="web"/>
+      <xs:enumeration value="add-in"/>
+      <xs:enumeration value="dashboard-object"/>
+      <xs:enumeration value="paramctrl"/>
+      <xs:enumeration value="flipboard"/>
+      <xs:enumeration value="flipboard-nav"/>
+      <xs:enumeration value="layout-basic"/>
+      <xs:enumeration value="layout-flow"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Zone-G">
+    <xs:sequence>
+      <xs:element name="zone">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="FormattedText-G"/>
+            <xs:group ref="Zone-LayoutCache-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Zone-G"/>
+            <xs:group minOccurs="0" ref="FlipboardDoc-G"/>
+            <xs:choice>
+              <xs:element minOccurs="0" name="button" type="Button-CT"/>
+              <xs:element minOccurs="0" name="add-in" type="Extension-CT"/>
+            </xs:choice>
+            <xs:group ref="Zone-ZoneStyle-G"/>
+          </xs:sequence>
+          <xs:attribute name="x" type="xs:int" use="required"/>
+          <xs:attribute name="y" type="xs:int" use="required"/>
+          <xs:attribute name="w" type="xs:int" use="required"/>
+          <xs:attribute name="h" type="xs:int" use="required"/>
+          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+          <xs:attribute name="story-point-id" type="xs:unsignedInt"/>
+          <xs:attribute name="flipboard-zone-id" type="xs:unsignedInt"/>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="type-v2" type="xs:string"/>
+          <xs:attribute name="layout-strategy-id" type="ZoneLayoutType-ST"/>
+          <xs:attribute name="param">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:minLength value="1"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="hidden" type="xs:boolean"/>
+          <xs:attribute name="hidden-by-user" type="xs:boolean"/>
+          <xs:attribute name="is-fixed" type="xs:boolean"/>
+          <xs:attribute name="fixed-size" type="xs:int"/>
+          <xs:attribute name="alt-text" type="xs:string"/>
+          <xs:attribute name="friendly-name" type="xs:string"/>
+          <xs:attribute name="url" type="xs:string"/>
+          <xs:attribute name="tip" type="xs:string"/>
+          <xs:attribute name="scroll" type="xs:string"/>
+          <xs:attribute name="error-action" type="xs:string"/>
+          <xs:attribute name="error-text" type="xs:string"/>
+          <xs:attribute name="error-url" type="xs:string"/>
+          <xs:attribute name="show-title" type="xs:boolean"/>
+          <xs:attribute name="show-caption" type="xs:boolean"/>
+          <xs:attribute name="show-context-menu" type="xs:boolean"/>
+          <xs:attribute name="suppress-dialogs" type="xs:boolean"/>
+          <xs:attribute name="removable" type="xs:boolean"/>
+          <xs:attribute name="is-centered" type="xs:string"/>
+          <xs:attribute name="is-scaled" type="xs:string"/>
+          <xs:attribute name="image-file-url" type="xs:string"/>
+          <xs:attribute name="paired-zone-id" type="xs:unsignedInt"/>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Zone-ZoneStyle-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="zone-style">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="format">
+              <xs:complexType>
+                <xs:attribute name="attr" type="StyleAttribute-ST" use="required"/>
+                <xs:attribute name="value" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Zone-LayoutCache-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="layout-cache">
+        <xs:complexType>
+          <xs:attribute name="type-w" type="DashboardLayoutType-ST" use="required"/>
+          <xs:attribute name="fixed-size-w" type="xs:int"/>
+          <xs:attribute name="cell-count-w" type="xs:int"/>
+          <xs:attribute name="non-cell-size-w" type="xs:int"/>
+          <xs:attribute name="has-max-size-w" type="xs:boolean"/>
+          <xs:attribute name="maxwidth" type="xs:int"/>
+          <xs:attribute name="minwidth" type="xs:int"/>
+          <xs:attribute name="type-h" type="DashboardLayoutType-ST" use="required"/>
+          <xs:attribute name="fixed-size-h" type="xs:int"/>
+          <xs:attribute name="cell-count-h" type="xs:int"/>
+          <xs:attribute name="non-cell-size-h" type="xs:int"/>
+          <xs:attribute name="has-max-size-h" type="xs:boolean"/>
+          <xs:attribute name="maxheight" type="xs:int"/>
+          <xs:attribute name="minheight" type="xs:int"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DashboardLayoutType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="fixed"/>
+      <xs:enumeration value="cell"/>
+      <xs:enumeration value="scalable"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DashboardDoc-G">
+    <xs:sequence>
+      <xs:element name="dashboard">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Dashboard-VizLayoutOptionsOrRepositoryLocation-G"/>
+            <xs:group minOccurs="0" ref="Stylesheet-G"/>
+            <xs:group ref="Dashboard-DashboardSizeOptions-G"/>
+            <xs:group ref="DataSourcesAndDependencies-G"/>
+            <xs:group ref="ZoneCollection-G"/>
+            <xs:group minOccurs="0" ref="DeviceLayouts-G"/>
+            <xs:group ref="SimpleIdentifierForThisDashboard-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="lock-updates" type="xs:boolean"/>
+          <xs:attribute name="lock-quick-filters" type="xs:boolean"/>
+          <xs:attribute name="type" type="Dashboard-DashboardType-ST"/>
+          <xs:attribute name="enable-sort-zone-taborder" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="FormattedNameForDeviceLayout-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Desktop"/>
+      <xs:enumeration value="Phone"/>
+      <xs:enumeration value="Tablet"/>
+      <xs:enumeration value="default"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DeviceLayouts-G">
+    <xs:sequence>
+      <xs:element name="devicelayouts">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="devicelayout" type="Dashboard-DeviceLayout-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ZoneCollection-G">
+    <xs:sequence>
+      <xs:element name="zones">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Zone-G"/>
+          </xs:sequence>
+          <xs:attribute name="is-pixels" type="xs:boolean"/>
+          <xs:attribute name="use-insets" type="xs:boolean"/>
+        </xs:complexType>
+        <xs:unique name="DemandZoneIdUnique">
+          <xs:selector xpath="zone"/>
+          <xs:field xpath="@id"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Dashboard-DashboardType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="storyboard"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Dashboard-DeviceLayout-CT">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="VizLayoutOptions-G"/>
+      <xs:group minOccurs="0" ref="Dashboard-DashboardSizeOptions-G"/>
+      <xs:group minOccurs="0" ref="ZoneCollection-G"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="FormattedNameForDeviceLayout-ST" use="required"/>
+    <xs:attribute name="active" type="xs:boolean"/>
+    <xs:attribute name="auto-generated" type="xs:boolean"/>
+  </xs:complexType>
+  <xs:group name="Dashboard-DashboardSizeOptions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="size">
+        <xs:complexType>
+          <xs:attribute name="fit-to-story" type="xs:string"/>
+          <xs:attribute name="minwidth" type="xs:int"/>
+          <xs:attribute name="minheight" type="xs:int"/>
+          <xs:attribute name="maxwidth" type="xs:int"/>
+          <xs:attribute name="maxheight" type="xs:int"/>
+          <xs:attribute name="preset-index" type="xs:unsignedInt"/>
+          <xs:attribute name="sizing-mode" type="DashboardSizingMode-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SimpleIdentifierForThisDashboard-G">
+    <xs:sequence>
+      <xs:group minOccurs="1" ref="SimpleIdentifier-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Dashboard-VizLayoutOptionsOrRepositoryLocation-G">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="2">
+        <xs:group ref="VizLayoutOptions-G"/>
+        <xs:group ref="RepositoryLocation-G"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="GridOverlayMode-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="automatic"/>
+      <xs:enumeration value="on"/>
+      <xs:enumeration value="off"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DefaultMapToolSelection-G">
+    <xs:sequence>
+      <xs:element name="default-map-tool-selection">
+        <xs:complexType>
+          <xs:attribute name="tool" type="DefaultMapToolSelection-DMT-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DefaultMapToolSelection-DMT-ST">
+    <xs:restriction base="xs:int">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+      <xs:enumeration value="4"/>
+      <xs:enumeration value="8"/>
+      <xs:enumeration value="16"/>
+      <xs:enumeration value="32"/>
+      <xs:enumeration value="12"/>
+      <xs:enumeration value="29"/>
+      <xs:enumeration value="30"/>
+      <xs:enumeration value="31"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DefaultMapUnitSelection-G">
+    <xs:sequence>
+      <xs:element name="default-map-unit-selection">
+        <xs:complexType>
+          <xs:attribute name="mapunit" type="DefaultMapUnitSelection-MUS-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DefaultMapUnitSelection-MUS-ST">
+    <xs:restriction base="xs:int">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="FloatingToolbarVisibility-G">
+    <xs:sequence>
+      <xs:element name="floating-toolbar-visibility">
+        <xs:complexType>
+          <xs:attribute name="value" type="FloatingToolbarVisibility-FTV-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="FloatingToolbarVisibility-FTV-ST">
+    <xs:restriction base="xs:int">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="GeoSearchVisibility-G">
+    <xs:sequence>
+      <xs:element name="geo-search-visibility">
+        <xs:complexType>
+          <xs:attribute name="value" type="GeoSearchVisibility-GSV-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="GeoSearchVisibility-GSV-ST">
+    <xs:restriction base="xs:integer">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="GlobalFieldNames-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="((\[([^\]]|\]\])*\](\.\[([^\]]|\]\])*\])*)?\n)*(\[([^\]]|\]\])*\](\.\[([^\]]|\]\])*\])*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EncodingType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="color"/>
+      <xs:enumeration value="size"/>
+      <xs:enumeration value="shape"/>
+      <xs:enumeration value="highlight"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="HighlightSpecification-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="highlight">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="HighlightSpecification-ColorOneWay-G"/>
+            <xs:element minOccurs="0" name="bucket-selection">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group maxOccurs="unbounded" minOccurs="0" ref="MultiBucket-Or-Bucket-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="color-one-way" type="xs:boolean"/>
+          <xs:attribute name="type" type="EncodingType-ST"/>
+          <xs:attribute name="field" type="GlobalFieldNames-ST"/>
+          <xs:attribute name="pattern" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="HighlightSpecification-ColorOneWay-G">
+    <xs:sequence>
+      <xs:element name="color-one-way">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="field" type="QualifiedName-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="LayerControl-G">
+    <xs:sequence>
+      <xs:element name="layer-control">
+        <xs:complexType>
+          <xs:attribute name="toolbar-button-enabled" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="NAV-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="MapNavigation-G">
+    <xs:sequence>
+      <xs:element name="map-navigation">
+        <xs:complexType>
+          <xs:attribute name="value" type="NAV-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapScaleVisibility-G">
+    <xs:sequence>
+      <xs:element name="map-scale-visibility">
+        <xs:complexType>
+          <xs:attribute name="value" type="MapScaleVisibility-GSV-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="MapScaleVisibility-GSV-ST">
+    <xs:restriction base="xs:integer">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ShelfType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="columns"/>
+      <xs:enumeration value="rows"/>
+      <xs:enumeration value="pages"/>
+      <xs:enumeration value="filter"/>
+      <xs:enumeration value="image"/>
+      <xs:enumeration value="measures"/>
+      <xs:enumeration value="showme"/>
+      <xs:enumeration value="geometry"/>
+      <xs:enumeration value="encoding"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="OrientedNodeReference-G">
+    <xs:sequence>
+      <xs:element name="oriented-node-reference">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="NodeReference-G"/>
+            <xs:group ref="PageReference-G"/>
+          </xs:sequence>
+          <xs:attribute name="orientation" type="Selection-Orientation-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="NodeSelection-G">
+    <xs:sequence>
+      <xs:element name="node-selection">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="OrientedNodeReference-G"/>
+          </xs:sequence>
+          <xs:attribute name="select-tuples" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="TupleSelection-G">
+    <xs:sequence>
+      <xs:element name="tuple-selection">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="TupleReference-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="FieldSelection-G">
+    <xs:sequence>
+      <xs:element name="field-selection">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="field-reference" type="Selection-FieldReference-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="BucketSelection-G">
+    <xs:sequence>
+      <xs:element name="bucket-selection">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="MultiBucket-Only-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ReferenceLineSelection-G">
+    <xs:sequence>
+      <xs:element name="reference-line-selection">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="reference-line" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="TrendLineSelection-G">
+    <xs:sequence>
+      <xs:element name="trendline-selection">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="trendline" type="xs:int"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SelectionCollection-G">
+    <xs:sequence>
+      <xs:element name="selection-collection">
+        <xs:complexType>
+          <xs:choice maxOccurs="unbounded" minOccurs="0">
+            <xs:group ref="NodeSelection-G"/>
+            <xs:group ref="TupleSelection-G"/>
+            <xs:group ref="FieldSelection-G"/>
+            <xs:group ref="BucketSelection-G"/>
+            <xs:group ref="ReferenceLineSelection-G"/>
+            <xs:group ref="TrendLineSelection-G"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Selection-Orientation-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="horizontal"/>
+      <xs:enumeration value="vertical"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Selection-FieldReference-CT">
+    <xs:simpleContent>
+      <xs:extension base="QualifiedName-ST">
+        <xs:attribute name="position" type="xs:unsignedInt" use="required"/>
+        <xs:attribute name="shelf" type="ShelfType-ST" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:group name="VisualDoc-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="viewpoint">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="VisualDoc-Viewpoint-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="VisualDocs-G">
+    <xs:sequence>
+      <xs:element name="viewpoints">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="VisualDoc-Viewpoints-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="VisualDoc-Viewpoint-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="VisualDoc-CurrentPage-G"/>
+      <xs:group minOccurs="0" ref="VisualDoc-Zoom-G"/>
+      <xs:group minOccurs="0" ref="SelectionCollection-G"/>
+      <xs:group minOccurs="0" ref="HighlightSpecification-G"/>
+      <xs:group minOccurs="0" ref="FloatingToolbarVisibility-G"/>
+      <xs:group minOccurs="0" ref="GeoSearchVisibility-G"/>
+      <xs:group minOccurs="0" ref="MapScaleVisibility-G"/>
+      <xs:group minOccurs="0" ref="DefaultMapToolSelection-G"/>
+      <xs:group minOccurs="0" ref="MapNavigation-G"/>
+      <xs:group minOccurs="0" ref="DefaultMapUnitSelection-G"/>
+      <xs:group minOccurs="0" ref="LayerControl-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="VisualDoc-Viewpoints-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="VisualDoc-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="VisualDoc-ZoomType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="percent"/>
+      <xs:enumeration value="entire-view"/>
+      <xs:enumeration value="fit-width"/>
+      <xs:enumeration value="fit-height"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="VisualDoc-CurrentPage-G">
+    <xs:sequence>
+      <xs:element name="current-page">
+        <xs:complexType>
+          <xs:group ref="MultiBucket-Only-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="VisualDoc-Zoom-G">
+    <xs:sequence>
+      <xs:element name="zoom">
+        <xs:complexType>
+          <xs:attribute name="type" type="VisualDoc-ZoomType-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Window-G">
+    <xs:sequence>
+      <xs:element name="window">
+        <xs:complexType>
+          <xs:group ref="Window-Window-G"/>
+          <xs:attributeGroup ref="Window-WindowAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Bookmark-G">
+    <xs:sequence>
+      <xs:element name="window">
+        <xs:complexType>
+          <xs:group ref="Window-WorksheetWindow-G"/>
+          <xs:attributeGroup ref="Window-WindowBookmarkAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Windows-G">
+    <xs:sequence>
+      <xs:element name="windows">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Window-Windows-G"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="Window-WindowsAttributes-AG"/>
+        </xs:complexType>
+        <xs:unique name="DemandWindowNameUnique">
+          <xs:selector xpath="window"/>
+          <xs:field xpath="@name"/>
+        </xs:unique>
+        <xs:unique name="DemandWindowSimpleIdUnique">
+          <xs:selector xpath="window/simple-id"/>
+          <xs:field xpath="@uuid"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="Window-WindowAttributes-AG">
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="class" type="Window-WindowType-ST"/>
+    <xs:attribute name="hidden" type="xs:boolean"/>
+    <xs:attribute name="maximized" type="xs:boolean"/>
+    <xs:attribute name="tab-color" type="ColorObject-ST"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="Window-WindowBookmarkAttributes-AG">
+    <xs:attribute name="tab-color" type="ColorObject-ST"/>
+  </xs:attributeGroup>
+  <xs:group name="Window-Window-G">
+    <xs:choice>
+      <xs:group ref="Window-WorksheetWindow-G"/>
+      <xs:group ref="Window-DashboardWindow-G"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="Window-WorksheetWindow-G">
+    <xs:sequence>
+      <xs:group ref="Cards-G"/>
+      <xs:group ref="VisualDoc-G"/>
+      <xs:group ref="SimpleIdentifierForThisWindow-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Window-DashboardWindow-G">
+    <xs:sequence>
+      <xs:group ref="VisualDocs-G"/>
+      <xs:element name="active">
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:int"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:group minOccurs="0" ref="Window-DevicePreviewSettings-G"/>
+      <xs:group ref="Window-DashboardGridOptions-G"/>
+      <xs:group ref="SimpleIdentifierForThisWindow-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SimpleIdentifierForThisWindow-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="SimpleIdentifier-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Window-DevicePreviewSettings-G">
+    <xs:sequence>
+      <xs:element name="device-preview">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="device">
+              <xs:complexType>
+                <xs:attribute name="type" type="FormattedNameForDeviceLayout-ST" use="required"/>
+                <xs:attribute name="name" type="xs:string"/>
+                <xs:attribute name="is-portrait" type="xs:boolean"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="visible" type="xs:boolean"/>
+          <xs:attribute name="selected" type="FormattedNameForDeviceLayout-ST"/>
+          <xs:attribute name="mobileapp-chrome-visible" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Window-DashboardGridOptions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="grid">
+        <xs:complexType>
+          <xs:attribute name="grid-overlay-mode" type="GridOverlayMode-ST"/>
+          <xs:attribute name="grid-size" type="xs:int"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Window-WindowType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="worksheet"/>
+      <xs:enumeration value="dashboard"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Window-Windows-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" ref="Window-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="Window-WindowsAttributes-AG">
+    <xs:attribute name="pres-mode" type="xs:boolean"/>
+    <xs:attribute name="film-mode" type="xs:boolean"/>
+    <xs:attribute name="show-side-pane" type="xs:boolean"/>
+    <xs:attribute name="source-height" type="xs:int"/>
+    <xs:attribute name="saved-dpi-scale-factor" type="xs:float"/>
+  </xs:attributeGroup>
+  <xs:simpleType name="PageOrientation-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="auto"/>
+      <xs:enumeration value="portrait"/>
+      <xs:enumeration value="landscape"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="LegendLayoutDirection-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="vertical"/>
+      <xs:enumeration value="horizontal"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="LegendLayoutLocation-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="right"/>
+      <xs:enumeration value="bottom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PercentMode-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="table"/>
+      <xs:enumeration value="column"/>
+      <xs:enumeration value="row"/>
+      <xs:enumeration value="pane"/>
+      <xs:enumeration value="row-in-pane"/>
+      <xs:enumeration value="column-in-pane"/>
+      <xs:enumeration value="cell-in-pane"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PageSizeOption-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="letter"/>
+      <xs:enumeration value="legal"/>
+      <xs:enumeration value="note"/>
+      <xs:enumeration value="folio"/>
+      <xs:enumeration value="tabloid"/>
+      <xs:enumeration value="ledger"/>
+      <xs:enumeration value="statement"/>
+      <xs:enumeration value="executive"/>
+      <xs:enumeration value="a3"/>
+      <xs:enumeration value="a4"/>
+      <xs:enumeration value="a5"/>
+      <xs:enumeration value="b4"/>
+      <xs:enumeration value="b5"/>
+      <xs:enumeration value="quarto"/>
+      <xs:enumeration value="unspecified"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="WorkbookLayoutType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="cartesian"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ForecastRangeType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="auto"/>
+      <xs:enumeration value="next"/>
+      <xs:enumeration value="end-of"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ForecastModelType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="auto-season"/>
+      <xs:enumeration value="auto"/>
+      <xs:enumeration value="custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ForecastComponentType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ets-none"/>
+      <xs:enumeration value="ets-additive"/>
+      <xs:enumeration value="ets-multiplicative"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TooltipMode-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="sticky"/>
+      <xs:enumeration value="smooth"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Workbook-DataSource-G">
+    <xs:sequence>
+      <xs:group ref="DataSourceInlineOrLink-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-DataSources-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="datasources">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Workbook-DataSource-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-MapSources-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="mapsources">
+        <xs:complexType>
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="MapSourceInlineOrLink-G"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-ViewSpecification-G">
+    <xs:sequence>
+      <xs:group ref="ViewSpecification-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Workbook-Fields-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="column" type="QualifiedName-ST"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="Workbook-Stylesheet-G">
+    <xs:sequence>
+      <xs:group ref="Stylesheet-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-MarkLayout-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="mark-layout">
+        <xs:complexType>
+          <xs:attribute name="type" type="WorkbookLayoutType-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-PageTrailOptions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="page-trail-options">
+        <xs:complexType>
+          <xs:attribute name="enabled" type="xs:boolean"/>
+          <xs:attribute name="mark-type" type="Workbook-MarkType-ST"/>
+          <xs:attribute name="marks" type="xs:boolean"/>
+          <xs:attribute name="lines" type="xs:boolean"/>
+          <xs:attribute name="size" type="xs:int"/>
+          <xs:attribute name="trail-effect" type="Workbook-TrailEffect-ST"/>
+          <xs:attribute name="start" type="xs:int"/>
+          <xs:attribute name="end" type="xs:int"/>
+          <xs:attribute name="mark-color" type="ColorObject-ST"/>
+          <xs:attribute name="mark-color-auto" type="xs:boolean"/>
+          <xs:attribute name="line-color" type="ColorObject-ST"/>
+          <xs:attribute name="line-stroke-width" type="xs:float"/>
+          <xs:attribute name="line-pattern" type="Workbook-LinePattern-ST"/>
+          <xs:attribute name="line-color-auto" type="xs:boolean"/>
+          <xs:attribute name="mark-line-pattern" type="Workbook-MarkLinePattern-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Workbook-MarkType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="manual"/>
+      <xs:enumeration value="all"/>
+      <xs:enumeration value="selected"/>
+      <xs:enumeration value="highlighted"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Workbook-TrailEffect-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="transparency"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Workbook-LinePattern-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="line-pattern-none"/>
+      <xs:enumeration value="line-pattern-solid"/>
+      <xs:enumeration value="line-pattern-dashed"/>
+      <xs:enumeration value="line-pattern-dotted"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Workbook-MarkLinePattern-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="solid"/>
+      <xs:enumeration value="dashed"/>
+      <xs:enumeration value="dotted"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Workbook-ForecastSpecification-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="forecast-specification">
+        <xs:complexType>
+          <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+          <xs:attribute name="range-type" type="ForecastRangeType-ST" use="required"/>
+          <xs:attribute name="ignore-last" type="xs:int" use="required"/>
+          <xs:attribute name="auto-forecast-agg" type="xs:boolean" use="required"/>
+          <xs:attribute name="model-type" type="ForecastModelType-ST" use="required"/>
+          <xs:attribute name="fill-type" type="DensificationFillType-ST" use="required"/>
+          <xs:attribute name="show-prediction-bands" type="xs:boolean" use="required"/>
+          <xs:attribute name="band-confidence-level" type="xs:float" use="required"/>
+          <xs:attribute name="range-size" type="xs:int"/>
+          <xs:attribute name="range-periods" type="AggType-ST"/>
+          <xs:attribute name="forecast-agg" type="AggType-ST"/>
+          <xs:attribute name="trend-type" type="ForecastComponentType-ST"/>
+          <xs:attribute name="season-type" type="ForecastComponentType-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="WorkbookStylesheet-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Stylesheet-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="WorkbookOptimizer-G">
+    <xs:sequence>
+      <xs:element name="workbook-optimizer">
+        <xs:complexType>
+          <xs:group minOccurs="0" ref="WorkbookOptimizer-RuleConfig-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="WorkbookOptimizer-RuleId-ST">
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="WorkbookOptimizer-RuleConfig-G">
+    <xs:sequence>
+      <xs:element name="rule-config">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="WorkbookOptimizer-Rule-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="WorkbookOptimizer-Rule-G">
+    <xs:sequence>
+      <xs:element name="rule">
+        <xs:complexType>
+          <xs:attribute name="ruleID" type="WorkbookOptimizer-RuleId-ST" use="required"/>
+          <xs:attribute name="ignored" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="BookmarkFile-CT">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DocumentManifest-G"/>
+      <xs:group minOccurs="0" ref="VizLayoutOptions-G"/>
+      <xs:group ref="RepositoryLocation-G"/>
+      <xs:group ref="Workbook-Preferences-G"/>
+      <xs:group ref="Workbook-DataSources-G"/>
+      <xs:group minOccurs="0" ref="Workbook-DataSourceRelationships-G"/>
+      <xs:group minOccurs="0" ref="Workbook-MapSources-G"/>
+      <xs:group minOccurs="0" ref="Actions-G"/>
+      <xs:group minOccurs="0" ref="Bookmark-G"/>
+      <xs:group ref="Workbook-VisualSpecification-G"/>
+    </xs:sequence>
+    <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+    <xs:attribute ref="xml:base"/>
+    <xs:attribute name="source-platform" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="WorkbookFile-CT">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DocumentManifest-G"/>
+      <xs:group ref="Workbook-RepositoryLocation-G"/>
+      <xs:group ref="Workbook-Preferences-G"/>
+      <xs:group ref="Workbook-StyleTheme-G"/>
+      <xs:group ref="Workbook-Styles-G"/>
+      <xs:group ref="Workbook-LocalData-G"/>
+      <xs:group ref="Workbook-DataSources-G"/>
+      <xs:group ref="Workbook-DataSourceRelationships-G"/>
+      <xs:group ref="Workbook-MapSources-G"/>
+      <xs:group ref="Workbook-SharedViews-G"/>
+      <xs:group ref="Workbook-Actions-G"/>
+      <xs:group ref="Workbook-Worksheets-G"/>
+      <xs:group ref="Workbook-Dashboards-G"/>
+      <xs:group ref="Workbook-Windows-G"/>
+      <xs:group ref="Workbook-Datagraph-G"/>
+      <xs:group ref="Workbook-Thumbnails-G"/>
+      <xs:group ref="Shapes-G"/>
+      <xs:group ref="Workbook-ReferencedExtensions-G"/>
+      <xs:group ref="Workbook-ExplainData-G"/>
+      <xs:group minOccurs="0" ref="Workbook-DataOrientation-G"/>
+      <xs:group minOccurs="0" ref="Workbook-TabAgentConfig-G"/>
+      <xs:group minOccurs="0" ref="Workbook-AcceleratorDetails-G"/>
+      <xs:group minOccurs="0" ref="Workbook-WorkbookOptimizer-G"/>
+    </xs:sequence>
+    <xs:attributeGroup ref="Workbook-WorkbookAttributes-AG"/>
+  </xs:complexType>
+  <xs:attributeGroup name="Workbook-WorkbookAttributes-AG">
+    <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+    <xs:attribute name="original-version" type="VersionNumber-ST"/>
+    <xs:attribute name="source-build" type="xs:string" use="required"/>
+    <xs:attribute ref="xml:base"/>
+    <xs:attribute name="upgrade-extracts" type="xs:boolean"/>
+    <xs:attribute name="locale" type="xs:string"/>
+    <xs:attribute name="source-platform" type="xs:string"/>
+    <xs:attribute name="include-phone-layouts" type="xs:boolean"/>
+  </xs:attributeGroup>
+  <xs:group name="Workbook-WorksheetDocRef-G">
+    <xs:sequence>
+      <xs:element name="worksheet">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="RepositoryLocation-G"/>
+            <xs:group ref="Workbook-DataSources-G"/>
+            <xs:group minOccurs="0" ref="Workbook-MapSources-G"/>
+            <xs:group ref="Workbook-VisualSpecification-G"/>
+          </xs:sequence>
+          <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-DataSourceRelationships-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="datasource-relationships">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="DataSourceRelationships-G"/>
+          </xs:sequence>
+          <xs:attribute name="target-secondaries" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-QuantitativeDomain-G">
+    <xs:sequence>
+      <xs:element name="domain">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="min" type="DataValue-ST"/>
+            <xs:element name="max" type="DataValue-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-CategoricalDomain-G">
+    <xs:sequence>
+      <xs:element name="domain">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="value" type="DataValue-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-LocalData-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="local-data">
+        <xs:complexType>
+          <xs:attribute name="directory" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element minOccurs="0" name="local-data-typed">
+        <xs:complexType>
+          <xs:attribute name="directory" type="xs:string" use="required"/>
+          <xs:attribute name="type" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Preferences-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Preferences-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-StyleTheme-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="style-theme">
+        <xs:complexType>
+          <xs:attribute name="name" type="StyleTheme-ST"/>
+          <xs:attribute name="value">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:minLength value="1"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-SharedView-G">
+    <xs:sequence>
+      <xs:element name="shared-view">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Workbook-DataSources-G"/>
+            <xs:group ref="DataSourceDependencies-G"/>
+            <xs:group ref="Workbook-ViewSpecification-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Workbook-FieldSet-CT">
+    <xs:complexContent>
+      <xs:extension base="Workbook-Fields-CT"/>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="Workbook-OnOff-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="on"/>
+      <xs:enumeration value="off"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Workbook-Worksheets-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="worksheets">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="Workbook-WorksheetDocPtr-G"/>
+          </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="DemandWorksheetNameUnique">
+          <xs:selector xpath="worksheet"/>
+          <xs:field xpath="@name"/>
+        </xs:unique>
+        <xs:unique name="UniqueWorksheetIdentifier">
+          <xs:selector xpath="worksheet/simple-id"/>
+          <xs:field xpath="@uuid"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-WorksheetDocPtr-G">
+    <xs:sequence>
+      <xs:element name="worksheet">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Workbook-VizLayoutOptionsOrRepositoryLocation-G"/>
+            <xs:group ref="Workbook-VisualSpecification-G"/>
+            <xs:group ref="SimpleIdentifierForThisWorksheet-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="lock-updates" type="xs:boolean"/>
+          <xs:attribute name="lock-quick-filters" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Worksheet-WorksheetNumber-G">
+    <xs:sequence>
+      <xs:element name="worksheet-number">
+        <xs:complexType>
+          <xs:attribute name="number" use="required" type="xs:int"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SimpleIdentifierForThisWorksheet-G">
+    <xs:sequence>
+      <xs:group minOccurs="1" ref="SimpleIdentifier-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Dashboards-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="dashboards">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="DashboardDoc-G"/>
+          </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="UniqueDashboardIdentifier">
+          <xs:selector xpath="dashboard/simple-id"/>
+          <xs:field xpath="@uuid"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-VizLayoutOptionsOrRepositoryLocation-G">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="2">
+        <xs:group ref="VizLayoutOptions-G"/>
+        <xs:group ref="RepositoryLocation-G"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-RepositoryLocation-G">
+    <xs:sequence>
+      <xs:group ref="RepositoryLocation-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Styles-G">
+    <xs:sequence>
+      <xs:group ref="WorkbookStylesheet-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-SharedViews-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="shared-views">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Workbook-SharedView-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Windows-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Windows-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Thumbnails-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="thumbnails">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="Thumbnail-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-ReferencedExtensions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" maxOccurs="1" name="referenced-extensions" type="ReferencedExtensions-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Actions-G">
+    <xs:sequence>
+      <xs:group ref="ActionsOrActionList-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-DataOrientation-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DataOrientation-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-TabAgentConfig-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="TabAgentConfig-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Workbook-Explanations-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="number-of-records"/>
+      <xs:enumeration value="average-of-records"/>
+      <xs:enumeration value="extreme-values"/>
+      <xs:enumeration value="distribution-of-records"/>
+      <xs:enumeration value="aggregated-dimensions"/>
+      <xs:enumeration value="unvisualized-measures"/>
+      <xs:enumeration value="null-value"/>
+      <xs:enumeration value="explain-average"/>
+      <xs:enumeration value="tvd-single-value"/>
+      <xs:enumeration value="ad-single-value"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Workbook-ExplanationTypes-G">
+    <xs:sequence>
+      <xs:element name="explanation-types">
+        <xs:complexType>
+          <xs:sequence maxOccurs="unbounded" minOccurs="0">
+            <xs:element name="explanation-type">
+              <xs:complexType>
+                <xs:attribute name="type" type="Workbook-Explanations-ST" use="required"/>
+                <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-ExplainData-G">
+    <xs:sequence>
+      <xs:element name="explain-data">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="Workbook-ExplanationTypes-G"/>
+          </xs:sequence>
+          <xs:attribute name="enabled-for-viewer" type="xs:boolean" use="required"/>
+          <xs:attribute name="extreme-values-enabled-for-all" type="xs:boolean" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Datagraph-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Datagraph-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-AcceleratorDetails-G">
+    <xs:sequence>
+      <xs:element name="accelerator-details">
+        <xs:complexType>
+          <xs:all>
+            <xs:element name="exchange-product-id" type="xs:unsignedInt"/>
+            <xs:element minOccurs="0" name="data-mapper-enabled" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="dataMapperState">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="selectedSourceDataSourceCaption" type="xs:string"/>
+                  <xs:element name="selectedSourceDataSourceName" type="xs:string"/>
+                  <xs:element name="selectedTargetDataSourceCaption" type="xs:string"/>
+                  <xs:element name="selectedTargetDataSourceName" type="xs:string"/>
+                  <xs:element name="targetFields">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="tableName" type="xs:string"/>
+                        <xs:element name="fields">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="field" maxOccurs="unbounded" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="sourceFullyQualifiedFieldName" type="xs:string"/>
+                                    <xs:element name="targetFullyQualifiedFieldName" type="xs:string"/>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:all>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-WorkbookOptimizer-G">
+    <xs:sequence>
+      <xs:group ref="WorkbookOptimizer-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="workbook" type="WorkbookFile-CT"/>
+</xs:schema>

--- a/skill/tableau-dashboard-creator/references/xsd/user.xsd
+++ b/skill/tableau-dashboard-creator/references/xsd/user.xsd
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.tableausoftware.com/xml/user"
+           elementFormDefault="qualified">
+  <xs:attributeGroup name="UserAttributes-AG">
+    <xs:anyAttribute namespace="##any" processContents="skip"/>
+  </xs:attributeGroup>
+</xs:schema>

--- a/skill/tableau-dashboard-creator/references/xsd/xml.xsd
+++ b/skill/tableau-dashboard-creator/references/xsd/xml.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/XML/1998/namespace"
+           xml:lang="en">
+  <xs:attribute name="lang">
+    <xs:simpleType>
+      <xs:union memberTypes="xs:language">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value=""/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:union>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="space">
+    <xs:simpleType>
+      <xs:restriction base="xs:NCName">
+        <xs:enumeration value="default"/>
+        <xs:enumeration value="preserve"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="base" type="xs:anyURI"/>
+  <xs:attribute name="id" type="xs:ID"/>
+  <xs:attributeGroup name="specialAttrs">
+    <xs:attribute ref="xml:base"/>
+    <xs:attribute ref="xml:lang"/>
+    <xs:attribute ref="xml:space"/>
+    <xs:attribute ref="xml:id"/>
+  </xs:attributeGroup>
+</xs:schema>

--- a/skill/tableau-dashboard-creator/scripts/validate_twb_xsd.py
+++ b/skill/tableau-dashboard-creator/scripts/validate_twb_xsd.py
@@ -1,0 +1,168 @@
+"""TWB XSD Validator — Structural Checks Against Official Tableau Schema.
+
+Validates a Tableau workbook (.twb) file against the official 2026.1 XSD
+published by Tableau (`tableau/tableau-document-schemas` on GitHub).
+
+This is complementary to `validate_twb.py`:
+    - `validate_twb.py` checks cross-section semantic integrity (datasource
+      references, column-instance refs, filter-slices consistency) — the
+      content the XSD marks as `processContents="skip"`.
+    - This script checks everything outside those skip-zones: element
+      nesting, required attributes, attribute value enums, child ordering.
+
+The XSD targets Tableau 2026.1. When validating a workbook authored for an
+older Tableau version (e.g., 2025.x), expect a small set of known
+"version-shifted" errors that are safe to ignore. See
+`references/step-e-twb-generation.md § XSD Validation` for the
+interpretation guide.
+
+Usage:
+    python validate_twb_xsd.py <path_to_twb_file>
+
+Exit codes:
+    0 — XSD validation passed (with no errors)
+    1 — XSD validation failed (one or more errors)
+    2 — file could not be parsed or schema could not be loaded (fatal)
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+try:
+    from lxml import etree
+except ImportError:
+    print("ERROR: lxml is required. Install with: pip install lxml",
+          file=sys.stderr)
+    sys.exit(2)
+
+# Logging setup
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# Schema location — sibling `references/xsd/` directory.
+# Script lives at: <skill-root>/scripts/validate_twb_xsd.py
+# XSD lives at:    <skill-root>/references/xsd/twb_2026.1.0.xsd
+SCRIPT_DIR = Path(__file__).resolve().parent
+XSD_PATH = SCRIPT_DIR.parent / "references" / "xsd" / "twb_2026.1.0.xsd"
+
+
+def load_schema(xsd_path: Path) -> etree.XMLSchema:
+    """Parse and compile the XSD into a usable schema validator.
+
+    Args:
+        xsd_path: Path to the root XSD file. The XSD imports `user.xsd`
+            and `xml.xsd` from the same directory.
+
+    Returns:
+        Compiled XMLSchema validator.
+
+    Raises:
+        FileNotFoundError: If the XSD file does not exist.
+        etree.XMLSchemaParseError: If the XSD itself is malformed or has
+            unresolved imports.
+    """
+    if not xsd_path.exists():
+        raise FileNotFoundError(f"XSD not found at expected path: {xsd_path}")
+    schema_doc = etree.parse(str(xsd_path))
+    return etree.XMLSchema(schema_doc)
+
+
+def validate(twb_path: Path, schema: etree.XMLSchema) -> tuple[bool, list]:
+    """Run the schema against a TWB file.
+
+    Args:
+        twb_path: Path to the .twb file to validate.
+        schema: Compiled XMLSchema validator from `load_schema`.
+
+    Returns:
+        Tuple of (passed, errors). `errors` is a list of
+        lxml `_LogEntry` objects; empty when `passed` is True.
+    """
+    doc = etree.parse(str(twb_path))
+    passed = schema.validate(doc)
+    return passed, list(schema.error_log)
+
+
+def print_report(twb_path: Path, passed: bool, errors: list) -> None:
+    """Print a human-readable validation report.
+
+    Args:
+        twb_path: Path of the file that was validated (for display).
+        passed: True if validation succeeded.
+        errors: List of lxml `_LogEntry` validation errors (may be empty).
+    """
+    logger.info("=" * 60)
+    logger.info("TWB XSD Validation Report")
+    logger.info("=" * 60)
+    logger.info("File:   %s", twb_path)
+    logger.info("Schema: twb_2026.1.0.xsd (Tableau official, version 26.1)")
+    logger.info("")
+
+    if passed:
+        logger.info("[+] XSD validation: PASS")
+        logger.info("Status: ALL CHECKS PASSED")
+        logger.info("=" * 60)
+        return
+
+    logger.info("[X] XSD validation: FAIL (%d errors)", len(errors))
+    logger.info("")
+    for err in errors:
+        logger.info("    Line %d: %s", err.line, err.message)
+    logger.info("")
+    logger.info("-" * 60)
+    logger.info(
+        "Note: when targeting Tableau 2025.x or earlier, a small set of "
+        "errors is expected (e.g., 'missing explain-data', "
+        "'dim-percentage not allowed'). See step-e-twb-generation.md "
+        "§ XSD Validation for the interpretation guide."
+    )
+    logger.info("=" * 60)
+
+
+def main() -> None:
+    """CLI entry point.
+
+    Parses args, loads the schema, validates the workbook, prints the
+    report, and exits with the appropriate code.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a Tableau .twb file against the official 2026.1 XSD."
+        ),
+    )
+    parser.add_argument(
+        "twb_file",
+        help="Path to the .twb file to validate",
+    )
+    args = parser.parse_args()
+
+    twb_path = Path(args.twb_file)
+    if not twb_path.exists():
+        logger.error("File not found: %s", twb_path)
+        sys.exit(2)
+    if twb_path.suffix.lower() != ".twb":
+        logger.warning("File does not have .twb extension: %s", twb_path)
+
+    try:
+        schema = load_schema(XSD_PATH)
+    except FileNotFoundError as e:
+        logger.error("%s", e)
+        sys.exit(2)
+    except etree.XMLSchemaParseError as e:
+        logger.error("Failed to compile XSD: %s", e)
+        sys.exit(2)
+
+    try:
+        passed, errors = validate(twb_path, schema)
+    except etree.XMLSyntaxError as e:
+        logger.error("File is not well-formed XML: %s", e)
+        sys.exit(2)
+
+    print_report(twb_path, passed, errors)
+    sys.exit(0 if passed else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Step 0** now asks for the minimum target Tableau Desktop version up front (`2024.2 – 2025.x` default, or `2026.1+`) and persists it in `design-tokens.md`. This drives Step E's emission rules — no re-prompting downstream.
- **Step E** is now version-aware: workbook `version` attribute and whether `<explain-data>` is emitted are chosen from the Step 0 answer. Codified after empirically confirming Tableau 2025.1 rejects `<explain-data>` (error code `D2E8DA72`) and that `<layout>` does NOT actually require `dim-percentage`/`measure-percentage` (the previous CRITICAL RULE #5 was wrong for both 2025.x and 2026.1).
- **Vendored the official Tableau XSD** (`tableau/tableau-document-schemas`, version `twb_2026.1.0.xsd`) under `references/xsd/` plus two namespace stubs (`user.xsd`, `xml.xsd`) needed because the upstream XSD imports those namespaces without bundling them.
- **New `scripts/validate_twb_xsd.py`** runs lxml-based structural validation against the vendored schema. Complementary to the existing `validate_twb.py` (which covers the `processContents=\"skip\"` regions the XSD ignores: datasource refs, column-instance refs, filter↔slices, worksheet↔window).
- **Step E now runs both validators** between assemble and package. A 3-bucket interpretation guide tells the agent how to classify each XSD error — real bug, known 2025.x-vs-2026.1 delta (single expected error catalogued inline), or unknown delta to investigate.

## Why

The user discovered the official Tableau XSD (published Feb 2026). We tested it end-to-end: built a minimal 4-KPI + 2-chart workbook from the skill, ran both validators, opened in Tableau Desktop 2025.1. The exercise surfaced two long-standing bugs in the skill's CRITICAL RULES list and produced a clean signal-to-noise ratio for structural validation (the full Sales Performance demo workbook produces exactly **one** expected XSD error — the documented 2026.1-only `explain-data` requirement).

## Test plan

- [ ] `pip install -r requirements.txt` resolves cleanly (now includes `lxml`)
- [ ] `python skill/tableau-dashboard-creator/scripts/validate_twb_xsd.py demo/output/mock-version/v_2/dashboard.twb` reports **1 error** (the documented bucket-2 `Missing child element` for the 2025.x target) and exits 1
- [ ] `python skill/tableau-dashboard-creator/scripts/validate_twb.py demo/output/mock-version/v_2/dashboard.twb` still reports 8/8 PASS
- [ ] Spot-check `references/step-0-brand-setup.md` — the new "ask for target Tableau version" sub-step is the first thing under `## Process` and the `## Target Tableau Version` section is in the design-tokens.md template
- [ ] Spot-check `references/step-e-twb-generation.md` — Tableau Version Targeting table is near the top; CRITICAL RULE #5 says do NOT emit `dim-percentage`/`measure-percentage`; Validation section explains both validators with copy-paste commands; 3-bucket interpretation guide is present
- [ ] No new top-level steps or gateways were introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)