### PR TITLE
feat: tableau-intake skill — free-form request → structured PRD.md (idempotent) (#6)

### DIFF
--- a/skills/tableau-intake/SKILL.md
+++ b/skills/tableau-intake/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: tableau-intake
+description: Turns a free-form dashboard request into a structured PRD.md for the tableau-dashboard-plugin workflow. Reads the analyst's DASHBOARD-REQUEST.md (or text pasted into the terminal, or the scaffold/ demo example) and authors a schema-complete PRD.md. Optional and idempotent — if a PRD.md already exists it offers to refine rather than overwrite. Use when the user wants to structure a dashboard request, write a PRD, or when tableau-route reports intake is next. Step 2 of 8 in the workflow.
+disable-model-invocation: true
+allowed-tools: Read, Write, Edit, AskUserQuestion, Bash(python *), Bash(python3 *)
+---
+
+# tableau-intake
+
+Step 2 of 8. Converts a free-form request into a structured `PRD.md` so the
+downstream planning steps work from an unambiguous spec. The step is **optional**
+(it can be skipped) and **idempotent** (re-running refines an existing PRD instead
+of clobbering it).
+
+| | |
+|---|---|
+| **Reads** | The request: production `DASHBOARD-REQUEST.md` (preferred) **or** text the analyst pastes **or** the `scaffold/EXAMPLE-DASHBOARD-REQUEST.md` demo example. None is a *required read* — the request can be pasted, so this step never refuses for a "missing" request file (CONTRACT.md §1). |
+| **Writes** | `PRD.md` at the project root (latest approved truth; overwritten in place). |
+| **STATE.md update** | Sets `intake` = `approved` (PRD authored) or `skipped`; flips every downstream `approved` step to `stale` on a re-run (CONTRACT.md §4.2). |
+| **Entry gate** | Refuses to run until `init` is `approved` in `STATE.md` (CONTRACT.md §4.1). |
+| **Next step** | `tableau-data` (or `tableau-route` to confirm). |
+
+**Why optional?** `PRD.md` is a *structuring convenience*, not a hard dependency.
+`tableau-plan` (step 5) reads it as an **optional** input and falls back to the raw
+`DASHBOARD-REQUEST.md` when intake was skipped (CONTRACT.md §1), so skipping never
+blocks the pipeline — it just means planning works from the unstructured request.
+
+The mechanical guarantees — the entry gate, the PRD schema check, and the STATE.md
+transition — live in `intake.py`, this skill's executable mirror of the contract.
+Your job is the part that needs judgment: reading the free-form request and
+authoring (or refining) the PRD prose. Run the script at the two points below; do
+not hand-edit `STATE.md` yourself.
+
+## How to run
+
+1. **Precheck.** From the project directory, run:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/intake.py" precheck "<project-dir>"
+   ```
+
+   (Use `python3` if `python` is unavailable.) If it prints `[BLOCKED]`, relay the
+   reason and **stop** — the analyst must run `tableau-init` first. Otherwise note
+   its three signals: whether a `PRD.md` already exists, which request source to
+   read, and the current `intake` status (a re-run).
+
+2. **Refine vs. overwrite.** If precheck reports a `PRD.md` already exists, use
+   **AskUserQuestion** to offer **Refine** (keep its structure, update the content),
+   **Overwrite** (author fresh), or **Skip**. **Never silently overwrite** an
+   existing `PRD.md`. If no PRD exists, author fresh (still offer Skip).
+
+3. **Read the request.** Follow precheck's `request source`:
+   - `DASHBOARD-REQUEST.md` — read the analyst's production request.
+   - `scaffold/EXAMPLE-DASHBOARD-REQUEST.md` — the **demo** fallback; **tell the
+     analyst** you're demoing the workflow, not using real input.
+   - `none` — ask the analyst to paste their request text.
+
+4. **Author `PRD.md`.** Write (or, when refining, `Edit`) `PRD.md` at the project
+   root using `references/PRD-TEMPLATE.md` as the structure. Always include the
+   required core — **Overview** and **Visualizations**. **Proactively propose**
+   KPIs, Filters, and Additional Notes, since most dashboards want them — but if
+   the analyst says a section isn't needed, omit it without friction. Don't
+   complicate the PRD with empty sections. When **refining**, preserve the analyst's
+   existing structure and custom sections; change only what the request updates.
+   Present the PRD for approval.
+
+5. **Commit** — only after the analyst approves (or chooses to skip):
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/intake.py" commit "<project-dir>" --status approved
+   # or, to skip the step:
+   python "${CLAUDE_SKILL_DIR}/intake.py" commit "<project-dir>" --status skipped
+   ```
+
+   On `--status approved` the script validates `PRD.md` has the required core; if
+   it prints `[REFUSED]` listing missing sections, add them and re-run. On success
+   it records the status and reports any downstream steps it marked `stale`. Relay
+   the summary and tell the analyst to open a fresh conversation and run the next
+   step (`tableau-data`, or `tableau-route` to confirm).
+
+## The PRD schema
+
+`intake.py` enforces only the **required core**; the rest is recommended-but-optional.
+
+| section | required? | what goes there |
+|---------|-----------|-----------------|
+| `## Overview` | **required** | Purpose, audience, update frequency. |
+| `## Visualizations` | **required** | The charts and what each shows. |
+| `## KPIs` | optional | Headline metrics with formulas; omit if the dashboard has none. |
+| `## Filters` | optional | Slicing controls; omit if users don't need filtering. |
+| `## Additional Notes` | optional | Branding, conditional formatting, sort orders, constraints. |
+
+The validator matches headings as case-insensitive substrings and allows extra
+custom sections, so a refined PRD that keeps its own structure still passes.
+
+## Notes
+
+- **Idempotent & non-blocking.** Skipping records `skipped` in `STATE.md` and never
+  blocks the pipeline — downstream `plan` falls back to `DASHBOARD-REQUEST.md` and
+  neutral handling (CONTRACT.md §1). Re-running refines the root `PRD.md` in place
+  and flips downstream `approved` steps to `stale`; it does **not** create a new
+  version directory (`PRD.md` is a root "latest truth" file, CONTRACT.md §4.3).
+- **Do the data/branding work elsewhere.** Intake only structures the request.
+  Data acquisition is `tableau-data`'s job and branding is `tableau-brand`'s.
+
+> The full `STATE.md` schema and the ordering / staleness / versioning rules live in
+> `CONTRACT.md` at the repo root. This skill restates only its own slice; `intake.py`
+> is the executable mirror of the contract it enforces.

--- a/skills/tableau-intake/intake.py
+++ b/skills/tableau-intake/intake.py
@@ -1,0 +1,594 @@
+"""Gate, validate, and commit the ``intake`` step of the tableau-dashboard-plugin.
+
+This is the executable core of the ``tableau-intake`` skill (CONTRACT.md step 2):
+the optional, idempotent step that turns a free-form ``DASHBOARD-REQUEST.md`` (or
+pasted text) into a structured ``PRD.md``. The PRD *content* is authored by the
+model; this script owns the three things that must be **mechanically guaranteed**
+rather than left to model prose:
+
+1. **Entry gate** - intake refuses to run until ``init`` is ``approved`` in
+   ``STATE.md`` (and ``STATE.md`` exists at all). This mirrors the ordering rule
+   in CONTRACT.md §4.1: a step does not run before its prerequisites are resolved.
+2. **PRD schema** - on approval the produced ``PRD.md`` must contain the required
+   core sections (``Overview``, ``Visualizations``). The common ``KPIs`` /
+   ``Filters`` / ``Additional Notes`` sections are *recommended but optional*: not
+   every dashboard has KPIs or filters, so a PRD that legitimately omits them is
+   still valid. The skill proposes them while refining; the validator never refuses
+   on a missing recommended section.
+3. **STATE.md transition** - intake is the first step that *mutates* an existing
+   ``STATE.md`` (init only creates it, route only reads it). Committing flips
+   ``intake`` to ``approved``/``skipped`` and propagates staleness (CONTRACT.md
+   §4.2): re-running flips every downstream ``approved`` step to ``stale`` so the
+   pipeline can never silently disagree with a changed request.
+
+The module is intentionally pure and stdlib-only (it does **not** import the
+router) so the contract test can call its functions directly, exactly like
+``init.py`` / ``route.py``. The CLI exposes two subcommands the skill runs at two
+moments - ``precheck`` (before authoring) and ``commit`` (after approval). What
+the CLI prints to stdout is the program's *output*; diagnostics go through
+``logging``.
+
+Keep ``STEP_ORDER`` below in lock-step with the ordered step list in CONTRACT.md §1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# --- Canonical constants (mirror of CONTRACT.md §1 / §2 / §3) ----------------
+
+STATE_FILENAME = "STATE.md"
+PRD_FILENAME = "PRD.md"
+
+#: Production request input (preferred) and its scaffold/ demo fallback (§3.1).
+REQUEST_FILENAME = "DASHBOARD-REQUEST.md"
+SCAFFOLD_REQUEST = "scaffold/EXAMPLE-DASHBOARD-REQUEST.md"
+
+#: This step, and the upstream step whose approval gates it (CONTRACT.md §4.1).
+INTAKE_STEP = "intake"
+INIT_STEP = "init"
+
+#: The 8 step names in canonical order (mirror of CONTRACT.md §1). Used to decide
+#: which steps are "downstream of intake" for staleness propagation (§4.2).
+STEP_ORDER: tuple[str, ...] = (
+    "init", "intake", "data", "brand", "plan", "mock", "spec", "build",
+)
+
+#: Statuses the commit subcommand may write for the intake step.
+COMMIT_STATUSES: tuple[str, ...] = ("approved", "skipped")
+
+#: PRD sections every dashboard PRD must have: what it is for + what it shows.
+PRD_REQUIRED_SECTIONS: tuple[str, ...] = ("Overview", "Visualizations")
+
+#: Common but genuinely optional PRD sections. Proposed while refining, never
+#: required - not every dashboard has KPIs or filters.
+PRD_RECOMMENDED_SECTIONS: tuple[str, ...] = ("KPIs", "Filters", "Additional Notes")
+
+
+# --- STATE.md reading --------------------------------------------------------
+
+# Matches a markdown ATX heading line, capturing its text (drops leading "#"s and
+# any trailing "#"s): "## Overview" -> "Overview".
+_HEADING_LINE = re.compile(r"^#{1,6}\s+(.*?)\s*#*\s*$")
+
+
+def _resolve_state_path(target: Path) -> Path:
+    """Resolve the STATE.md path for a project directory or a direct file path.
+
+    Args:
+        target: Either a project directory (which may contain ``STATE.md``) or a
+            path to a ``STATE.md`` file directly.
+
+    Returns:
+        The path where ``STATE.md`` is expected. It may or may not exist.
+    """
+    if target.is_dir():
+        return target / STATE_FILENAME
+    return target
+
+
+def parse_statuses(text: str) -> dict[str, str]:
+    """Parse the per-step statuses out of a STATE.md manifest.
+
+    Parsing is tolerant (matching the router's parser): only genuine
+    ``| order | step | skill | status |`` rows whose step name is known
+    contribute; header, separator, and stray rows are ignored.
+
+    Args:
+        text: The full contents of a ``STATE.md`` file.
+
+    Returns:
+        A ``{step_name: status}`` mapping (both lower-cased).
+    """
+    statuses: dict[str, str] = {}
+    in_steps = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        # Section headers toggle which parser applies.
+        if line.lower().startswith("## steps"):
+            in_steps = True
+            continue
+        if line.startswith("## "):  # any other section ends the Steps table
+            in_steps = False
+
+        if in_steps and line.startswith("|"):
+            cells = [cell.strip() for cell in line.strip("|").split("|")]
+            if len(cells) < 4:
+                continue
+            step_name, status = cells[1].lower(), cells[3].lower()
+            if step_name in STEP_ORDER:
+                statuses[step_name] = status
+    return statuses
+
+
+# --- PRD schema --------------------------------------------------------------
+
+def _markdown_headings(text: str) -> list[str]:
+    """Extract the text of every markdown heading in a document.
+
+    Args:
+        text: Markdown document contents.
+
+    Returns:
+        The heading texts, in document order (e.g. ``["Overview", "KPIs"]``).
+    """
+    return [
+        match.group(1).strip()
+        for raw_line in text.splitlines()
+        if (match := _HEADING_LINE.match(raw_line.strip()))
+    ]
+
+
+def validate_prd(text: str) -> tuple[bool, list[str], list[str]]:
+    """Check a PRD's section coverage against the canonical schema.
+
+    A PRD is *valid* when it contains every **required** section; recommended
+    sections are reported when absent but never make a PRD invalid (CONTRACT
+    feedback: not all dashboards have KPIs or filters). Section names are matched
+    case-insensitively as substrings of the document's headings, so a refined PRD
+    that keeps custom headings (e.g. ``## Overview & Audience``) still validates -
+    and extra custom sections are always allowed.
+
+    Args:
+        text: The contents of a ``PRD.md`` file.
+
+    Returns:
+        A ``(ok, missing_required, missing_recommended)`` tuple. ``ok`` is True
+        iff ``missing_required`` is empty.
+    """
+    headings_blob = "\n".join(_markdown_headings(text)).lower()
+    missing_required = [
+        section for section in PRD_REQUIRED_SECTIONS
+        if section.lower() not in headings_blob
+    ]
+    missing_recommended = [
+        section for section in PRD_RECOMMENDED_SECTIONS
+        if section.lower() not in headings_blob
+    ]
+    return (not missing_required, missing_required, missing_recommended)
+
+
+def render_prd_template() -> str:
+    """Return the canonical PRD template text this skill ships.
+
+    Reads ``references/PRD-TEMPLATE.md`` so there is a single source of truth for
+    the schema-complete starting PRD - the same file the skill hands the model to
+    fill in. It is, by construction, schema-complete (contains the required core).
+
+    Returns:
+        The template file contents.
+
+    Raises:
+        FileNotFoundError: If the bundled template is missing.
+    """
+    template_path = Path(__file__).resolve().parent / "references" / "PRD-TEMPLATE.md"
+    if not template_path.is_file():
+        raise FileNotFoundError(f"PRD template not found: {template_path}")
+    return template_path.read_text(encoding="utf-8-sig")
+
+
+# --- STATE.md rewriting ------------------------------------------------------
+
+def _format_step_row(cells: list[str]) -> str:
+    """Render a Steps-table row with the canonical column widths.
+
+    Matches the alignment ``init.render_state_md`` produces (``order<5 | step<6 |
+    skill<14 | status<8``) so a rewritten row stays visually consistent with the
+    rest of the table.
+
+    Args:
+        cells: The four cell values ``[order, step, skill, status]``.
+
+    Returns:
+        The formatted ``| ... |`` table row (no trailing newline).
+    """
+    order, step, skill, status = cells[0], cells[1], cells[2], cells[3]
+    return f"| {order:<5} | {step:<6} | {skill:<14} | {status:<8} |"
+
+
+def apply_status_updates(text: str, updates: dict[str, str]) -> str:
+    """Rewrite the status cell of one or more Steps-table rows.
+
+    Only rows inside the ``## Steps`` table whose step name is a key in
+    ``updates`` are touched; every other line (metadata, prose, untouched rows) is
+    preserved byte-for-byte. The trailing newline of the input is preserved.
+
+    Args:
+        text: The full ``STATE.md`` contents.
+        updates: ``{step_name: new_status}`` for the rows to rewrite (step names
+            lower-cased).
+
+    Returns:
+        The updated ``STATE.md`` contents.
+    """
+    out_lines: list[str] = []
+    in_steps = False
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+
+        if stripped.lower().startswith("## steps"):
+            in_steps = True
+            out_lines.append(raw_line)
+            continue
+        if stripped.startswith("## "):  # any other section ends the Steps table
+            in_steps = False
+
+        if in_steps and stripped.startswith("|"):
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            if len(cells) >= 4 and cells[1].lower() in updates:
+                cells[3] = updates[cells[1].lower()]
+                out_lines.append(_format_step_row(cells))
+                continue
+
+        out_lines.append(raw_line)
+
+    result = "\n".join(out_lines)
+    if text.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def _downstream_stale_updates(statuses: dict[str, str]) -> dict[str, str]:
+    """Compute which downstream steps must flip to ``stale`` (CONTRACT.md §4.2).
+
+    Every step ordered after ``intake`` that is currently ``approved`` becomes
+    ``stale``; steps already ``pending`` / ``skipped`` / ``stale`` are left as-is.
+
+    Args:
+        statuses: The current ``{step_name: status}`` mapping.
+
+    Returns:
+        ``{step_name: "stale"}`` for each downstream step that was ``approved``.
+    """
+    intake_index = STEP_ORDER.index(INTAKE_STEP)
+    return {
+        step: "stale"
+        for step in STEP_ORDER[intake_index + 1:]
+        if statuses.get(step) == "approved"
+    }
+
+
+# --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
+
+def entry_gate_blocker(project_root: Path) -> Optional[str]:
+    """Return why intake may not run yet, or ``None`` if it may.
+
+    Intake refuses to run unless ``STATE.md`` exists and ``init`` is ``approved``.
+
+    Args:
+        project_root: The analyst's project directory.
+
+    Returns:
+        A human-readable blocker message, or ``None`` when the gate is open.
+    """
+    state_path = project_root / STATE_FILENAME
+    if not state_path.exists():
+        return (
+            "No STATE.md found. Run 'tableau-init' first to scaffold the project "
+            "and initialize STATE.md before running 'tableau-intake'."
+        )
+
+    init_status = parse_statuses(state_path.read_text(encoding="utf-8-sig")).get(
+        INIT_STEP, "pending"
+    )
+    if init_status != "approved":
+        return (
+            f"Step 'init' is '{init_status}', not 'approved'. Run 'tableau-init' "
+            f"first; 'tableau-intake' cannot run until init is approved."
+        )
+    return None
+
+
+# --- precheck ----------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PrecheckResult:
+    """The state intake needs to know before authoring a PRD.
+
+    Attributes:
+        can_run: True when the entry gate is open (init approved, STATE.md present).
+        blocker: Why intake cannot run, when ``can_run`` is False; else ``None``.
+        prd_exists: Whether a ``PRD.md`` already exists at the project root. When
+            True the skill must offer refine-vs-overwrite, never silently overwrite.
+        request_source: Where the free-form request will be read from -
+            ``"DASHBOARD-REQUEST.md"`` (production), ``SCAFFOLD_REQUEST`` (demo
+            fallback), or ``"none"`` (the analyst will paste text).
+        intake_status: The intake step's current status (to detect a re-run).
+    """
+
+    can_run: bool
+    blocker: Optional[str]
+    prd_exists: bool
+    request_source: str
+    intake_status: str
+
+
+def _resolve_request_source(project_root: Path) -> str:
+    """Pick the request input, preferring production over the demo fallback (§3.1).
+
+    Args:
+        project_root: The analyst's project directory.
+
+    Returns:
+        ``REQUEST_FILENAME``, ``SCAFFOLD_REQUEST``, or ``"none"``.
+    """
+    if (project_root / REQUEST_FILENAME).exists():
+        return REQUEST_FILENAME
+    if (project_root / SCAFFOLD_REQUEST).exists():
+        return SCAFFOLD_REQUEST
+    return "none"
+
+
+def precheck(project_dir: Path | str) -> PrecheckResult:
+    """Report whether intake may run and what it should read.
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`PrecheckResult`. When the entry gate is closed, ``can_run`` is
+        False and ``blocker`` explains why; the other fields are placeholders.
+    """
+    project_root = Path(project_dir)
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return PrecheckResult(False, blocker, False, "none", "unknown")
+
+    statuses = parse_statuses((project_root / STATE_FILENAME).read_text(encoding="utf-8-sig"))
+    return PrecheckResult(
+        can_run=True,
+        blocker=None,
+        prd_exists=(project_root / PRD_FILENAME).exists(),
+        request_source=_resolve_request_source(project_root),
+        intake_status=statuses.get(INTAKE_STEP, "pending"),
+    )
+
+
+# --- commit ------------------------------------------------------------------
+
+@dataclass
+class CommitResult:
+    """Outcome of committing the intake step's result to STATE.md.
+
+    Attributes:
+        ok: True when STATE.md was updated; False when the commit was refused.
+        message: Human-readable explanation (the refusal reason when not ``ok``).
+        status_set: The status written for ``intake`` (``approved``/``skipped``),
+            or ``None`` when refused.
+        staled_steps: Downstream steps flipped to ``stale`` by this commit.
+        missing_required: Required PRD sections that were absent (only populated
+            on an approval refusal).
+        missing_recommended: Recommended PRD sections that were absent (reported as
+            an informational note; never blocks an approval).
+    """
+
+    ok: bool
+    message: str
+    status_set: Optional[str] = None
+    staled_steps: list[str] = field(default_factory=list)
+    missing_required: list[str] = field(default_factory=list)
+    missing_recommended: list[str] = field(default_factory=list)
+
+
+def commit(project_dir: Path | str, status: str) -> CommitResult:
+    """Record the intake step's result in STATE.md and propagate staleness.
+
+    On ``approved`` the project's ``PRD.md`` must exist and contain the required
+    core sections, or the commit is refused (so the model fixes it and re-commits).
+    On either status, every downstream ``approved`` step is flipped to ``stale``
+    (CONTRACT.md §4.2) - a no-op on a first run, but the guard that keeps a re-run
+    from silently disagreeing with the rest of the pipeline.
+
+    Args:
+        project_dir: The analyst's project directory.
+        status: The status to record for ``intake`` - one of :data:`COMMIT_STATUSES`.
+
+    Returns:
+        A :class:`CommitResult`. ``ok`` is False (and STATE.md is left untouched)
+        when the entry gate is closed or an approval's PRD is incomplete.
+
+    Raises:
+        ValueError: If ``status`` is not an allowed commit status.
+    """
+    if status not in COMMIT_STATUSES:
+        allowed = " | ".join(COMMIT_STATUSES)
+        raise ValueError(f"Invalid intake status '{status}'. Allowed: {allowed}.")
+
+    project_root = Path(project_dir)
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return CommitResult(False, blocker)
+
+    missing_recommended: list[str] = []
+    if status == "approved":
+        prd_path = project_root / PRD_FILENAME
+        if not prd_path.exists():
+            return CommitResult(
+                False,
+                f"Cannot approve intake: '{PRD_FILENAME}' does not exist. Author it "
+                f"first, or commit '--status skipped' to skip this step.",
+            )
+        ok, missing_required, missing_recommended = validate_prd(
+            prd_path.read_text(encoding="utf-8-sig")
+        )
+        if not ok:
+            return CommitResult(
+                False,
+                f"'{PRD_FILENAME}' is missing required section(s): "
+                f"{', '.join(missing_required)}. Add them and re-run commit.",
+                missing_required=missing_required,
+                missing_recommended=missing_recommended,
+            )
+
+    state_path = project_root / STATE_FILENAME
+    text = state_path.read_text(encoding="utf-8-sig")
+    statuses = parse_statuses(text)
+
+    stale_updates = _downstream_stale_updates(statuses)
+    updates = {INTAKE_STEP: status, **stale_updates}
+    state_path.write_text(apply_status_updates(text, updates), encoding="utf-8")
+
+    staled_steps = sorted(stale_updates, key=STEP_ORDER.index)
+    logger.info(f"Set intake -> {status}; marked stale: {staled_steps or 'none'}.")
+    return CommitResult(
+        ok=True,
+        message=f"intake -> {status}",
+        status_set=status,
+        staled_steps=staled_steps,
+        missing_recommended=missing_recommended,
+    )
+
+
+# --- CLI ---------------------------------------------------------------------
+
+def format_precheck(result: PrecheckResult) -> str:
+    """Render a :class:`PrecheckResult` as a human-readable block.
+
+    Args:
+        result: The precheck result to render.
+
+    Returns:
+        A multi-line, plain-ASCII string suitable for printing to the analyst.
+    """
+    # Plain ASCII only: this prints to the console, which on Windows is cp1252
+    # and would raise UnicodeEncodeError on emoji/box-drawing glyphs.
+    if not result.can_run:
+        return f"[BLOCKED] tableau-intake cannot run.\n{result.blocker}"
+
+    lines = ["[INTAKE] precheck OK - tableau-intake can run."]
+    lines.append(f"  PRD.md exists : {'yes' if result.prd_exists else 'no'}")
+    if result.prd_exists:
+        lines.append(
+            "    -> a PRD.md already exists; offer REFINE vs OVERWRITE - never "
+            "silently overwrite the analyst's work."
+        )
+
+    if result.request_source == "none":
+        lines.append(
+            "  request source: none found - ask the analyst to paste the request text."
+        )
+    elif result.request_source == SCAFFOLD_REQUEST:
+        lines.append(
+            f"  request source: {SCAFFOLD_REQUEST} (DEMO fallback - say so; there is "
+            f"no root {REQUEST_FILENAME})."
+        )
+    else:
+        lines.append(f"  request source: {result.request_source} (production input).")
+
+    rerun_note = (
+        " (re-run; downstream approved steps will be marked stale on commit)"
+        if result.intake_status in ("approved", "stale")
+        else ""
+    )
+    lines.append(f"  intake status : {result.intake_status}{rerun_note}")
+    return "\n".join(lines)
+
+
+def format_commit(result: CommitResult) -> str:
+    """Render a :class:`CommitResult` as a human-readable block.
+
+    Args:
+        result: The commit result to render.
+
+    Returns:
+        A multi-line, plain-ASCII string suitable for printing to the analyst.
+    """
+    # Plain ASCII only (see format_precheck).
+    if not result.ok:
+        return f"[REFUSED] {result.message}"
+
+    lines = [f"[INTAKE] {result.message}."]
+    if result.missing_recommended:
+        lines.append(
+            f"  note: PRD has no {', '.join(result.missing_recommended)} section(s) "
+            f"- optional, left as-is."
+        )
+    if result.staled_steps:
+        lines.append(
+            f"  downstream marked stale: {', '.join(result.staled_steps)} "
+            f"(re-run these in order)."
+        )
+    lines.append(
+        "  next: open a fresh conversation and run 'tableau-route' (or 'tableau-data')."
+    )
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point: run ``precheck`` or ``commit`` and print the result.
+
+    Args:
+        argv: Argument list (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Process exit code: ``0`` on success, ``2`` when intake is blocked/refused
+        or on a usage error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Gate, validate, and commit the tableau-intake step.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    precheck_parser = subparsers.add_parser(
+        "precheck", help="Report whether intake may run and what to read."
+    )
+    precheck_parser.add_argument(
+        "project_dir", nargs="?", default=".", help="Project directory (default: cwd)."
+    )
+
+    commit_parser = subparsers.add_parser(
+        "commit", help="Record intake's result in STATE.md and propagate staleness."
+    )
+    commit_parser.add_argument(
+        "project_dir", nargs="?", default=".", help="Project directory (default: cwd)."
+    )
+    commit_parser.add_argument(
+        "--status", required=True, choices=COMMIT_STATUSES,
+        help="Status to record for the intake step.",
+    )
+
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    if args.command == "precheck":
+        precheck_result = precheck(args.project_dir)
+        print(format_precheck(precheck_result))
+        return 0 if precheck_result.can_run else 2
+
+    commit_result = commit(args.project_dir, args.status)
+    print(format_commit(commit_result))
+    return 0 if commit_result.ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/tableau-intake/references/PRD-TEMPLATE.md
+++ b/skills/tableau-intake/references/PRD-TEMPLATE.md
@@ -1,0 +1,45 @@
+# <Dashboard name> — PRD
+
+> Canonical `PRD.md` structure produced by `tableau-intake`. Fill each section
+> from the analyst's request. **`## Overview` and `## Visualizations` are the
+> required core** — every dashboard PRD has them. `## KPIs`, `## Filters`, and
+> `## Additional Notes` are **optional**: propose them while refining, but omit a
+> section the analyst says they don't need rather than padding the PRD. You may
+> add your own sections too — the validator only checks the required core is present.
+
+## Overview
+
+_Purpose, audience, and update frequency. Who is this for, what decisions does it
+support, and how often is the data refreshed?_
+
+## Visualizations
+
+_The charts and what each shows. One numbered entry per view — chart type, the
+measures/dimensions it plots, and any grouping, sorting, or reference lines._
+
+1. **<Chart name>** — <chart type> of <measure> by <dimension>; <sort / breakdown / notes>.
+
+## KPIs
+
+> _Optional — include if the dashboard has headline numbers. Remove this section
+> if the analyst says KPIs aren't needed._
+
+_The headline metrics to track, with a formula where it's specific._
+
+1. **<KPI name>** — <definition / formula>, <comparison to target if any>.
+
+## Filters
+
+> _Optional — include if users need to slice the data. Remove this section if the
+> analyst says filters aren't needed._
+
+_The filtering controls users need._
+
+- **<Filter name>** — <field it filters and control type (dropdown, date range, …)>.
+
+## Additional Notes
+
+> _Optional — branding, conditional formatting, sort orders, number formats, or any
+> other must-haves and constraints. Remove if there are none._
+
+- <constraint or styling note>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SKILL_SCRIPT_DIRS = (
     _REPO_ROOT / "skills" / "tableau-route",
     _REPO_ROOT / "skills" / "tableau-init",
+    _REPO_ROOT / "skills" / "tableau-intake",
 )
 
 for _script_dir in _SKILL_SCRIPT_DIRS:

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -1,0 +1,257 @@
+"""Contract test for tableau-intake (CONTRACT.md step 2, §3.1, §4.1, §4.2).
+
+``tableau-intake`` is the first skill that *mutates* an existing ``STATE.md`` (init
+only creates it, route only reads it), and the only optional/idempotent step besides
+``brand``. The PRD prose is model-authored, so this test pins the parts that must be
+mechanically guaranteed - exactly the seams ``intake.py`` owns:
+
+1. the entry gate (intake refuses until ``init`` is ``approved``, §4.1);
+2. the precheck signals the skill branches on (existing PRD, request source);
+3. the PRD schema - a required core (Overview, Visualizations) is enforced while
+   KPIs/Filters stay optional, and a refined PRD that keeps custom sections still
+   validates;
+4. the STATE.md transition + staleness propagation (§4.2), cross-checked by routing
+   the resulting manifest through the *router's* own ``compute_next_step``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import init    # builds a realistic STATE.md the same way a real project would
+import intake  # the skill under test (on sys.path via conftest.py)
+import route   # the router parses/routes the STATE.md intake writes
+
+TARGET_VERSION = "2024.2-2025.x"
+
+# A schema-complete PRD (required core present) plus optional sections.
+FULL_PRD = (
+    "# Sales Dashboard\n\n"
+    "## Overview\nFor the VP of Sales.\n\n"
+    "## Visualizations\n1. Revenue trend line chart.\n\n"
+    "## KPIs\n1. Total Revenue.\n\n"
+    "## Filters\n- Region.\n"
+)
+
+# Only the required core - a legitimate dashboard with no KPIs and no filters.
+CORE_ONLY_PRD = (
+    "# Status Board\n\n"
+    "## Overview\nA live status wall.\n\n"
+    "## Visualizations\n1. A single status table.\n"
+)
+
+# Missing the required core entirely (has only an optional section).
+INCOMPLETE_PRD = "# Half-baked\n\n## KPIs\n1. Some number.\n"
+
+
+def _write_state(project_dir: Path, **status_overrides: str) -> None:
+    """Write a canonical STATE.md, optionally overriding some step statuses.
+
+    Args:
+        project_dir: Directory to write ``STATE.md`` into.
+        **status_overrides: ``step=status`` pairs to apply on top of a fresh
+            manifest (e.g. ``intake="approved"``).
+    """
+    text = init.render_state_md(TARGET_VERSION)
+    if status_overrides:
+        text = intake.apply_status_updates(text, {k: v for k, v in status_overrides.items()})
+    (project_dir / "STATE.md").write_text(text, encoding="utf-8")
+
+
+# --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
+
+def test_precheck_blocks_when_no_state(tmp_path):
+    """No STATE.md ⇒ intake cannot run; the blocker points at tableau-init."""
+    result = intake.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "tableau-init" in result.blocker
+
+
+def test_precheck_blocks_when_init_not_approved(tmp_path):
+    """init must be approved before intake runs (§4.1)."""
+    _write_state(tmp_path, init="pending")
+
+    result = intake.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "init" in result.blocker and "pending" in result.blocker
+
+
+def test_commit_refuses_when_init_not_approved(tmp_path):
+    """The same gate guards commit, not just precheck."""
+    _write_state(tmp_path, init="pending")
+    (tmp_path / "PRD.md").write_text(FULL_PRD, encoding="utf-8")
+
+    result = intake.commit(tmp_path, status="approved")
+
+    assert result.ok is False
+    assert "init" in result.message
+    # STATE.md must be untouched: intake stays pending.
+    assert route.parse_state(tmp_path / "STATE.md").statuses["intake"] == "pending"
+
+
+# --- Precheck signals --------------------------------------------------------
+
+def test_precheck_detects_existing_prd(tmp_path):
+    """precheck reports whether a PRD.md already exists (the refine-vs-overwrite signal)."""
+    _write_state(tmp_path)
+    assert intake.precheck(tmp_path).prd_exists is False
+
+    (tmp_path / "PRD.md").write_text(FULL_PRD, encoding="utf-8")
+    assert intake.precheck(tmp_path).prd_exists is True
+
+
+def test_request_source_prefers_production_over_scaffold(tmp_path):
+    """Root DASHBOARD-REQUEST.md > scaffold/ demo example > none (§3.1)."""
+    # A scaffolded project has only the scaffold/ demo example.
+    init.scaffold_project(tmp_path, target_version=TARGET_VERSION)
+    assert intake.precheck(tmp_path).request_source == intake.SCAFFOLD_REQUEST
+
+    # Adding the production request flips the preference to it.
+    (tmp_path / "DASHBOARD-REQUEST.md").write_text("my request", encoding="utf-8")
+    assert intake.precheck(tmp_path).request_source == "DASHBOARD-REQUEST.md"
+
+
+def test_request_source_none_when_nothing_present(tmp_path):
+    """With neither a root request nor the scaffold example, the analyst will paste."""
+    _write_state(tmp_path)  # bare project: STATE.md only, no scaffold/ files
+
+    assert intake.precheck(tmp_path).request_source == "none"
+
+
+# --- PRD schema --------------------------------------------------------------
+
+def test_validate_prd_required_core():
+    """A PRD missing the required core is invalid and names what's missing."""
+    ok, missing_required, _ = intake.validate_prd(INCOMPLETE_PRD)
+
+    assert ok is False
+    assert set(missing_required) == {"Overview", "Visualizations"}
+
+
+def test_validate_prd_recommended_are_optional():
+    """Core-only PRD is valid; the absent recommended sections are merely reported."""
+    ok, missing_required, missing_recommended = intake.validate_prd(CORE_ONLY_PRD)
+
+    assert ok is True
+    assert missing_required == []
+    # KPIs/Filters/Additional Notes absent — reported, but not a failure.
+    assert set(missing_recommended) == set(intake.PRD_RECOMMENDED_SECTIONS)
+
+
+def test_validate_prd_allows_custom_sections_when_refining():
+    """A refined PRD that keeps the core plus its own custom sections still validates."""
+    refined = CORE_ONLY_PRD + "\n## Data Sources\nsales.csv\n\n## Open Questions\nTBD\n"
+
+    ok, missing_required, _ = intake.validate_prd(refined)
+
+    assert ok is True and missing_required == []
+
+
+def test_shipped_template_is_schema_complete():
+    """The bundled PRD-TEMPLATE.md contains the required core (validator's anchor)."""
+    ok, missing_required, _ = intake.validate_prd(intake.render_prd_template())
+
+    assert ok is True and missing_required == []
+
+
+# --- Commit: approve, skip, refuse -------------------------------------------
+
+def test_commit_approved_with_complete_prd(tmp_path):
+    """A schema-complete PRD commits: intake → approved in STATE.md."""
+    _write_state(tmp_path)
+    (tmp_path / "PRD.md").write_text(FULL_PRD, encoding="utf-8")
+
+    result = intake.commit(tmp_path, status="approved")
+
+    assert result.ok is True
+    assert route.parse_state(tmp_path / "STATE.md").statuses["intake"] == "approved"
+
+
+def test_commit_approved_refuses_incomplete_prd(tmp_path):
+    """commit refuses to approve a PRD missing the required core, and STATE is untouched."""
+    _write_state(tmp_path)
+    (tmp_path / "PRD.md").write_text(INCOMPLETE_PRD, encoding="utf-8")
+
+    result = intake.commit(tmp_path, status="approved")
+
+    assert result.ok is False
+    assert "Overview" in result.message and "Visualizations" in result.message
+    assert route.parse_state(tmp_path / "STATE.md").statuses["intake"] == "pending"
+
+
+def test_commit_approved_refuses_when_prd_absent(tmp_path):
+    """Approving without a PRD.md on disk is refused (nothing to approve)."""
+    _write_state(tmp_path)
+
+    result = intake.commit(tmp_path, status="approved")
+
+    assert result.ok is False
+    assert "PRD.md" in result.message
+
+
+def test_commit_core_only_prd_succeeds_and_notes_recommended(tmp_path):
+    """A core-only PRD (no KPIs/filters) commits; missing recommended is just a note."""
+    _write_state(tmp_path)
+    (tmp_path / "PRD.md").write_text(CORE_ONLY_PRD, encoding="utf-8")
+
+    result = intake.commit(tmp_path, status="approved")
+
+    assert result.ok is True
+    assert set(result.missing_recommended) == set(intake.PRD_RECOMMENDED_SECTIONS)
+
+
+def test_commit_skipped_needs_no_prd_and_does_not_block(tmp_path):
+    """Skipping records 'skipped' without any PRD and lets the pipeline continue."""
+    _write_state(tmp_path)
+
+    result = intake.commit(tmp_path, status="skipped")
+
+    assert result.ok is True
+    statuses = route.parse_state(tmp_path / "STATE.md").statuses
+    assert statuses["intake"] == "skipped"
+    # 'skipped' is resolved, so the router advances past intake (to data).
+    assert route.compute_next_step(tmp_path).next_step == "data"
+
+
+def test_commit_rejects_unknown_status(tmp_path):
+    """An out-of-vocabulary status is a programming error, not a silent no-op."""
+    _write_state(tmp_path)
+
+    with pytest.raises(ValueError, match="intake status"):
+        intake.commit(tmp_path, status="approve")  # typo: not in COMMIT_STATUSES
+
+
+# --- Staleness propagation (CONTRACT.md §4.2) --------------------------------
+
+def test_rerun_marks_downstream_approved_steps_stale(tmp_path):
+    """Re-running intake flips downstream approved steps to stale; others untouched."""
+    # A mid-pipeline project: intake already approved, data+brand approved, plan pending.
+    _write_state(tmp_path, intake="approved", data="approved", brand="approved")
+    (tmp_path / "PRD.md").write_text(FULL_PRD, encoding="utf-8")
+
+    result = intake.commit(tmp_path, status="approved")
+
+    assert result.ok is True
+    # data and brand (downstream, approved) flip to stale, in canonical order.
+    assert result.staled_steps == ["data", "brand"]
+
+    statuses = route.parse_state(tmp_path / "STATE.md").statuses
+    assert statuses["data"] == "stale" and statuses["brand"] == "stale"
+    assert statuses["plan"] == "pending"      # was pending → left as-is
+    assert statuses["intake"] == "approved"   # its own step re-approved
+
+    # Cross-check through the router: the first unresolved step is now stale 'data'.
+    routed = route.compute_next_step(tmp_path)
+    assert routed.next_step == "data" and "stale" in routed.reason.lower()
+
+
+def test_first_run_marks_nothing_stale(tmp_path):
+    """On a first approval there is nothing downstream approved, so nothing goes stale."""
+    _write_state(tmp_path)
+    (tmp_path / "PRD.md").write_text(FULL_PRD, encoding="utf-8")
+
+    result = intake.commit(tmp_path, status="approved")
+
+    assert result.ok is True and result.staled_steps == []


### PR DESCRIPTION
## Summary

Implements **issue #6** — the `tableau-intake` skill (step 2 of 8). Converts a free-form `DASHBOARD-REQUEST.md` (or pasted text, or the `scaffold/` demo example) into a structured `PRD.md`. Optional and idempotent: if a `PRD.md` already exists, the skill offers refine-vs-overwrite instead of clobbering it.

The PRD prose is model-authored; `intake.py` is the executable mirror that owns the mechanical guarantees (entry gate, schema validation, STATE.md transition) — the same pattern as `init.py` / `route.py`.

## What's in it

```
skills/tableau-intake/
├── SKILL.md                    # step 2, disable-model-invocation, 5-step how-to + PRD schema
├── intake.py                   # precheck + commit + validate_prd (stdlib-only, pure)
└── references/PRD-TEMPLATE.md  # canonical schema-complete PRD the model fills/refines
tests/test_intake.py            # 18 contract tests
tests/conftest.py               # +1 line: intake on sys.path
```

**Two-phase CLI:**
- `precheck` — entry gate (refuses until `init` is approved, §4.1) + reports `prd_exists`, `request_source` (root > scaffold demo > paste), and intake status.
- `commit --status approved|skipped` — validates the PRD, flips `intake`'s status, and propagates staleness (downstream `approved` → `stale`, §4.2). STATE.md rows are rewritten with `init`'s canonical column widths.

**Tiered PRD schema:** `Overview` + `Visualizations` are the required core (enforced); `KPIs` / `Filters` / `Additional Notes` are proposed-but-optional and never block — not all dashboards have KPIs or filters. `validate_prd` allows custom sections, so a refined PRD that keeps its own structure still validates.

**Intake stays optional** per CONTRACT.md §1/§2: `tableau-plan` reads `PRD.md` as an *optional* input and falls back to the raw `DASHBOARD-REQUEST.md` when intake is skipped — so skipping never blocks the pipeline.

## Acceptance criteria (issue #6)

- [x] Populated `DASHBOARD-REQUEST.md` → structured `PRD.md`
- [x] Existing `PRD.md` → refine-vs-overwrite, never silent overwrite (`precheck.prd_exists` + AskUserQuestion)
- [x] Skippable, records `skipped`, doesn't block (`commit --status skipped`)
- [x] Honors CONTRACT.md: refuses before `init` approved; re-run flips downstream `stale`
- [x] Contract test: refine preserves structure; fresh path produces schema-complete PRD

## Testing

- `python -m pytest tests/` → **42 passed** (18 new + 24 existing, no regression).
- Manual CLI smoke: blocked-on-fresh → demo fallback → refuse-no-PRD → refuse-incomplete → approve → router advances to `data` → re-run staleness (table stays aligned) → skip path.

## Out of scope (follow-ups)
- `CONTRACT.md` needed no change — intake's row and PRD schema rules already exist.
- `README.md` still describes the old monolithic skill; a v2 README sync is its own task.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)