### PR TITLE
feat(tableau-data): published-ds route via VizQL Data Service (#9)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,8 @@
 pandas>=2.0,<3.0
 python-dotenv>=1.0,<2.0
 
+# Step 3 (tableau-data) — published-ds route: REST sign-in + VizQL Data Service calls
+requests>=2.31,<3.0
+
 # Step E — XSD validation of generated .twb files
 lxml>=5.0,<6.0

--- a/skills/tableau-data/SKILL.md
+++ b/skills/tableau-data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tableau-data
-description: Acquires the data for a tableau-dashboard-plugin project and writes the DATA-MODEL.md handoff artifact. CSV mode (the default, zero-credential path) profiles the analyst's data/*.csv into documented field names + types and validates that headers match exactly; the scaffold/sample-data/ demo CSVs are the fallback. Detects the published-ds route (datasources.json + .env) and defers its VizQL Data Service extraction. Use when the user wants to acquire or model dashboard data, build DATA-MODEL.md, or when tableau-route reports data is next. Step 3 of 8 in the workflow.
+description: Acquires the data for a tableau-dashboard-plugin project and writes the DATA-MODEL.md handoff artifact. CSV mode (the default, zero-credential path) profiles the analyst's data/*.csv into documented field names + types and validates that headers match exactly; the scaffold/sample-data/ demo CSVs are the fallback. The published-ds route (datasources.json + .env) samples published sources through the VizQL Data Service into data/*.csv. Use when the user wants to acquire or model dashboard data, build DATA-MODEL.md, or when tableau-route reports data is next. Step 3 of 8 in the workflow.
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, AskUserQuestion, Bash(python *), Bash(python3 *)
 ---
@@ -15,7 +15,7 @@ headers exactly** before approving.
 
 | | |
 |---|---|
-| **Reads** | The data: production `data/*.csv` (preferred) **or** the `scaffold/sample-data/*.csv` demo fallback. Also *detects* the published-ds route inputs (`datasources.json` + `.env`). None is a *required read* — `data` has no producer-gated inputs (CONTRACT.md §1). |
+| **Reads** | The data: production `data/*.csv` (preferred) **or** the `scaffold/sample-data/*.csv` demo fallback. For the published-ds route, the inputs `datasources.json` + `.env` (the latter discovered by walking up — nearest wins). None is a *required read* — `data` has no producer-gated inputs (CONTRACT.md §1). |
 | **Writes** | `DATA-MODEL.md` at the project root (latest approved truth; overwritten in place). The CSVs themselves are analyst-provided in `data/` (or the demo `scaffold/sample-data/`). |
 | **STATE.md update** | Sets `data` = `approved`; flips every downstream `approved` step to `stale` on a re-run (CONTRACT.md §4.2). |
 | **Entry gate** | Refuses to run until `init` is `approved` in `STATE.md` (CONTRACT.md §4.1). |
@@ -28,18 +28,20 @@ There are exactly **two** ways to get the mimicking CSVs (CONTRACT.md §3.2). Th
 clearly-labelled `scaffold/sample-data/` demo, never invented rows.
 
 - **Route 1 — `data_mode: csv` (default, zero-credential).** The analyst drops CSV
-  file(s) in `data/`. **Each CSV is one data source.** This skill implements Route 1
-  fully: profile → document → validate.
+  file(s) in `data/`. **Each CSV is one data source.** `profile` → enrich → `commit`.
 - **Route 2 — `data_mode: published-ds` (VizQL Data Service).** The analyst lists
-  published sources in `datasources.json` and supplies Tableau creds in `.env`. This
-  skill **detects** those inputs and reports them, but the VDS query itself is part of
-  the published-ds work — it is **not** run here.
+  published sources in `datasources.json` (one entry each: `ds_name` + `project_name`)
+  and supplies a Tableau connection in `.env`. `pull` signs in with the Personal Access
+  Token and samples each source through the VDS — `read-metadata` (authoritative field
+  names/types/descriptions) then `query-datasource` (a capped row sample) — writing one
+  `data/<slug>.csv` per source plus `DATA-MODEL.md`. Then enrich → `commit`, exactly as
+  Route 1. **Fires only when `data/` has no production CSVs** (real CSVs always win).
 
-The mechanical guarantees — the entry gate, CSV profiling/type inference, the
-header↔model validation, and the STATE.md transition — live in `data.py`, this
-skill's executable mirror of the contract. Your job is the judgment part: confirming
-which route applies and enriching each field's **Description** in `DATA-MODEL.md`.
-Run the script at the three points below; do not hand-edit `STATE.md` yourself.
+The mechanical guarantees — the entry gate, CSV profiling/type inference, the VDS pull,
+the header↔model validation, and the STATE.md transition — live in `data.py` (with the
+VDS client in `vds.py`), this skill's executable mirror of the contract. Your job is the
+judgment part: confirming which route applies and enriching each field's **Description**
+in `DATA-MODEL.md`. Run the script at the points below; do not hand-edit `STATE.md`.
 
 ## How to run
 
@@ -57,15 +59,36 @@ Run the script at the three points below; do not hand-edit `STATE.md` yourself.
 
 2. **Branch on the situation** precheck reported:
    - **CSV available** (`data/` or the demo) → go to step 3 (profile).
-   - **Route 2 only** (`datasources.json` + `.env`, no CSVs) → tell the analyst the
-     published-ds route is detected and its VDS extraction is handled separately; to
-     proceed now under CSV mode they can drop CSV(s) in `data/`. **Stop.**
+   - **Route 2** (`datasources.json` + `.env`, no production CSVs) → go to step 3a (pull).
+     If `datasources.json` is present but `.env` is missing, tell the analyst to copy
+     `scaffold/.env.example` to `.env` and fill in their Tableau connection first.
    - **Nothing** → tell the analyst to either drop CSV(s) in `data/`, or add
      `datasources.json` + `.env` for the published-ds route. To just demo the
      workflow they can re-run `tableau-init` to lay down the `scaffold/sample-data/`
      examples. **Stop.**
 
-3. **Profile.** Generate the field tables from the resolved CSVs:
+3a. **Pull (published-ds route only).** Sample the listed published sources via VDS:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/data.py" pull "<project-dir>"
+   ```
+
+   This signs in with the PAT, and for each source pulls metadata + a capped row sample,
+   writing one `data/<slug>.csv` (slug = lowercased `ds_name`, e.g. `Regional Sales` →
+   `regional_sales.csv`) and a schema-complete `DATA-MODEL.md` (tier
+   `published-ds (VDS query)`, types/descriptions taken from VDS metadata). It also sets
+   `data_mode: published-ds` in `STATE.md`. The row cap is `--row-limit` (default `100`,
+   **silent up to `1000`**); a value **above `1000` is refused** until you confirm the
+   larger sample with the analyst and re-run with `--confirm-large`. `pull` is
+   **non-destructive** (refuses if `DATA-MODEL.md` exists; re-run with `--force` to
+   re-sample). If it prints `[REFUSED]`, relay the actionable reason and **stop** — no
+   artifact is written on failure (sign-in/connection error, the source's **API Access**
+   capability is off, the named source is not a *published* source — it may be
+   **embedded**, in which case export it to CSV and use Route 1 — or the query returned
+   zero rows). On success, go to step 4 (enrich) — there is no separate `profile` step
+   for this route.
+
+3. **Profile (csv route only).** Generate the field tables from the resolved CSVs:
 
    ```bash
    python "${CLAUDE_SKILL_DIR}/data.py" profile "<project-dir>"
@@ -99,11 +122,13 @@ Run the script at the three points below; do not hand-edit `STATE.md` yourself.
 
 ## The DATA-MODEL.md schema
 
-`profile` generates this; the model enriches only the Description (and Role) cells.
+`profile` (csv route) or `pull` (published-ds route) generates this; the model enriches
+the Description (and refines Role) cells. For the published-ds route, Type and any
+Description come pre-filled from authoritative VDS metadata.
 
 ```markdown
 ## Acquisition
-- tier: csv (provided in data/)        # or: csv (demo - scaffold/sample-data/)
+- tier: csv (provided in data/)        # or: csv (demo - scaffold/sample-data/), or: published-ds (VDS query)
 
 ## Data source: `sales_orders.csv`
 - rows profiled: 40

--- a/skills/tableau-data/data.py
+++ b/skills/tableau-data/data.py
@@ -24,18 +24,22 @@ model prose:
    so the pipeline can never silently disagree with changed data.
 
 There are exactly **two** data-acquisition routes (CONTRACT.md §3.2): Route 1 -
-``data_mode: csv`` (the default, implemented here) and Route 2 - ``published-ds``
-(VizQL Data Service). This module implements Route 1 fully and only *detects* Route 2
-inputs (``datasources.json`` + ``.env``), deferring the VDS query itself to the
-published-ds work. There is deliberately **no** synthesized/random data path: the
+``data_mode: csv`` (the default) and Route 2 - ``published-ds`` (VizQL Data Service).
+This module implements **both**: Route 1 by profiling analyst-provided CSVs
+(``profile``), and Route 2 by sampling published sources through the VizQL Data Service
+(``pull``), with the network half delegated to the sibling :mod:`vds` module
+(CONTRACT.md §7). There is deliberately **no** synthesized/random data path: the
 guaranteed floor is the ``scaffold/sample-data/`` demo CSVs (CONTRACT.md §3.1),
 surfaced as a clearly-labelled demo - never invented rows.
 
-The module is intentionally pure and stdlib-only (it does **not** import the router)
-so the contract test can call its functions directly, exactly like ``init.py`` /
-``intake.py``. The CLI exposes three subcommands the skill runs at three moments -
-``precheck`` (before authoring), ``profile`` (generate the field tables), and
-``commit`` (after approval). What the CLI prints to stdout is the program's *output*;
+The module's stdlib-only core (gate, profiling, validation, STATE.md rewriting) is kept
+importable without third-party packages so the contract test can call those functions
+directly, exactly like ``init.py`` / ``intake.py``. The published-ds ``pull`` path needs
+``requests`` (via :mod:`vds`), so :mod:`vds` is imported **locally inside** :func:`pull`
+rather than at module top - importing ``data`` never requires ``requests``. The CLI
+exposes four subcommands the skill runs at four moments - ``precheck`` (before
+authoring), ``profile`` (csv route field tables), ``pull`` (published-ds route sample),
+and ``commit`` (after approval). What the CLI prints to stdout is the program's *output*;
 diagnostics go through ``logging``.
 
 Keep ``STEP_ORDER`` below in lock-step with the ordered step list in CONTRACT.md §1.
@@ -73,10 +77,19 @@ STEP_ORDER: tuple[str, ...] = (
 DATA_DIR = "data"
 SCAFFOLD_DATA_DIR = "scaffold/sample-data"
 
-#: Route 2 (published-ds): the inputs whose presence we *detect* and defer to the
-#: VizQL Data Service work (CONTRACT.md §3.2). Not queried here.
+#: Route 2 (published-ds): the inputs the VDS pull reads (CONTRACT.md §3.2).
 DATASOURCES_FILENAME = "datasources.json"
 ENV_FILENAME = ".env"
+
+#: STATE.md ``data_mode`` metadata values (CONTRACT.md §2). A successful ``pull`` flips
+#: the recorded mode to ``published-ds``; ``profile`` leaves the default ``csv``.
+DATA_MODE_CSV = "csv"
+DATA_MODE_PUBLISHED_DS = "published-ds"
+
+#: Row-limit policy for the VDS sample (CONTRACT.md §3.2): default 100, silent up to
+#: 1000, and a value above 1000 needs explicit analyst confirmation before the pull.
+DEFAULT_ROW_LIMIT = 100
+MAX_SILENT_ROW_LIMIT = 1000
 
 #: The Tableau-friendly column types ``profile`` infers and ``DATA-MODEL.md`` records.
 #: Ordered narrowest-first; that order is the inference precedence in ``infer_type``.
@@ -90,10 +103,11 @@ TYPES: tuple[str, ...] = (
     TYPE_BOOLEAN, TYPE_INTEGER, TYPE_REAL, TYPE_DATE, TYPE_DATETIME, TYPE_STRING,
 )
 
-#: Acquisition tiers recorded in DATA-MODEL.md (CONTRACT.md §3.2). The published-ds
-#: tier is added by the VDS work; csv mode produces one of the two below.
+#: Acquisition tiers recorded in DATA-MODEL.md (CONTRACT.md §3.2). The csv route
+#: produces one of the first two; the published-ds route (``pull``) records the third.
 TIER_CSV_PROVIDED = "csv (provided in data/)"
 TIER_CSV_DEMO = "csv (demo - scaffold/sample-data/)"
+TIER_PUBLISHED_DS = "published-ds (VDS query)"
 
 #: How many data rows ``profile`` reads to infer types and gather sample values.
 PROFILE_SAMPLE_ROWS = 200
@@ -236,12 +250,16 @@ class FieldProfile:
         role: A suggested Tableau role (``Measure`` for numeric, else ``Dimension``);
             a starting point the model may refine.
         samples: A few distinct example values, for the analyst's eyes.
+        description: A field description. Blank (``""``) for the csv route - the model
+            fills it in. For the published-ds route it is pre-filled from authoritative
+            VDS metadata where available (CONTRACT.md §3.2).
     """
 
     name: str
     type: str
     role: str
     samples: list[str]
+    description: str = ""
 
 
 @dataclass(frozen=True)
@@ -338,6 +356,28 @@ def profile_csv(csv_path: Path | str) -> CsvProfile:
 
 # --- DATA-MODEL.md rendering -------------------------------------------------
 
+def _md_table_cell(text: str) -> str:
+    """Make free-text safe for a single GitHub-flavored-markdown table cell.
+
+    Real data (especially VDS field descriptions and sample values) can contain
+    newlines and ``|`` pipes - both of which corrupt a markdown table: a newline splits
+    the row across physical lines, and a pipe is read as a column separator. Newlines
+    (and carriage returns) are collapsed to spaces and pipes are backslash-escaped so
+    the value stays in one cell on one row.
+
+    This is applied to the Sample-values and Description cells only - never to the
+    Field name (which :func:`parse_data_model` reads back and validates against the CSV
+    header verbatim).
+
+    Args:
+        text: The raw cell text.
+
+    Returns:
+        The text rendered safe for one markdown table cell.
+    """
+    return text.replace("\r", " ").replace("\n", " ").replace("|", "\\|").strip()
+
+
 def render_data_model(profiles: list[CsvProfile], tier: str) -> str:
     """Render the DATA-MODEL.md handoff artifact from profiled CSVs.
 
@@ -382,10 +422,11 @@ def render_data_model(profiles: list[CsvProfile], tier: str) -> str:
             "|-------|------|------|---------------|-------------|",
         ]
         for field_profile in profile.fields:
-            samples = ", ".join(field_profile.samples)
+            samples = _md_table_cell(", ".join(field_profile.samples))
+            description = _md_table_cell(field_profile.description)
             lines.append(
                 f"| {field_profile.name} | {field_profile.type} | "
-                f"{field_profile.role} | {samples} |  |"
+                f"{field_profile.role} | {samples} | {description} |"
             )
 
     return "\n".join(lines) + "\n"
@@ -605,6 +646,33 @@ def apply_status_updates(text: str, updates: dict[str, str]) -> str:
 
         out_lines.append(raw_line)
 
+    result = "\n".join(out_lines)
+    if text.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def set_data_mode(text: str, mode: str) -> str:
+    """Rewrite the ``- data_mode: ...`` metadata line in a STATE.md manifest.
+
+    Only the metadata line is touched; any trailing inline comment (e.g.
+    ``# csv | published-ds``) and every other line are preserved. If no ``data_mode``
+    line exists the text is returned unchanged (older manifests stay valid).
+
+    Args:
+        text: The full ``STATE.md`` contents.
+        mode: The new mode to record (e.g. :data:`DATA_MODE_PUBLISHED_DS`).
+
+    Returns:
+        The updated ``STATE.md`` contents (trailing newline preserved).
+    """
+    out_lines: list[str] = []
+    for raw_line in text.splitlines():
+        match = re.match(r"^(\s*-\s*data_mode\s*:\s*)(\S+)(.*)$", raw_line)
+        if match:
+            out_lines.append(f"{match.group(1)}{mode}{match.group(3)}")
+        else:
+            out_lines.append(raw_line)
     result = "\n".join(out_lines)
     if text.endswith("\n"):
         result += "\n"
@@ -982,6 +1050,248 @@ def _format_mismatch_message(mismatches: dict[str, HeaderCheck]) -> str:
     return "\n".join(parts)
 
 
+# --- pull (Route 2: published-ds via VizQL Data Service, CONTRACT.md §3.2) ----
+
+@dataclass
+class PullResult:
+    """Outcome of sampling published sources via VDS into data/ + DATA-MODEL.md.
+
+    Attributes:
+        ok: True when the CSVs and DATA-MODEL.md were written; False when refused or
+            the pull failed (in which case nothing was written - STATE.md untouched).
+        message: Human-readable explanation (the refusal/failure reason when not ``ok``).
+        tier: The acquisition tier recorded, when written (:data:`TIER_PUBLISHED_DS`).
+        written: Base names of the ``data/<slug>.csv`` files written.
+        row_counts: ``{csv_filename: rows_pulled}`` for each written source.
+        row_limit: The row cap applied to the sample.
+    """
+
+    ok: bool
+    message: str
+    tier: Optional[str] = None
+    written: list[str] = field(default_factory=list)
+    row_counts: dict[str, int] = field(default_factory=dict)
+    row_limit: int = 0
+
+
+def _csv_cell(value) -> str:
+    """Serialize a VDS cell value for the pulled CSV.
+
+    Booleans are lower-cased (``true``/``false``) so the written CSV round-trips through
+    type inference consistently; ``None`` becomes empty; everything else is ``str()``.
+
+    Args:
+        value: A JSON value from a VDS query row.
+
+    Returns:
+        The cell's string form for the CSV.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _profile_pulled_source(slug: str, fields, rows: list[dict]) -> CsvProfile:
+    """Build a :class:`CsvProfile` from VDS metadata + sampled rows.
+
+    Types and descriptions come from the authoritative VDS metadata (CONTRACT.md §3.2);
+    only the sample values are derived from the pulled rows. The result renders through
+    the same :func:`render_data_model` the csv route uses.
+
+    Args:
+        slug: The data-source slug (the CSV base name without extension).
+        fields: The ``vds.FieldMeta`` list for this source (metadata order).
+        rows: The sampled rows (dicts keyed by field caption).
+
+    Returns:
+        A :class:`CsvProfile` for the source.
+    """
+    field_profiles: list[FieldProfile] = []
+    for meta in fields:
+        column = [_csv_cell(row.get(meta.caption)) for row in rows]
+        field_profiles.append(FieldProfile(
+            name=meta.caption,
+            type=meta.model_type,
+            role=_suggest_role(meta.model_type),
+            samples=_distinct_samples(column, SAMPLE_VALUES_SHOWN),
+            description=meta.description,
+        ))
+    return CsvProfile(filename=f"{slug}.csv", row_count=len(rows), fields=field_profiles)
+
+
+def _write_pulled_csv(csv_path: Path, captions: list[str], rows: list[dict]) -> None:
+    """Write a pulled sample to ``data/<slug>.csv`` (headers = field captions).
+
+    Args:
+        csv_path: Destination path (its parent ``data/`` is created if needed).
+        captions: The field captions, in metadata order (the CSV header).
+        rows: The sampled rows (dicts keyed by caption).
+    """
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(captions)
+        for row in rows:
+            writer.writerow([_csv_cell(row.get(caption)) for caption in captions])
+
+
+def pull(project_dir: Path | str, row_limit: int = DEFAULT_ROW_LIMIT,
+         confirm_large: bool = False, force: bool = False, session=None) -> PullResult:
+    """Sample published data sources via the VizQL Data Service (CONTRACT.md §3.2).
+
+    Route 2 of the two acquisition routes. Reads ``datasources.json`` + the nearest
+    ``.env``, signs in with a Personal Access Token, and for each listed source pulls a
+    capped sample through VDS (``read-metadata`` then ``query-datasource``). On full
+    success it writes one ``data/<slug>.csv`` per source and a ``DATA-MODEL.md`` whose
+    types/descriptions come from the authoritative VDS metadata, and records
+    ``data_mode: published-ds`` in STATE.md.
+
+    The pull is **atomic**: every network call runs before any file is written, so a
+    failure on any source leaves ``data/``, ``DATA-MODEL.md``, and STATE.md untouched -
+    there is no partial or synthesized fallback (CONTRACT.md §3.2).
+
+    Args:
+        project_dir: The analyst's project directory.
+        row_limit: Rows to cap the sample at (default 100, silent up to 1000).
+        confirm_large: Required to be True when ``row_limit`` exceeds 1000.
+        force: Re-pull over a prior pull's output - overwrites an existing DATA-MODEL.md
+            and re-samples the CSVs. It will **not** overwrite an analyst's own dropped
+            CSVs (only data/ that a prior published-ds pull wrote, identified by tier).
+        session: An HTTP session to use (injected by tests); a real one is created
+            when ``None``.
+
+    Returns:
+        A :class:`PullResult`. ``ok`` is False (nothing written) when the gate is
+        closed, production CSVs already exist (that is Route 1), DATA-MODEL.md exists
+        without ``force``, the row limit is too large unconfirmed, or any VDS call fails.
+    """
+    project_root = Path(project_dir)
+    data_model_path = project_root / DATA_MODEL_FILENAME
+
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return PullResult(False, blocker)
+
+    # Real CSVs in data/ always win (CONTRACT.md §3.1/§3.2) - that is the csv route.
+    # The one exception: --force re-pulls over data/ that a *prior published-ds pull*
+    # wrote (identified by the recorded tier), so re-pulling never clobbers an analyst's
+    # own dropped CSVs.
+    source, _csv_paths = resolve_csv_source(project_root)
+    if source == "data":
+        prior_tier = (
+            parse_acquisition_tier(data_model_path.read_text(encoding="utf-8-sig"))
+            if data_model_path.exists() else None
+        )
+        from_prior_pull = force and prior_tier == TIER_PUBLISHED_DS
+        if not from_prior_pull:
+            hint = (
+                "Run 'profile' instead"
+                if prior_tier != TIER_PUBLISHED_DS
+                else "re-run with '--force' to re-pull over them"
+            )
+            return PullResult(
+                False,
+                f"Production CSV(s) already exist in 'data/' - that is the csv route "
+                f"(Route 1). {hint}. The published-ds pull only fills an empty data/ "
+                f"(or re-pulls its own prior output with --force).",
+            )
+
+    if not (project_root / DATASOURCES_FILENAME).exists():
+        return PullResult(
+            False,
+            f"No '{DATASOURCES_FILENAME}' found. The published-ds route needs it (one "
+            f"entry per published source); copy scaffold/EXAMPLE-datasources.json to the "
+            f"project root, or drop CSV(s) in data/ for the csv route.",
+        )
+
+    if data_model_path.exists() and not force:
+        return PullResult(
+            False,
+            f"'{DATA_MODEL_FILENAME}' already exists. Edit it in place to refine, or "
+            f"re-run 'pull --force' to re-sample from VDS (this overwrites the pulled "
+            f"CSVs and discards prior field descriptions).",
+        )
+
+    if row_limit > MAX_SILENT_ROW_LIMIT and not confirm_large:
+        return PullResult(
+            False,
+            f"row_limit {row_limit} exceeds {MAX_SILENT_ROW_LIMIT}. Confirm the larger "
+            f"sample with the analyst, then re-run 'pull --row-limit {row_limit} "
+            f"--confirm-large' (CONTRACT.md §3.2).",
+            row_limit=row_limit,
+        )
+
+    # The network half lives in vds (requests-backed); import it lazily so importing
+    # 'data' never requires requests (the stdlib-only contract test imports 'data').
+    import vds
+
+    if session is None:
+        session = vds.make_session()
+
+    try:
+        refs = vds.parse_datasources_json(project_root / DATASOURCES_FILENAME)
+        conn = vds.load_connection(project_root)
+        token, site_id = vds.sign_in(conn, session)
+
+        # Pull everything into memory first; only write once all sources succeed.
+        pulled: list[tuple[str, list, list[dict]]] = []
+        slug_owner: dict[str, str] = {}
+        for ref in refs:
+            slug = vds.slugify(ref.ds_name)
+            if slug in slug_owner:
+                raise vds.VdsError(
+                    f"Data sources '{slug_owner[slug]}' and '{ref.ds_name}' both map to "
+                    f"'{slug}.csv'. Rename one source so each gets a distinct CSV."
+                )
+            slug_owner[slug] = ref.ds_name
+            luid = vds.resolve_luid(
+                conn, token, site_id, ref.ds_name, ref.project_name, session
+            )
+            fields = vds.read_metadata(conn, token, luid, session)
+            rows = vds.query_rows(
+                conn, token, luid, [meta.caption for meta in fields], row_limit, session
+            )
+            pulled.append((slug, fields, rows))
+    except vds.VdsError as error:
+        logger.error(f"Published-ds pull failed: {error}")
+        return PullResult(False, str(error), row_limit=row_limit)
+
+    # All sources succeeded - write the CSVs and DATA-MODEL.md, then flip data_mode.
+    profiles: list[CsvProfile] = []
+    row_counts: dict[str, int] = {}
+    for slug, fields, rows in pulled:
+        csv_path = project_root / DATA_DIR / f"{slug}.csv"
+        _write_pulled_csv(csv_path, [meta.caption for meta in fields], rows)
+        profiles.append(_profile_pulled_source(slug, fields, rows))
+        row_counts[f"{slug}.csv"] = len(rows)
+
+    data_model_path.write_text(
+        render_data_model(profiles, TIER_PUBLISHED_DS), encoding="utf-8"
+    )
+
+    state_path = project_root / STATE_FILENAME
+    state_path.write_text(
+        set_data_mode(state_path.read_text(encoding="utf-8-sig"), DATA_MODE_PUBLISHED_DS),
+        encoding="utf-8",
+    )
+
+    written = [profile.filename for profile in profiles]
+    logger.info(
+        f"Pulled {len(written)} published source(s) via VDS (rowLimit={row_limit}); "
+        f"wrote {DATA_MODEL_FILENAME} and set data_mode=published-ds."
+    )
+    return PullResult(
+        ok=True,
+        message=f"pulled {len(written)} published source(s) via VDS",
+        tier=TIER_PUBLISHED_DS,
+        written=written,
+        row_counts=row_counts,
+        row_limit=row_limit,
+    )
+
+
 # --- CLI ---------------------------------------------------------------------
 
 def format_precheck(result: PrecheckResult) -> str:
@@ -1025,8 +1335,14 @@ def format_precheck(result: PrecheckResult) -> str:
         lines.append("  -> Route 1 (CSV). Run 'profile' to write DATA-MODEL.md, then enrich + commit.")
     elif result.has_datasources_json and result.has_env:
         lines.append(
-            "  -> Route 2 (published-ds) detected. VDS extraction lands in the "
-            "published-ds work; not run here. Provide CSVs in data/ to use Route 1 now."
+            "  -> Route 2 (published-ds) detected. Run 'pull' to sample each source via "
+            "the VizQL Data Service into data/ + DATA-MODEL.md, then enrich + commit. "
+            "(Drop CSVs in data/ instead to use Route 1.)"
+        )
+    elif result.has_datasources_json:
+        lines.append(
+            "  -> Route 2 (published-ds) inputs incomplete: datasources.json present but "
+            "no .env creds. Copy scaffold/.env.example to .env and fill it, then 'pull'."
         )
     else:
         action = "  -> No data available. Either drop CSV(s) in data/, or add datasources.json + .env "
@@ -1067,6 +1383,33 @@ def format_profile(result: ProfileResult) -> str:
     return "\n".join(lines)
 
 
+def format_pull(result: PullResult) -> str:
+    """Render a :class:`PullResult` as a human-readable block.
+
+    Args:
+        result: The pull result to render.
+
+    Returns:
+        A multi-line, plain-ASCII string suitable for printing to the analyst.
+    """
+    if not result.ok:
+        return f"[REFUSED] {result.message}"
+
+    lines = [f"[DATA] {result.message}."]
+    lines.append(f"  tier          : {result.tier}")
+    lines.append(f"  row limit     : {result.row_limit}")
+    sources = ", ".join(
+        f"{name} ({result.row_counts.get(name, 0)} rows)" for name in result.written
+    )
+    lines.append(f"  data sources  : {sources}")
+    lines.append("  data_mode set to 'published-ds' in STATE.md.")
+    lines.append(
+        "  next: enrich/refine each field's Description in DATA-MODEL.md (types and any "
+        "VDS descriptions are pre-filled), present it for approval, then run 'commit'."
+    )
+    return "\n".join(lines)
+
+
 def format_commit(result: CommitResult) -> str:
     """Render a :class:`CommitResult` as a human-readable block.
 
@@ -1092,7 +1435,7 @@ def format_commit(result: CommitResult) -> str:
 
 
 def main(argv: Optional[list[str]] = None) -> int:
-    """CLI entry point: run ``precheck``, ``profile``, or ``commit``.
+    """CLI entry point: run ``precheck``, ``profile``, ``pull``, or ``commit``.
 
     Args:
         argv: Argument list (defaults to ``sys.argv[1:]``).
@@ -1104,7 +1447,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     import sys
 
     parser = argparse.ArgumentParser(
-        description="Gate, profile, validate, and commit the tableau-data step.",
+        description="Gate, profile, pull, validate, and commit the tableau-data step.",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -1116,7 +1459,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
 
     profile_parser = subparsers.add_parser(
-        "profile", help="Profile the resolved CSVs into DATA-MODEL.md."
+        "profile", help="Profile the resolved CSVs into DATA-MODEL.md (csv route)."
     )
     profile_parser.add_argument(
         "project_dir", nargs="?", default=".", help="Project directory (default: cwd)."
@@ -1124,6 +1467,27 @@ def main(argv: Optional[list[str]] = None) -> int:
     profile_parser.add_argument(
         "--force", action="store_true",
         help="Overwrite an existing DATA-MODEL.md (discards prior descriptions).",
+    )
+
+    pull_parser = subparsers.add_parser(
+        "pull",
+        help="Sample published sources via the VizQL Data Service (published-ds route).",
+    )
+    pull_parser.add_argument(
+        "project_dir", nargs="?", default=".", help="Project directory (default: cwd)."
+    )
+    pull_parser.add_argument(
+        "--row-limit", type=int, default=DEFAULT_ROW_LIMIT,
+        help=f"Max rows to sample per source (default {DEFAULT_ROW_LIMIT}; silent up to "
+             f"{MAX_SILENT_ROW_LIMIT}).",
+    )
+    pull_parser.add_argument(
+        "--confirm-large", action="store_true",
+        help=f"Required when --row-limit exceeds {MAX_SILENT_ROW_LIMIT} (analyst-confirmed).",
+    )
+    pull_parser.add_argument(
+        "--force", action="store_true",
+        help="Overwrite an existing DATA-MODEL.md and re-sample the CSVs from VDS.",
     )
 
     commit_parser = subparsers.add_parser(
@@ -1144,6 +1508,16 @@ def main(argv: Optional[list[str]] = None) -> int:
         profile_result = profile(args.project_dir, force=args.force)
         print(format_profile(profile_result))
         return 0 if profile_result.ok else 2
+
+    if args.command == "pull":
+        pull_result = pull(
+            args.project_dir,
+            row_limit=args.row_limit,
+            confirm_large=args.confirm_large,
+            force=args.force,
+        )
+        print(format_pull(pull_result))
+        return 0 if pull_result.ok else 2
 
     commit_result = commit(args.project_dir)
     print(format_commit(commit_result))

--- a/skills/tableau-data/vds.py
+++ b/skills/tableau-data/vds.py
@@ -1,0 +1,577 @@
+"""VizQL Data Service (VDS) client for the ``tableau-data`` published-ds route.
+
+This module is the network half of ``tableau-data`` Route 2 (CONTRACT.md §3.2): it
+samples *published* Tableau data sources through Tableau's official VizQL Data Service
+and hands the result back to ``data.py``, which turns it into ``data/<slug>.csv`` files
+and ``DATA-MODEL.md``. It deliberately owns **only** the network concerns
+(authentication, LUID resolution, the two VDS calls); the orchestration, file writing,
+and STATE.md transition live in ``data.py`` (CONTRACT.md §7 — each skill owns its own
+VDS client).
+
+The contract pins the shape of the work, and this module implements exactly that and
+nothing more:
+
+1. **PAT sign-in** — a Tableau REST Personal Access Token sign-in
+   (``POST /api/<ver>/auth/signin``) returns a credentials token reused for VDS.
+2. **LUID resolution** — ``datasources.json`` names sources by ``(ds_name,
+   project_name)``; VDS addresses them by ``datasourceLuid``, so we look the LUID up via
+   the REST ``Query Data Sources`` endpoint.
+3. **``read-metadata``** — ``POST /api/v1/vizql-data-service/read-metadata`` returns the
+   queryable fields (caption, type, description). These are *authoritative*: the pulled
+   CSV schema and ``DATA-MODEL.md`` take their types/descriptions from here.
+4. **``query-datasource``** — ``POST /api/v1/vizql-data-service/query-datasource`` pulls
+   a capped sample of all queryable fields.
+
+There is **no** extract download, GraphQL, embedded-source reading, or synthesized data
+(CONTRACT.md §3.2). VDS requires **Tableau Cloud, or Tableau Server 2025.1+**, and the
+data source must have the **API Access** capability enabled.
+
+Every HTTP function takes an injectable ``session`` (a ``requests.Session``) so the
+contract tests can drive the client with a fake transport and never touch the network.
+Failures raise :class:`VdsError` with an analyst-actionable message; ``data.py`` relays
+it and writes no artifact.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# --- Canonical constants (mirror of CONTRACT.md §3.2 and scaffold/.env.example) ---
+
+#: Default Tableau REST API version when ``.env`` does not pin one. 3.24 ships with the
+#: 2025.1 server family that first carries VDS on Server; Cloud tracks the latest.
+DEFAULT_API_VERSION = "3.24"
+
+#: ``.env`` keys read for the connection (see scaffold/.env.example).
+ENV_SERVER = "TABLEAU_SERVER"
+ENV_SITE = "TABLEAU_SITE"
+ENV_API_VERSION = "TABLEAU_API_VERSION"
+ENV_PAT_NAME = "TABLEAU_PAT_NAME"
+ENV_PAT_SECRET = "TABLEAU_PAT_SECRET"
+
+#: The VDS field ``dataType`` values mapped onto data.py's TYPES vocabulary. Anything
+#: not listed (e.g. ``SPATIAL``) falls back to ``string`` — it is still queryable, we
+#: just document it as text.
+_VDS_TYPE_MAP = {
+    "STRING": "string",
+    "INTEGER": "integer",
+    "REAL": "real",
+    "DATE": "date",
+    "DATETIME": "datetime",
+    "BOOLEAN": "boolean",
+}
+_FALLBACK_MODEL_TYPE = "string"
+
+#: VDS endpoints are versioned under a fixed ``/api/v1/`` path, independent of the REST
+#: API version used for sign-in / LUID lookup.
+_VDS_BASE_PATH = "/api/v1/vizql-data-service"
+
+#: A short network timeout (connect, read) so a hung site fails fast with a clear error.
+_HTTP_TIMEOUT = (10, 60)
+
+
+class VdsError(Exception):
+    """A published-ds pull failure with an analyst-actionable message.
+
+    Raised for every failure mode CONTRACT.md §3.2 enumerates — sign-in/connection
+    failure, the source not resolving as a *published* source, the **API Access**
+    capability being off, or a query returning no rows. ``data.py`` catches it, relays
+    ``str(error)``, and writes no artifact (STATE.md untouched).
+    """
+
+
+# --- Connection config (.env) ------------------------------------------------
+
+@dataclass(frozen=True)
+class TableauConnection:
+    """A resolved Tableau connection read from the nearest ``.env``.
+
+    Attributes:
+        server: Base server / pod URL, e.g. ``https://10ax.online.tableau.com`` (no
+            trailing slash).
+        site: The site *content URL* (the token in the site's URL); empty string for
+            the default site.
+        api_version: The REST API version for sign-in and LUID lookup (e.g. ``3.24``).
+        pat_name: Personal Access Token name.
+        pat_secret: Personal Access Token secret.
+    """
+
+    server: str
+    site: str
+    api_version: str
+    pat_name: str
+    pat_secret: str
+
+    def rest_url(self, path: str) -> str:
+        """str: Build a versioned REST URL, e.g. ``…/api/3.24/auth/signin``."""
+        return f"{self.server}/api/{self.api_version}{path}"
+
+    def vds_url(self, endpoint: str) -> str:
+        """str: Build a VDS URL, e.g. ``…/api/v1/vizql-data-service/read-metadata``."""
+        return f"{self.server}{_VDS_BASE_PATH}/{endpoint}"
+
+
+def find_env(project_root: Path | str) -> Optional[Path]:
+    """Find the nearest ``.env`` by walking up from the project directory.
+
+    The nearest file wins (CONTRACT.md §3.2): the project directory is checked first,
+    then each ancestor up to the filesystem root.
+
+    Args:
+        project_root: The analyst's project directory.
+
+    Returns:
+        The path to the closest ``.env``, or ``None`` if none exists on the way up.
+    """
+    start = Path(project_root).resolve()
+    for directory in (start, *start.parents):
+        candidate = directory / ".env"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def load_connection(project_root: Path | str) -> TableauConnection:
+    """Load and validate the Tableau connection from the nearest ``.env``.
+
+    Uses ``python-dotenv`` (already a shared dependency) to read the ``.env`` without
+    mutating ``os.environ``. The site content URL is optional (empty = default site)
+    and the API version defaults to :data:`DEFAULT_API_VERSION`; everything else is
+    required.
+
+    Args:
+        project_root: The analyst's project directory (the search starts here).
+
+    Returns:
+        A validated :class:`TableauConnection`.
+
+    Raises:
+        VdsError: If no ``.env`` is found, or a required variable is missing/blank.
+    """
+    from dotenv import dotenv_values  # local import: only the published-ds route needs it
+
+    env_path = find_env(project_root)
+    if env_path is None:
+        raise VdsError(
+            "No .env found walking up from the project directory. The published-ds "
+            "route needs Tableau credentials: copy scaffold/.env.example to .env at the "
+            "project root and fill in your TABLEAU_* connection."
+        )
+
+    values = dotenv_values(env_path)
+    logger.info(f"Loaded Tableau connection from {env_path}.")
+
+    def _required(key: str) -> str:
+        value = (values.get(key) or "").strip()
+        if not value:
+            raise VdsError(
+                f"Required variable '{key}' is missing or blank in {env_path}. "
+                f"See scaffold/.env.example for the full published-ds connection."
+            )
+        return value
+
+    server = _required(ENV_SERVER).rstrip("/")
+    return TableauConnection(
+        server=server,
+        site=(values.get(ENV_SITE) or "").strip(),
+        api_version=(values.get(ENV_API_VERSION) or "").strip() or DEFAULT_API_VERSION,
+        pat_name=_required(ENV_PAT_NAME),
+        pat_secret=_required(ENV_PAT_SECRET),
+    )
+
+
+# --- datasources.json --------------------------------------------------------
+
+@dataclass(frozen=True)
+class DatasourceRef:
+    """One published data source the analyst asked to sample.
+
+    Attributes:
+        key: The entry id in ``datasources.json`` (e.g. ``ds_1``); used only for
+            error messages.
+        ds_name: The published data source's name on the site.
+        project_name: The Tableau project the source lives in; with ``ds_name`` it
+            identifies the source uniquely.
+    """
+
+    key: str
+    ds_name: str
+    project_name: str
+
+
+def parse_datasources_json(path: Path | str) -> list[DatasourceRef]:
+    """Parse ``datasources.json`` into an ordered list of data-source references.
+
+    Keys starting with ``_`` are ignored (they are comments, e.g. ``_comment`` in the
+    scaffold example). Each remaining entry must carry both ``ds_name`` and
+    ``project_name`` (CONTRACT.md §3.2).
+
+    Args:
+        path: Path to ``datasources.json``.
+
+    Returns:
+        The referenced sources in file order.
+
+    Raises:
+        VdsError: If the file is missing, not valid JSON, has no usable entries, or an
+            entry omits ``ds_name`` / ``project_name``.
+    """
+    json_path = Path(path)
+    if not json_path.is_file():
+        raise VdsError(f"datasources.json not found at {json_path}.")
+
+    try:
+        raw = json.loads(json_path.read_text(encoding="utf-8-sig"))
+    except json.JSONDecodeError as error:
+        raise VdsError(f"datasources.json is not valid JSON: {error}.")
+    if not isinstance(raw, dict):
+        raise VdsError("datasources.json must be a JSON object keyed by data-source id.")
+
+    refs: list[DatasourceRef] = []
+    for key, entry in raw.items():
+        if key.startswith("_"):
+            continue
+        if not isinstance(entry, dict):
+            raise VdsError(f"datasources.json entry '{key}' must be an object.")
+        ds_name = (entry.get("ds_name") or "").strip()
+        project_name = (entry.get("project_name") or "").strip()
+        if not ds_name or not project_name:
+            raise VdsError(
+                f"datasources.json entry '{key}' must have both 'ds_name' and "
+                f"'project_name' (one published source per entry)."
+            )
+        refs.append(DatasourceRef(key=key, ds_name=ds_name, project_name=project_name))
+
+    if not refs:
+        raise VdsError(
+            "datasources.json lists no data sources (only comment keys). Add one entry "
+            "per published source: {\"ds_1\": {\"ds_name\": ..., \"project_name\": ...}}."
+        )
+    return refs
+
+
+# --- Slug / type helpers -----------------------------------------------------
+
+def slugify(ds_name: str) -> str:
+    """Turn a data-source name into the ``data/<slug>.csv`` base name (CONTRACT.md §3.2).
+
+    Lowercases, collapses every run of non-alphanumeric characters to a single ``_``,
+    and strips leading/trailing underscores. ``"Regional Sales"`` -> ``"regional_sales"``.
+
+    Args:
+        ds_name: The published data source's name.
+
+    Returns:
+        A filesystem-safe slug (without the ``.csv`` extension).
+
+    Raises:
+        VdsError: If the name has no alphanumeric characters to slugify.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "_", ds_name.lower()).strip("_")
+    if not slug:
+        raise VdsError(
+            f"Data source name '{ds_name}' has no alphanumeric characters to build a "
+            f"CSV filename from."
+        )
+    return slug
+
+
+def vds_type_to_model_type(vds_data_type: str) -> str:
+    """Map a VDS field ``dataType`` to data.py's TYPES vocabulary (default ``string``).
+
+    Args:
+        vds_data_type: The ``dataType`` from VDS metadata (e.g. ``"INTEGER"``).
+
+    Returns:
+        One of data.py's TYPES; ``"string"`` for any unrecognized VDS type.
+    """
+    return _VDS_TYPE_MAP.get((vds_data_type or "").upper(), _FALLBACK_MODEL_TYPE)
+
+
+# --- Metadata field shape ----------------------------------------------------
+
+@dataclass(frozen=True)
+class FieldMeta:
+    """One queryable field as reported by VDS ``read-metadata``.
+
+    Attributes:
+        caption: The field caption (``fieldCaption``) — the header used in the pulled
+            CSV and the query body. Authoritative field name.
+        model_type: The VDS ``dataType`` mapped onto data.py's TYPES.
+        description: The field description from metadata (``""`` when VDS gives none;
+            the model fills these in afterward, as for the csv route).
+    """
+
+    caption: str
+    model_type: str
+    description: str
+
+
+# --- HTTP helpers ------------------------------------------------------------
+
+def _post_json(session: requests.Session, url: str, *, headers: dict, payload: dict,
+               what: str) -> dict:
+    """POST JSON and return the decoded body, mapping any failure to :class:`VdsError`.
+
+    Args:
+        session: The HTTP session (injectable for tests).
+        url: The absolute URL to POST to.
+        headers: Request headers.
+        payload: The JSON request body.
+        what: A short description of the call for error messages (e.g. ``"sign-in"``).
+
+    Returns:
+        The decoded JSON response body.
+
+    Raises:
+        VdsError: On a connection error, a non-2xx status, or a non-JSON body.
+    """
+    try:
+        response = session.post(url, json=payload, headers=headers, timeout=_HTTP_TIMEOUT)
+    except requests.RequestException as error:
+        raise VdsError(f"{what} failed to reach {url}: {error}.")
+    return _decode(response, what)
+
+
+def _decode(response: requests.Response, what: str) -> dict:
+    """Validate an HTTP status and decode a JSON body, raising :class:`VdsError`.
+
+    Args:
+        response: The HTTP response to validate.
+        what: A short description of the call for error messages.
+
+    Returns:
+        The decoded JSON response body.
+
+    Raises:
+        VdsError: On a non-2xx status (with the server's message) or a non-JSON body.
+    """
+    if not response.ok:
+        raise VdsError(
+            f"{what} returned HTTP {response.status_code}: "
+            f"{response.text.strip()[:500] or '(no body)'}."
+        )
+    try:
+        return response.json()
+    except ValueError:
+        raise VdsError(f"{what} returned a non-JSON response: {response.text[:200]!r}.")
+
+
+def make_session() -> requests.Session:
+    """requests.Session: A fresh HTTP session for a pull (factory, for easy mocking)."""
+    return requests.Session()
+
+
+# --- Sign-in -----------------------------------------------------------------
+
+def sign_in(conn: TableauConnection, session: requests.Session) -> tuple[str, str]:
+    """Sign in with the Personal Access Token and return ``(auth_token, site_id)``.
+
+    The credentials token returned here is reused for both the LUID lookup and the VDS
+    calls via the ``X-Tableau-Auth`` header (CONTRACT.md §3.2).
+
+    Args:
+        conn: The resolved Tableau connection.
+        session: The HTTP session (injectable for tests).
+
+    Returns:
+        A ``(auth_token, site_id)`` tuple.
+
+    Raises:
+        VdsError: On a connection failure, bad credentials, or an unexpected response
+            shape (e.g. a wrong server URL or a PAT that has been revoked).
+    """
+    payload = {
+        "credentials": {
+            "personalAccessTokenName": conn.pat_name,
+            "personalAccessTokenSecret": conn.pat_secret,
+            "site": {"contentUrl": conn.site},
+        }
+    }
+    body = _post_json(
+        session,
+        conn.rest_url("/auth/signin"),
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        payload=payload,
+        what="Tableau sign-in",
+    )
+    credentials = body.get("credentials", {})
+    token = credentials.get("token")
+    site_id = credentials.get("site", {}).get("id")
+    if not token or not site_id:
+        raise VdsError(
+            "Tableau sign-in succeeded but returned no token/site id. Check "
+            "TABLEAU_SERVER, TABLEAU_SITE, and the PAT name/secret in your .env."
+        )
+    logger.info(f"Signed in to {conn.server} (site id {site_id}).")
+    return token, site_id
+
+
+def _auth_headers(token: str) -> dict:
+    """dict: The headers carrying the credentials token for REST + VDS calls."""
+    return {
+        "X-Tableau-Auth": token,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+# --- LUID resolution ---------------------------------------------------------
+
+def resolve_luid(conn: TableauConnection, token: str, site_id: str,
+                 ds_name: str, project_name: str, session: requests.Session) -> str:
+    """Resolve a published source's LUID from its ``(ds_name, project_name)``.
+
+    Queries the REST ``Query Data Sources`` endpoint filtered by name, then matches the
+    project. A source that does not resolve is most often **embedded** (VDS cannot see
+    embedded sources) or simply absent, so the error steers the analyst to export the
+    data to CSV and use Route 1 instead (CONTRACT.md §3.2).
+
+    Args:
+        conn: The resolved Tableau connection.
+        token: The credentials token from :func:`sign_in`.
+        site_id: The site id from :func:`sign_in`.
+        ds_name: The published data source's name.
+        project_name: The project the source should live in.
+        session: The HTTP session (injectable for tests).
+
+    Returns:
+        The data source's LUID (its REST ``id``).
+
+    Raises:
+        VdsError: On a request failure, or when no published source matches both the
+            name and the project.
+    """
+    # Server-side name filter narrows the result; we still match the project ourselves
+    # because (name, project) is what makes the source unique.
+    url = conn.rest_url(f"/sites/{site_id}/datasources")
+    params = {"filter": f"name:eq:{ds_name}", "pageSize": "100"}
+    try:
+        response = session.get(url, params=params, headers=_auth_headers(token),
+                               timeout=_HTTP_TIMEOUT)
+    except requests.RequestException as error:
+        raise VdsError(f"Querying data sources failed to reach {url}: {error}.")
+    body = _decode(response, "Query Data Sources")
+
+    candidates = body.get("datasources", {}).get("datasource", [])
+    for candidate in candidates:
+        if candidate.get("name") == ds_name and \
+                candidate.get("project", {}).get("name") == project_name:
+            luid = candidate.get("id")
+            if not luid:
+                break
+            logger.info(f"Resolved '{ds_name}' in '{project_name}' to LUID {luid}.")
+            return luid
+
+    raise VdsError(
+        f"No PUBLISHED data source named '{ds_name}' in project '{project_name}' "
+        f"resolved on this site. Check the name/project, or note that VDS sees "
+        f"PUBLISHED sources only — if this is an EMBEDDED source (bundled inside a "
+        f"workbook) it cannot be queried; export the data to CSV from Tableau and drop "
+        f"the CSV(s) in data/ to use the csv route instead."
+    )
+
+
+# --- VDS calls ---------------------------------------------------------------
+
+def read_metadata(conn: TableauConnection, token: str, luid: str,
+                  session: requests.Session) -> list[FieldMeta]:
+    """Read the queryable fields of a data source via VDS ``read-metadata``.
+
+    The returned fields are authoritative for names, types, and descriptions
+    (CONTRACT.md §3.2). Only these queryable fields are pulled; hidden / non-queryable
+    fields are absent here and therefore skipped downstream.
+
+    Args:
+        conn: The resolved Tableau connection.
+        token: The credentials token from :func:`sign_in`.
+        luid: The data source LUID from :func:`resolve_luid`.
+        session: The HTTP session (injectable for tests).
+
+    Returns:
+        One :class:`FieldMeta` per queryable field, in metadata order.
+
+    Raises:
+        VdsError: On a request failure, or when metadata reports no queryable fields
+            (commonly the source's **API Access** capability is off).
+    """
+    body = _post_json(
+        session,
+        conn.vds_url("read-metadata"),
+        headers=_auth_headers(token),
+        payload={"datasource": {"datasourceLuid": luid}},
+        what="VDS read-metadata",
+    )
+    raw_fields = body.get("data", [])
+    fields: list[FieldMeta] = []
+    for raw in raw_fields:
+        caption = (raw.get("fieldCaption") or "").strip()
+        if not caption:
+            continue  # a field with no caption cannot be queried or used as a header
+        fields.append(FieldMeta(
+            caption=caption,
+            model_type=vds_type_to_model_type(raw.get("dataType", "")),
+            description=(raw.get("description") or "").strip(),
+        ))
+
+    if not fields:
+        raise VdsError(
+            f"VDS read-metadata returned no queryable fields for LUID {luid}. Enable the "
+            f"data source's 'API Access' capability in Tableau (required for VDS), then "
+            f"re-run."
+        )
+    return fields
+
+
+def query_rows(conn: TableauConnection, token: str, luid: str,
+               field_captions: list[str], row_limit: int,
+               session: requests.Session) -> list[dict]:
+    """Pull a capped sample of the given fields via VDS ``query-datasource``.
+
+    Sends exactly the body CONTRACT.md §3.2 specifies. ``row_limit`` caps the rows
+    returned to us, not what VDS reads from the underlying source.
+
+    Args:
+        conn: The resolved Tableau connection.
+        token: The credentials token from :func:`sign_in`.
+        luid: The data source LUID from :func:`resolve_luid`.
+        field_captions: The captions to pull (all queryable fields, from metadata).
+        row_limit: The maximum number of rows to return.
+        session: The HTTP session (injectable for tests).
+
+    Returns:
+        The sampled rows as dicts keyed by field caption.
+
+    Raises:
+        VdsError: On a request failure, or when the query returns zero rows (no silent
+            fallback — the analyst fixes the source or uses Route 1).
+    """
+    payload = {
+        "datasource": {"datasourceLuid": luid},
+        "query": {"fields": [{"fieldCaption": caption} for caption in field_captions]},
+        "options": {"rowLimit": row_limit},
+    }
+    body = _post_json(
+        session,
+        conn.vds_url("query-datasource"),
+        headers=_auth_headers(token),
+        payload=payload,
+        what="VDS query-datasource",
+    )
+    rows = body.get("data", [])
+    if not rows:
+        raise VdsError(
+            f"VDS query-datasource returned zero rows for LUID {luid}. The source may be "
+            f"empty or filtered to nothing; there is no synthesized-data fallback "
+            f"(CONTRACT.md §3.2)."
+        )
+    return rows

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -25,6 +25,7 @@ import pytest
 import data   # the skill under test (on sys.path via conftest.py)
 import init   # builds a realistic STATE.md the same way a real project would
 import route  # the router parses/routes the STATE.md data writes
+from tests.test_vds import FakeSession, _datasources_payload  # shared fake VDS transport
 
 TARGET_VERSION = "2024.2-2025.x"
 
@@ -164,6 +165,35 @@ def test_render_then_parse_recovers_fields(tmp_path):
     assert by_name["order_date"] == data.TYPE_DATE
     assert by_name["is_paid"] == data.TYPE_BOOLEAN
     assert data.parse_acquisition_tier(text) == data.TIER_CSV_PROVIDED
+
+
+def test_render_sanitizes_newlines_and_pipes_in_cells():
+    """Newlines/pipes in samples or descriptions stay in one table row/cell.
+
+    Real VDS data can carry both (e.g. a multi-line field description, or pipe-laden
+    category values). They must not corrupt the markdown table, and the field name +
+    type must still round-trip through parse_data_model.
+    """
+    messy = data.CsvProfile(filename="messy.csv", row_count=1, fields=[
+        data.FieldProfile(
+            name="Category", type="string", role="Dimension",
+            samples=["Electronics|Audio|Headphones", "Home|Kitchen"],
+            description="The product's rating (e.g. 4.2).\nNote: aggregate, not per-row.",
+        ),
+    ])
+
+    text = data.render_data_model([messy], data.TIER_PUBLISHED_DS)
+
+    # Exactly one physical line carries the Category row (no split on the newline).
+    category_rows = [ln for ln in text.splitlines() if ln.startswith("| Category |")]
+    assert len(category_rows) == 1
+    row = category_rows[0]
+    assert "\n" not in row and "Note: aggregate" in row   # description folded onto one line
+    assert "Electronics\\|Audio" in row                    # data pipes escaped, not bare
+
+    # Field name + type still recover cleanly for header validation.
+    recovered = data.parse_data_model(text)["messy.csv"]
+    assert recovered == [("Category", "string")]
 
 
 # --- Header <-> model validator (AC: match + mismatch) -----------------------
@@ -339,3 +369,220 @@ def test_first_run_marks_nothing_stale(tmp_path):
     result = data.commit(tmp_path)
 
     assert result.ok is True and result.staled_steps == []
+
+
+# --- pull: published-ds route via VDS (CONTRACT.md §3.2) ---------------------
+
+def _write_env(project_dir: Path) -> None:
+    """Write a full, valid Tableau connection .env at the project root."""
+    (project_dir / ".env").write_text(
+        "TABLEAU_SERVER=https://pod.online.tableau.com\n"
+        "TABLEAU_SITE=mysite\n"
+        "TABLEAU_PAT_NAME=tok\n"
+        "TABLEAU_PAT_SECRET=secret\n",
+        encoding="utf-8",
+    )
+
+
+def _write_datasources(project_dir: Path, *entries: tuple[str, str]) -> None:
+    """Write datasources.json from (ds_name, project_name) pairs (keyed ds_1, ds_2…)."""
+    import json
+    body = {"_comment": "test"}
+    for index, (ds_name, project_name) in enumerate(entries, start=1):
+        body[f"ds_{index}"] = {"ds_name": ds_name, "project_name": project_name}
+    (project_dir / "datasources.json").write_text(json.dumps(body), encoding="utf-8")
+
+
+def _vds_session(*, luid="luid-1", ds_name="Superstore", project="Samples",
+                 metadata=None, rows=None) -> FakeSession:
+    """A FakeSession primed for one source's full sign-in -> metadata -> query flow."""
+    metadata = metadata if metadata is not None else {"data": [
+        {"fieldCaption": "Order ID", "dataType": "STRING", "description": "Unique order id"},
+        {"fieldCaption": "Revenue", "dataType": "REAL"},
+        {"fieldCaption": "Paid", "dataType": "BOOLEAN"},
+    ]}
+    rows = rows if rows is not None else {"data": [
+        {"Order ID": "ORD-1", "Revenue": 10.5, "Paid": True},
+        {"Order ID": "ORD-2", "Revenue": 20.0, "Paid": False},
+    ]}
+    return FakeSession(
+        signin={"credentials": {"token": "auth-tok", "site": {"id": "site-1"}}},
+        datasources=_datasources_payload((luid, ds_name, project)),
+        metadata=metadata,
+        query=rows,
+    )
+
+
+def test_pull_writes_csv_and_data_model_with_published_tier(tmp_path):
+    """A successful pull writes data/<slug>.csv + DATA-MODEL.md and flips data_mode."""
+    _write_state(tmp_path)
+    _write_datasources(tmp_path, ("Superstore", "Samples"))
+    _write_env(tmp_path)
+
+    result = data.pull(tmp_path, session=_vds_session())
+
+    assert result.ok is True
+    assert result.tier == data.TIER_PUBLISHED_DS
+    assert result.written == ["superstore.csv"]
+    assert result.row_counts == {"superstore.csv": 2}
+
+    # The CSV header mirrors the field captions; booleans are lower-cased.
+    csv_text = (tmp_path / "data" / "superstore.csv").read_text(encoding="utf-8")
+    assert csv_text.splitlines()[0] == "Order ID,Revenue,Paid"
+    assert "ORD-1,10.5,true" in csv_text
+
+    # DATA-MODEL.md carries the published-ds tier, the metadata types, and the
+    # metadata-provided description (pre-filled, not blank).
+    model_text = (tmp_path / "DATA-MODEL.md").read_text(encoding="utf-8")
+    assert data.parse_acquisition_tier(model_text) == data.TIER_PUBLISHED_DS
+    documented = data.parse_data_model(model_text)["superstore.csv"]
+    assert dict(documented) == {"Order ID": "string", "Revenue": "real", "Paid": "boolean"}
+    assert "Unique order id" in model_text
+
+    # data_mode flipped in STATE.md.
+    assert "data_mode: published-ds" in (tmp_path / "STATE.md").read_text(encoding="utf-8")
+
+
+def test_pull_then_commit_validates_cleanly(tmp_path):
+    """The pulled CSV headers match the documented fields, so commit approves."""
+    _write_state(tmp_path)
+    _write_datasources(tmp_path, ("Superstore", "Samples"))
+    _write_env(tmp_path)
+    data.pull(tmp_path, session=_vds_session())
+
+    result = data.commit(tmp_path)
+
+    assert result.ok is True and result.validated == ["superstore.csv"]
+    assert route.parse_state(tmp_path / "STATE.md").statuses["data"] == "approved"
+
+
+def test_pull_refuses_when_production_csv_exists(tmp_path):
+    """Real CSVs in data/ win (Route 1); pull refuses rather than overwrite them."""
+    _write_state(tmp_path)
+    _write_datasources(tmp_path, ("Superstore", "Samples"))
+    _write_env(tmp_path)
+    _write_csv(tmp_path, "data/sales.csv")
+
+    result = data.pull(tmp_path, session=_vds_session())
+
+    assert result.ok is False and "Route 1" in result.message
+
+
+def test_pull_force_does_not_clobber_analyst_csvs(tmp_path):
+    """--force must NOT overwrite the analyst's own dropped CSVs (csv-tier model)."""
+    _write_state(tmp_path)
+    _write_datasources(tmp_path, ("Superstore", "Samples"))
+    _write_env(tmp_path)
+    _write_csv(tmp_path, "data/sales.csv")
+    data.profile(tmp_path)   # writes a csv-tier DATA-MODEL.md for the dropped CSV
+
+    result = data.pull(tmp_path, force=True, session=_vds_session())
+
+    assert result.ok is False and "Route 1" in result.message
+    assert (tmp_path / "data" / "sales.csv").exists()   # untouched
+
+
+def test_pull_force_repulls_prior_published_output(tmp_path):
+    """--force re-pulls over data/ that a prior published-ds pull wrote (its own output)."""
+    _write_state(tmp_path)
+    _write_datasources(tmp_path, ("Superstore", "Samples"))
+    _write_env(tmp_path)
+    first = data.pull(tmp_path, session=_vds_session())
+    assert first.ok is True   # data/superstore.csv + published-ds-tier DATA-MODEL.md
+
+    # A plain re-pull is refused (DATA-MODEL.md exists); --force re-pulls cleanly.
+    assert data.pull(tmp_path, session=_vds_session()).ok is False
+    forced = data.pull(tmp_path, force=True, session=_vds_session())
+
+    assert forced.ok is True and forced.written == ["superstore.csv"]
+
+
+def test_pull_refuses_when_data_model_exists_without_force(tmp_path):
+    """An existing DATA-MODEL.md is preserved unless --force (like profile)."""
+    _write_state(tmp_path)
+    _write_datasources(tmp_path, ("Superstore", "Samples"))
+    _write_env(tmp_path)
+    (tmp_path / "DATA-MODEL.md").write_text("# pre-existing\n", encoding="utf-8")
+
+    result = data.pull(tmp_path, session=_vds_session())
+
+    assert result.ok is False and "already exists" in result.message
+
+
+def test_pull_refuses_when_no_datasources_json(tmp_path):
+    """The published-ds route needs datasources.json; absent => actionable refusal."""
+    _write_state(tmp_path)
+    _write_env(tmp_path)
+
+    result = data.pull(tmp_path, session=_vds_session())
+
+    assert result.ok is False and "datasources.json" in result.message
+
+
+def test_pull_refuses_large_row_limit_until_confirmed(tmp_path):
+    """row_limit > 1000 is refused unless confirm_large is set (CONTRACT.md §3.2)."""
+    _write_state(tmp_path)
+    _write_datasources(tmp_path, ("Superstore", "Samples"))
+    _write_env(tmp_path)
+
+    refused = data.pull(tmp_path, row_limit=2000, session=_vds_session())
+    assert refused.ok is False and "confirm" in refused.message.lower()
+    assert not (tmp_path / "DATA-MODEL.md").exists()   # nothing written
+
+    confirmed = data.pull(
+        tmp_path, row_limit=2000, confirm_large=True, session=_vds_session()
+    )
+    assert confirmed.ok is True and confirmed.row_limit == 2000
+
+
+def test_pull_is_atomic_on_vds_failure(tmp_path):
+    """A VDS failure writes no artifact and leaves STATE.md untouched (§3.2)."""
+    _write_state(tmp_path)
+    _write_datasources(tmp_path, ("Superstore", "Samples"))
+    _write_env(tmp_path)
+    # Zero-row query is a hard failure (no synthesized fallback).
+    failing = _vds_session(rows={"data": []})
+
+    result = data.pull(tmp_path, session=failing)
+
+    assert result.ok is False and "zero rows" in result.message
+    assert not (tmp_path / "DATA-MODEL.md").exists()
+    assert not (tmp_path / "data").exists()
+    state_text = (tmp_path / "STATE.md").read_text(encoding="utf-8")
+    assert "data_mode: csv" in state_text   # not flipped
+    assert route.parse_state(tmp_path / "STATE.md").statuses["data"] == "pending"
+
+
+def test_pull_refuses_when_init_not_approved(tmp_path):
+    """The entry gate guards pull too (§4.1)."""
+    _write_state(tmp_path, init="pending")
+    _write_datasources(tmp_path, ("Superstore", "Samples"))
+    _write_env(tmp_path)
+
+    result = data.pull(tmp_path, session=_vds_session())
+
+    assert result.ok is False and "init" in result.message
+
+
+def test_pull_multiple_sources_one_csv_each(tmp_path):
+    """Each listed source becomes its own data/<slug>.csv ('csv = datasource')."""
+    _write_state(tmp_path)
+    _write_datasources(tmp_path, ("Superstore", "Samples"), ("Regional Sales", "Samples"))
+    _write_env(tmp_path)
+    # The fake's datasources payload must resolve BOTH names in project 'Samples'.
+    session = FakeSession(
+        signin={"credentials": {"token": "auth-tok", "site": {"id": "site-1"}}},
+        datasources=_datasources_payload(
+            ("luid-1", "Superstore", "Samples"),
+            ("luid-2", "Regional Sales", "Samples"),
+        ),
+        metadata={"data": [{"fieldCaption": "Order ID", "dataType": "STRING"}]},
+        query={"data": [{"Order ID": "ORD-1"}]},
+    )
+
+    result = data.pull(tmp_path, session=session)
+
+    assert result.ok is True
+    assert sorted(result.written) == ["regional_sales.csv", "superstore.csv"]
+    assert (tmp_path / "data" / "regional_sales.csv").exists()
+    assert (tmp_path / "data" / "superstore.csv").exists()

--- a/tests/test_vds.py
+++ b/tests/test_vds.py
@@ -1,0 +1,341 @@
+"""Contract test for the published-ds route's VizQL Data Service client (CONTRACT.md §3.2).
+
+``vds.py`` is the network half of ``tableau-data`` Route 2. Its job is mechanical and
+must be pinned exactly: parse ``datasources.json``, load the ``.env`` connection, sign in
+with a PAT, resolve each ``(ds_name, project_name)`` to a LUID, and make the two VDS
+calls (``read-metadata`` + ``query-datasource``) with the precise request bodies the
+contract specifies. Every failure mode must surface as an actionable :class:`vds.VdsError`
+(never a silent fallback).
+
+All HTTP is driven through an injected fake ``session`` (:class:`FakeSession`), so these
+tests are deterministic and never touch the network — the same seam the real ``pull``
+uses to talk to Tableau.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import vds   # the module under test (on sys.path via conftest.py)
+
+
+# --- A fake requests.Session (records calls, returns canned JSON) ------------
+
+class FakeResponse:
+    """A minimal stand-in for ``requests.Response`` (only what vds.py reads)."""
+
+    def __init__(self, payload, status_code: int = 200, text: str = ""):
+        self._payload = payload
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self.text = text if text else (str(payload) if payload is not None else "")
+
+    def json(self):
+        if self._payload is _NOT_JSON:
+            raise ValueError("No JSON object could be decoded")
+        return self._payload
+
+
+_NOT_JSON = object()  # sentinel: a response whose .json() raises (non-JSON body)
+
+
+class FakeSession:
+    """Routes POST/GET by URL to canned responses and records every request.
+
+    Configure per-endpoint responses via the keyword payloads; any of them can be a
+    :class:`FakeResponse` (to simulate an error status / non-JSON body) or a plain dict
+    (wrapped in a 200 automatically).
+    """
+
+    def __init__(self, *, signin=None, datasources=None, metadata=None, query=None):
+        self._routes = {
+            "signin": signin,
+            "datasources": datasources,
+            "metadata": metadata,
+            "query": query,
+        }
+        self.posts: list[dict] = []
+        self.gets: list[dict] = []
+
+    @staticmethod
+    def _as_response(value) -> FakeResponse:
+        return value if isinstance(value, FakeResponse) else FakeResponse(value)
+
+    def _route_for(self, url: str) -> str:
+        if "/auth/signin" in url:
+            return "signin"
+        if "read-metadata" in url:
+            return "metadata"
+        if "query-datasource" in url:
+            return "query"
+        if "/datasources" in url:
+            return "datasources"
+        raise AssertionError(f"unexpected URL in test: {url}")
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        route = self._route_for(url)
+        self.posts.append({"url": url, "json": json, "headers": headers, "route": route})
+        return self._as_response(self._routes[route])
+
+    def get(self, url, params=None, headers=None, timeout=None):
+        self.gets.append({"url": url, "params": params, "headers": headers})
+        return self._as_response(self._routes["datasources"])
+
+
+def _conn() -> vds.TableauConnection:
+    """A canned connection (no .env needed for the unit-level HTTP tests)."""
+    return vds.TableauConnection(
+        server="https://pod.online.tableau.com",
+        site="mysite",
+        api_version="3.24",
+        pat_name="tok",
+        pat_secret="secret",
+    )
+
+
+# --- slugify (CONTRACT.md §3.2) ----------------------------------------------
+
+@pytest.mark.parametrize("name, expected", [
+    ("Regional Sales", "regional_sales"),
+    ("Superstore", "superstore"),
+    ("Sales (2025) — EMEA", "sales_2025_emea"),
+    ("  spaces  ", "spaces"),
+    ("ALLCAPS", "allcaps"),
+])
+def test_slugify(name, expected):
+    """ds_name -> CSV slug: lowercase, non-alphanumeric runs -> single underscore."""
+    assert vds.slugify(name) == expected
+
+
+def test_slugify_rejects_empty():
+    """A name with no alphanumerics has no slug to build a filename from."""
+    with pytest.raises(vds.VdsError):
+        vds.slugify("!!!")
+
+
+# --- vds_type_to_model_type --------------------------------------------------
+
+@pytest.mark.parametrize("vds_type, expected", [
+    ("STRING", "string"),
+    ("integer", "integer"),       # case-insensitive
+    ("REAL", "real"),
+    ("DATE", "date"),
+    ("DATETIME", "datetime"),
+    ("BOOLEAN", "boolean"),
+    ("SPATIAL", "string"),        # unknown -> string (still queryable, documented as text)
+    ("", "string"),
+])
+def test_vds_type_to_model_type(vds_type, expected):
+    """VDS dataType maps onto data.py's TYPES; unknown types fall back to string."""
+    assert vds.vds_type_to_model_type(vds_type) == expected
+
+
+# --- parse_datasources_json --------------------------------------------------
+
+def test_parse_datasources_json_ignores_comment_keys(tmp_path):
+    """`_`-prefixed keys (e.g. _comment) are skipped; real entries keep file order."""
+    path = tmp_path / "datasources.json"
+    path.write_text(
+        '{"_comment": "ignore me", '
+        '"ds_1": {"ds_name": "Superstore", "project_name": "Samples"}, '
+        '"ds_2": {"ds_name": "Regional Sales", "project_name": "Sales"}}',
+        encoding="utf-8",
+    )
+
+    refs = vds.parse_datasources_json(path)
+
+    assert [r.ds_name for r in refs] == ["Superstore", "Regional Sales"]
+    assert refs[0].project_name == "Samples" and refs[0].key == "ds_1"
+
+
+def test_parse_datasources_json_requires_name_and_project(tmp_path):
+    """An entry missing ds_name/project_name is an actionable error."""
+    path = tmp_path / "datasources.json"
+    path.write_text('{"ds_1": {"ds_name": "Superstore"}}', encoding="utf-8")
+
+    with pytest.raises(vds.VdsError, match="ds_name.*project_name|project_name"):
+        vds.parse_datasources_json(path)
+
+
+def test_parse_datasources_json_refuses_when_only_comments(tmp_path):
+    """A file with only comment keys lists no sources -> refuse."""
+    path = tmp_path / "datasources.json"
+    path.write_text('{"_comment": "nothing real here"}', encoding="utf-8")
+
+    with pytest.raises(vds.VdsError, match="no data sources"):
+        vds.parse_datasources_json(path)
+
+
+# --- .env discovery + load_connection ----------------------------------------
+
+def _write_env(directory: Path, **overrides: str) -> Path:
+    """Write a .env with a full valid connection, applying overrides (None drops a key)."""
+    fields = {
+        "TABLEAU_SERVER": "https://pod.online.tableau.com/",   # trailing slash trimmed
+        "TABLEAU_SITE": "mysite",
+        "TABLEAU_API_VERSION": "3.24",
+        "TABLEAU_PAT_NAME": "tok",
+        "TABLEAU_PAT_SECRET": "secret",
+    }
+    fields.update(overrides)
+    lines = [f"{key}={value}" for key, value in fields.items() if value is not None]
+    path = directory / ".env"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_find_env_walks_up(tmp_path):
+    """find_env returns the nearest .env walking up from the project dir."""
+    _write_env(tmp_path)
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+
+    assert vds.find_env(nested) == (tmp_path / ".env")
+
+
+def test_load_connection_reads_and_trims(tmp_path):
+    """A full .env loads into a TableauConnection; the server trailing slash is trimmed."""
+    _write_env(tmp_path)
+
+    conn = vds.load_connection(tmp_path)
+
+    assert conn.server == "https://pod.online.tableau.com"   # no trailing slash
+    assert conn.site == "mysite" and conn.api_version == "3.24"
+    assert conn.pat_name == "tok" and conn.pat_secret == "secret"
+
+
+def test_load_connection_defaults_api_version(tmp_path):
+    """An absent TABLEAU_API_VERSION falls back to the default; site may be empty."""
+    _write_env(tmp_path, TABLEAU_API_VERSION=None, TABLEAU_SITE="")
+
+    conn = vds.load_connection(tmp_path)
+
+    assert conn.api_version == vds.DEFAULT_API_VERSION
+    assert conn.site == ""   # default site
+
+
+def test_load_connection_errors_on_missing_pat(tmp_path):
+    """A missing required var is an actionable error naming the key."""
+    _write_env(tmp_path, TABLEAU_PAT_SECRET=None)
+
+    with pytest.raises(vds.VdsError, match="TABLEAU_PAT_SECRET"):
+        vds.load_connection(tmp_path)
+
+
+def test_load_connection_errors_when_no_env(tmp_path):
+    """No .env anywhere -> a clear 'copy scaffold/.env.example' error."""
+    with pytest.raises(vds.VdsError, match="No .env"):
+        vds.load_connection(tmp_path)
+
+
+# --- sign_in -----------------------------------------------------------------
+
+def test_sign_in_builds_pat_body_and_parses_token():
+    """sign_in posts the PAT credentials body and returns (token, site_id)."""
+    session = FakeSession(
+        signin={"credentials": {"token": "auth-tok", "site": {"id": "site-99"}}}
+    )
+
+    token, site_id = vds.sign_in(_conn(), session)
+
+    assert (token, site_id) == ("auth-tok", "site-99")
+    sent = session.posts[0]["json"]["credentials"]
+    assert sent["personalAccessTokenName"] == "tok"
+    assert sent["personalAccessTokenSecret"] == "secret"
+    assert sent["site"] == {"contentUrl": "mysite"}
+    assert session.posts[0]["url"].endswith("/api/3.24/auth/signin")
+
+
+def test_sign_in_raises_on_bad_status():
+    """A 401 (bad PAT) surfaces as VdsError carrying the server message."""
+    session = FakeSession(signin=FakeResponse({}, status_code=401, text="invalid token"))
+
+    with pytest.raises(vds.VdsError, match="401"):
+        vds.sign_in(_conn(), session)
+
+
+# --- resolve_luid ------------------------------------------------------------
+
+def _datasources_payload(*entries) -> dict:
+    """Build a REST Query-Data-Sources body from (id, name, project) triples."""
+    return {"datasources": {"datasource": [
+        {"id": luid, "name": name, "project": {"name": project}}
+        for luid, name, project in entries
+    ]}}
+
+
+def test_resolve_luid_matches_name_and_project():
+    """The LUID is the entry matching BOTH name and project; name filter is sent."""
+    session = FakeSession(datasources=_datasources_payload(
+        ("luid-other", "Superstore", "Wrong Project"),
+        ("luid-1", "Superstore", "Samples"),
+    ))
+
+    luid = vds.resolve_luid(_conn(), "tok", "site-1", "Superstore", "Samples", session)
+
+    assert luid == "luid-1"
+    assert session.gets[0]["params"]["filter"] == "name:eq:Superstore"
+    assert session.gets[0]["headers"]["X-Tableau-Auth"] == "tok"
+
+
+def test_resolve_luid_errors_and_names_embedded_possibility():
+    """No name+project match -> error that names the embedded/export-to-CSV fallback."""
+    session = FakeSession(datasources=_datasources_payload(
+        ("luid-1", "Superstore", "Other"),
+    ))
+
+    with pytest.raises(vds.VdsError, match="EMBEDDED|export the data to CSV"):
+        vds.resolve_luid(_conn(), "tok", "site-1", "Superstore", "Samples", session)
+
+
+# --- read_metadata -----------------------------------------------------------
+
+def test_read_metadata_parses_fields_and_maps_types():
+    """read-metadata returns captions/types/descriptions; the body targets the LUID."""
+    session = FakeSession(metadata={"data": [
+        {"fieldCaption": "Order ID", "dataType": "STRING", "description": "the id"},
+        {"fieldCaption": "Revenue", "dataType": "REAL"},
+        {"fieldCaption": "", "dataType": "STRING"},   # no caption -> skipped
+    ]})
+
+    fields = vds.read_metadata(_conn(), "tok", "luid-1", session)
+
+    assert [f.caption for f in fields] == ["Order ID", "Revenue"]
+    assert fields[0].model_type == "string" and fields[0].description == "the id"
+    assert fields[1].model_type == "real" and fields[1].description == ""
+    assert session.posts[0]["json"] == {"datasource": {"datasourceLuid": "luid-1"}}
+
+
+def test_read_metadata_errors_when_no_queryable_fields():
+    """Empty metadata -> error pointing at the 'API Access' capability."""
+    session = FakeSession(metadata={"data": []})
+
+    with pytest.raises(vds.VdsError, match="API Access"):
+        vds.read_metadata(_conn(), "tok", "luid-1", session)
+
+
+# --- query_rows --------------------------------------------------------------
+
+def test_query_rows_builds_contract_body_and_returns_rows():
+    """The query body matches CONTRACT.md §3.2 exactly (fields + rowLimit)."""
+    session = FakeSession(query={"data": [
+        {"Order ID": "ORD-1", "Revenue": 10.5},
+        {"Order ID": "ORD-2", "Revenue": 20.0},
+    ]})
+
+    rows = vds.query_rows(_conn(), "tok", "luid-1", ["Order ID", "Revenue"], 100, session)
+
+    assert len(rows) == 2 and rows[0]["Order ID"] == "ORD-1"
+    body = session.posts[0]["json"]
+    assert body["datasource"] == {"datasourceLuid": "luid-1"}
+    assert body["query"] == {"fields": [{"fieldCaption": "Order ID"},
+                                        {"fieldCaption": "Revenue"}]}
+    assert body["options"] == {"rowLimit": 100}
+
+
+def test_query_rows_errors_on_zero_rows():
+    """Zero rows -> error (no synthesized-data fallback, CONTRACT.md §3.2)."""
+    session = FakeSession(query={"data": []})
+
+    with pytest.raises(vds.VdsError, match="zero rows"):
+        vds.query_rows(_conn(), "tok", "luid-1", ["Order ID"], 100, session)


### PR DESCRIPTION
Implements **Route 2** of the `tableau-data` step (CONTRACT.md §3.2): sample published Tableau data sources through the **VizQL Data Service** into `data/*.csv` + `DATA-MODEL.md`. The skill previously only *detected* `datasources.json` + `.env` and deferred the extraction.

Closes #9.

## What it does
`pull` signs in with a Personal Access Token, resolves each `(ds_name, project_name)` to a LUID, then calls `read-metadata` (authoritative field names/types/descriptions) and `query-datasource` (capped row sample). Each source becomes one `data/<slug>.csv`; `DATA-MODEL.md` records the `published-ds (VDS query)` tier.

## Highlights
- **New `skills/tableau-data/vds.py`** — self-contained VDS client (CONTRACT.md §7). Injectable `requests.Session` for testability; typed `VdsError` (actionable message) on every failure mode.
- **`data.py`** — `pull` command/function: atomic (writes nothing on any VDS failure), `data_mode` flip, row-limit policy (default 100, silent ≤1000, `>1000` → `--confirm-large`), and `--force` re-pull that overwrites only a prior pull's own output (never analyst-dropped CSVs). `requests` imported lazily so the stdlib-only core stays import-clean.
- **Bug fix** — `render_data_model` now sanitizes Sample-values/Description cells so newlines and literal `|` in real data don't corrupt the markdown table (caught by the live multi-source test).
- **Docs** — `SKILL.md` documents the route, row-limit rules, and failure modes (incl. embedded-source → export-to-CSV).

## Testing
- **113 unit tests pass** (mocked HTTP, no credentials).
- **Live-validated against Tableau Cloud**: single- and multi-source pulls (`Education Costs Data`, `amazonData`) → `commit`; plus the bad-creds and not-a-published-source (embedded) failure paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)