### PR TITLE
feat: tableau-brand skill — extract design tokens to DESIGN-TOKENS.md (skippable) (#10)

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -105,6 +105,14 @@ analyst is in the workflow.
 > A step is **resolved** when its status is `approved` or `skipped`. Resolved is the condition the
 > ordering gate (§4.1) checks for and the condition the router (§5) treats as "done."
 
+> **Skip preconditions are skill-specific.** A skill may gate its own `skipped` transition behind a
+> minimal precondition when skipping blank would degrade the whole pipeline. `tableau-brand` (step 4)
+> only accepts `skipped` once `branding/branding.md` exists: branding drives how good the mock and the
+> Tableau spec can be, so the analyst must capture at least some brand intent (a spec, a scraped org
+> `.twb`, or the brand interview) before opting into neutral styling. `tableau-intake` (step 2) has no
+> such precondition — its request can be skipped outright. This narrows *when* a step may be skipped;
+> it never changes what `skipped` then means (a resolved step that produced no artifact).
+
 ---
 
 ## 3. The artifact-naming rule

--- a/skills/tableau-brand/SKILL.md
+++ b/skills/tableau-brand/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: tableau-brand
+description: Extracts design tokens (palette, type, spacing) into DESIGN-TOKENS.md for the tableau-dashboard-plugin workflow, so the mock and the Tableau workbook match the brand. Reads the analyst's branding/ (a branding.md spec and/or an org template .twb, plus logo/icons), or runs a short brand interview when none exists. Every value guessed from a Tableau default is flagged. Skippable only once branding/branding.md exists. Use when the user wants to set up branding/design tokens, or when tableau-route reports brand is next. Step 4 of 8 in the workflow.
+disable-model-invocation: true
+allowed-tools: Read, Write, Edit, AskUserQuestion, Bash(python *), Bash(python3 *)
+---
+
+# tableau-brand
+
+Step 4 of 8. Turns the analyst's branding into a `DESIGN-TOKENS.md` — the single
+source of truth for **palette, type, and spacing** that `tableau-mock` (the HTML
+demo) and `tableau-build` (the `.twb`) both consume.
+
+| | |
+|---|---|
+| **Reads** | The analyst's `branding/` (lowercase input): `branding/branding.md` (spec, preferred), an org template `branding/*.twb`, and any `branding/logo.*` / `branding/icons/`. Falls back to the `scaffold/branding/EXAMPLE-branding.md` demo. **No required read** — branding is an input, so this step never refuses for a "missing" file (CONTRACT.md §1). |
+| **Writes** | `DESIGN-TOKENS.md` at the project root (latest approved truth; overwritten in place). May also author `branding/branding.md` from a scraped `.twb` or the brand interview. |
+| **STATE.md update** | Sets `brand` = `approved` (tokens authored) or `skipped`; flips every downstream `approved` step to `stale` on a re-run (CONTRACT.md §4.2). |
+| **Entry gate** | Refuses to run until `init` is `approved` in `STATE.md` (CONTRACT.md §4.1). |
+| **Next step** | `tableau-plan` (or `tableau-route` to confirm). |
+
+> **Tell the analyst this step matters.** Branding is what lets the later steps
+> know *how to build the mock* and *how to write a precise Tableau implementation
+> spec*. Don't skimp on the palette, the fonts, the padding, the sizing — vague
+> branding here produces a bland, generic dashboard downstream. This is why the step
+> can only be **skipped once `branding/branding.md` exists** (see below): the analyst
+> must capture at least some brand intent before opting into neutral styling.
+
+The mechanical guarantees — the entry gate, the `DESIGN-TOKENS.md` schema check, the
+skip precondition, and the STATE.md transition — live in `brand.py`, this skill's
+executable mirror of the contract. Your job is the part that needs judgment: reading
+the branding (or interviewing for it) and authoring the tokens. Run the script at the
+two points below; do not hand-edit `STATE.md` yourself.
+
+## How to run
+
+1. **Precheck.** From the project directory, run:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/brand.py" precheck "<project-dir>"
+   ```
+
+   (Use `python3` if `python` is unavailable.) If it prints `[BLOCKED]`, relay the
+   reason and **stop** — the analyst must run `tableau-init` first. Otherwise note
+   its signals: whether a `DESIGN-TOKENS.md` already exists (refine vs overwrite),
+   the **source mode**, any logo/icon assets to integrate, and whether skip is
+   allowed.
+
+2. **Refine vs overwrite.** If precheck reports `DESIGN-TOKENS.md` already exists,
+   use **AskUserQuestion** to offer **Refine** (keep its structure, update values),
+   **Overwrite** (author fresh), or **Skip** (only if allowed). **Never silently
+   overwrite** existing tokens.
+
+3. **Follow the source mode** precheck reported:
+
+   | source mode | what to do |
+   |-------------|------------|
+   | `spec` | Extract tokens from `branding/branding.md`. |
+   | `spec+twb` | Scrape the org `branding/*.twb` and use it to **enrich** the existing `branding/branding.md` (don't discard the analyst's spec), then build tokens. |
+   | `twb` | Scrape the org `branding/*.twb`, **write** `branding/branding.md` from what you find, then build tokens. |
+   | `scaffold` | Only the `scaffold/` demo example exists — **say so** (you're demoing, not using real brand input). |
+   | `none` | Run the **brand interview** (next section), write `branding/branding.md` from the answers, then build tokens. |
+
+   **When a `.twb` is involved:** before reading it, **ask the analyst to confirm
+   the workbook is as thin as possible** (a minimal template — ideally one styled
+   sheet/dashboard, no large data extracts or dozens of sheets). A heavy `.twb`
+   floods the context with irrelevant XML. Scrape only what feeds design tokens:
+   fonts, colors (fills, text, series palette), sizing, container/spacing structure,
+   and any embedded logo (`<zone type='bitmap'>`).
+
+4. **Brand interview (source mode `none` only).** When there is no branding input at
+   all, **do not** leave the brand blank — interview the analyst, borrowing the
+   `grill-me` approach but **bounded to at most 10 questions**. Ask one at a time,
+   propose a recommended default for each (from
+   `references/tableau-design-tokens.md`), and choose the questions that recover the
+   most token-relevant information: primary/secondary colors, a cohesive ≤5-color
+   series palette, font family (default the Tableau family), title vs label sizing,
+   card padding / section spacing, dashboard sizing mode, and whether a logo/icons
+   exist. Prefer **AskUserQuestion** (multiple-choice with your recommendation
+   first). Write the answers into `branding/branding.md`, then build tokens.
+
+5. **Author `DESIGN-TOKENS.md`.** Write (or `Edit`, when refining) `DESIGN-TOKENS.md`
+   at the project root using `references/DESIGN-TOKENS-TEMPLATE.md` as the structure.
+   Fill palette/type/spacing from the branding source. **For every value the brand
+   did not specify, pull the Tableau default from
+   `references/tableau-design-tokens.md` and list it under `## Fallback Decisions`**
+   — that section is how the analyst sees which visual choices were guessed (it is
+   required; if nothing was guessed, write "None"). Integrate any logo/icons precheck
+   found. Present the tokens for approval.
+
+6. **Commit** — only after the analyst approves (or chooses to skip):
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/brand.py" commit "<project-dir>" --status approved
+   # or, to skip the step (allowed only once branding/branding.md exists):
+   python "${CLAUDE_SKILL_DIR}/scripts/brand.py" commit "<project-dir>" --status skipped
+   ```
+
+   On `--status approved` the script validates `DESIGN-TOKENS.md` has the required
+   core; if it prints `[REFUSED]` listing missing sections, add them and re-run. On
+   `--status skipped` it refuses unless `branding/branding.md` exists. On success it
+   records the status and reports any downstream steps it marked `stale`. Relay the
+   summary and tell the analyst to open a fresh conversation and run the next step
+   (`tableau-plan`, or `tableau-route` to confirm).
+
+## The DESIGN-TOKENS schema
+
+`brand.py` enforces the **required core**; the rest is recommended-but-optional.
+
+| section | required? | what goes there |
+|---------|-----------|-----------------|
+| `## Colors` | **required** | Backgrounds, accent bars, a cohesive ≤5-color series palette, text colors. |
+| `## Typography` | **required** | Font family + sizes/weights for title, chart title, labels, tooltips. |
+| `## Spacing` | **required** | Card padding, section spacing, container margins, accent-bar height. |
+| `## Fallback Decisions` | **required** | Every value pulled from a Tableau default, flagged as guessed (or "None"). |
+| `## Source` | optional | Which branding source produced these tokens. |
+| `## Dashboard Sizing` | optional | Mode (default Range), min width/height, max (default Flex). |
+| `## Logo` / `## Icons` | optional | Brand assets to integrate; omit when none. |
+
+The validator matches headings as case-insensitive substrings and allows extra
+custom sections, so a refined token file that keeps its own structure still passes.
+
+## Notes
+
+- **Skippable, but deliberately gated.** Skipping records `skipped` in `STATE.md`
+  and yields neutral styling downstream (`mock`/`build` read `DESIGN-TOKENS.md` as an
+  *optional* input — absent ⇒ neutral, CONTRACT.md §1). But skip is only offered once
+  `branding/branding.md` exists, so the analyst can't bypass branding with zero brand
+  intent on file.
+- **Defaults worth keeping** (from `references/tableau-design-tokens.md`): the native
+  **Tableau** font family (Bold/Medium/Light); a **cohesive ≤5-color** palette (a
+  dashboard speaks one color language); **Range** sizing with no max (Flex), not
+  Automatic; worksheet **headers hidden** with the visible title as a **Text object**;
+  a collapsible filter panel via a **Show/Hide button**.
+- **Root file, no version bump.** Re-running refines the root `DESIGN-TOKENS.md` in
+  place and flips downstream `approved` steps to `stale`; it does **not** create a new
+  version directory (`DESIGN-TOKENS.md` is a root "latest truth" file, CONTRACT.md §4.3).
+
+> The full `STATE.md` schema and the ordering / staleness / versioning rules live in
+> `CONTRACT.md` at the repo root. This skill restates only its own slice; `brand.py`
+> is the executable mirror of the contract it enforces.

--- a/skills/tableau-brand/references/DESIGN-TOKENS-TEMPLATE.md
+++ b/skills/tableau-brand/references/DESIGN-TOKENS-TEMPLATE.md
@@ -1,0 +1,99 @@
+# Design Tokens
+
+> Authored by `tableau-brand` (step 4). The single source of truth for palette,
+> type, and spacing consumed by `tableau-mock` (the HTML demo) and `tableau-build`
+> (the `.twb`). Fill every bracketed value from `branding/` (the spec, a scraped
+> org `.twb`, or the brand interview); for anything the brand didn't specify, pull
+> the Tableau default from `references/tableau-design-tokens.md` **and list it under
+> `## Fallback Decisions`**.
+
+## Source
+
+- **Brand source**: [branding/branding.md | branding/<name>.twb | brand interview | scaffold demo]
+- **Logo / icons**: [paths under branding/, or "none provided"]
+
+## Typography
+
+- **Font family**: [font]
+- **Dashboard title**: [size]px, [weight], [hex]
+- **Chart title**: [size]px, [weight], [hex]   *(a Text object, not the worksheet's built-in header — see Constraints)*
+- **Filter / section labels**: [size]px, [weight], [hex]
+- **Worksheet default**: [size]px
+- **Tooltip**: [size]px
+
+## Colors
+
+### Backgrounds
+- **Dashboard background**: [hex]
+- **Top banner / title area**: [hex]
+- **Chart card background**: [hex]
+- **Separator line**: [hex]
+
+### Accent colors (KPI top border bars)
+- Accent 1: [hex]
+- Accent 2: [hex]
+- Accent 3: [hex]
+- Accent 4: [hex]
+
+### Chart series colors
+[Ordered list of hex colors for chart data series.]
+
+### Text
+- Dark (titles): [hex]
+- Medium (labels): [hex]
+
+## Logo
+
+- **File**: [path under branding/, or "none provided"]
+- **Placement**: Top-left header container (alongside the dashboard-title Text object)
+
+## Dashboard Sizing
+
+- **Sizing mode**: [Range | Fixed]   *(default Range; avoid Automatic — it distorts aspect ratios)*
+- **Minimum width**: [px]
+- **Minimum height**: [px]
+- **Maximum**: [Flex (no max) by default, unless the brand requests a fixed cap]
+
+## Icons
+
+[If `branding/icons/` exists, map icon name -> file. Otherwise note that
+`tableau-mock` will generate simple inline SVG icons matching chart types.]
+
+| Icon name | File | Size |
+|-----------|------|------|
+| [name] | [branding/icons/<file>.svg] | 40x40 |
+
+## Spacing
+
+| Element | Property | Value |
+|---------|----------|-------|
+| Chart card | padding | [px] |
+| Section | spacing | [px] |
+| Container | margin | [px] |
+| KPI accent bar | height | [px] |
+
+## Fallback Decisions
+
+Every value below was **not** specified by the brand and was filled from the
+Tableau defaults in `references/tableau-design-tokens.md`. If the brand specified
+everything, write `None — all values came from the brand source.`
+
+| Token / decision | Fallback value used | Why it was needed |
+|------------------|---------------------|-------------------|
+| [token] | [value] | [missing from brand input] |
+
+## Constraints
+
+- **Sheet headers are hidden; the visible header is a Text object.** Every
+  worksheet's built-in title is turned off (`Show Header` unchecked); the visible
+  chart/dashboard title is a separate **Text object**, so it can sit inside a header
+  container alongside the logo and icons and be positioned freely. (Tableau's
+  built-in title is always pinned to the top and can't be moved.)
+- **Collapsible filter panel via a Show/Hide button** (not Dynamic Zone Visibility):
+  a container revealed/hidden by a Show/Hide button.
+- **Tiled layout by default** — use tiled horizontal/vertical layout containers for
+  spacing control; reserve floating for overlays (e.g. a Show/Hide filter panel).
+- **Insight-style titles** — prefer titles that state the takeaway, not just the
+  chart name (e.g. "Revenue up 12% YoY", not "Revenue").
+- Tableau-fidelity: no rounded corners on `2024.2-2025.x`; border-style none; white
+  chart cards on a light dashboard background.

--- a/skills/tableau-brand/references/tableau-design-tokens.md
+++ b/skills/tableau-brand/references/tableau-design-tokens.md
@@ -1,0 +1,160 @@
+# Fallback Design Tokens (Tableau Defaults)
+
+These are default Tableau design tokens used as a **fallback** when the brand
+leaves a value unspecified — whether `tableau-brand` is working from a
+`branding/branding.md`, a scraped org `*.twb`, or the brand interview. `tableau-brand`
+produces a project-specific `DESIGN-TOKENS.md` that overrides these values and
+**must disclose every fallback-driven value under its `## Fallback Decisions`
+section** so the analyst knows which visual decisions were guessed.
+
+This reference is owned by `tableau-brand` (self-containment, CONTRACT.md §7) and is
+read by the skill at authoring time only; it is never a handoff artifact.
+
+## Typography
+
+Use the native **Tableau** font family (it ships with Tableau Desktop, so the
+workbook renders identically without installing anything):
+
+- **Font family**: Tableau (Tableau Bold / Tableau Medium / Tableau Light)
+- **Dashboard title**: 28px, Tableau Bold, `#1c2833`
+- **Chart title**: 15px, Tableau Medium, `#1c2833`
+- **Filter / section labels**: 12px, Tableau Medium, `#5d6d7e`
+- **Worksheet default font size**: 12px, Tableau Light
+- **Tooltip font size**: 12px, Tableau Light
+
+> Titles are rendered as **Text objects**, not the worksheet's built-in header
+> (see Constraints). Prefer **insight-style** title copy that states the takeaway
+> (e.g. "Revenue up 12% YoY") over a bare field name.
+
+## Colors
+
+A dashboard should **speak one color language** — a cohesive, analogous palette
+(not a rainbow). Default to **at most 5** series colors drawn from the same
+blue-teal family, so categories stay distinguishable without clashing.
+
+### Backgrounds
+- **Dashboard background**: `#f6f7f9`
+- **Top banner / title area**: `#f5f7f9`
+- **Chart card background**: `#ffffff`
+- **Separator line**: `#eef1f4`
+
+### KPI Accent Colors (top border bar — same family as the series)
+- Accent 1: `#2e75b6` (primary blue)
+- Accent 2: `#41a5a5` (teal)
+- Accent 3: `#5b9bd5` (light blue)
+- Accent 4: `#6f8faf` (slate blue)
+
+### Chart Series Colors (cohesive, max 5)
+`#2e75b6` (blue), `#41a5a5` (teal), `#5b9bd5` (light blue), `#6f8faf` (slate), `#9b8bbd` (muted purple)
+
+### Text
+- Dark (titles): `#1c2833`
+- Medium (labels): `#5d6d7e`
+
+### Borders
+- Default border-style: `none` (border-width: 0)
+
+## Dashboard Sizing
+
+- **Sizing mode**: Range
+- **Minimum width**: 1100
+- **Minimum height**: 800
+- **Maximum**: Flex (no max) — the default, unless the brand requests a fixed cap
+
+> **Avoid Automatic sizing.** Automatic distorts aspect ratios on resize (wide
+> charts go tall-and-thin, fonts become unreadable). Range with a minimum set and
+> no maximum keeps charts legible while letting the dashboard expand on larger
+> screens. Use Fixed only when a specific device/canvas is the target.
+
+## Standard Container Hierarchy
+
+```
+layout-basic (root, 100% x 100%)
+└── Content (vertical flow, centered)
+    ├── Header container (horizontal flow, fixed-size 65)
+    │   ├── Logo area (fixed-size 195, padding: 7, padding-left: 12)
+    │   ├── Title (Text object — NOT the worksheet header)
+    │   ├── Spacer (Blank, flex)
+    │   └── Right section (update time, info icon)
+    ├── Top Filters (horizontal flow, fixed-size 53)
+    │   ├── Label (fixed-size 185, margin: 4)
+    │   ├── Filter placeholder (margin: 4)
+    │   ├── Spacer (Blank, flex)
+    │   └── Show/Hide button (fixed-size ~38, margin: 4)
+    │   └── [margin-top: 11, margin-bottom: 11]
+    └── Charts & Hidden Filters (horizontal flow, flex)
+        ├── KPI & Charts (vertical flow, ~86% width)
+        │   ├── Main KPI row (horizontal, distribute-evenly, fixed-size 94)
+        │   ├── Chart rows (per layout)
+        │   └── Spacer (Blank, flex)
+        └── Hidden Filters panel (vertical flow, collapsible via Show/Hide button)
+            └── Spacer (Blank, flex)
+```
+
+## KPI Card Pattern
+
+```
+KPI container (horizontal flow, margin-right: 16)
+└── Inner wrapper (vertical flow, bg: card background)
+    ├── Accent bar (3px height, margin: 0, bg: accent color)
+    ├── KPI content area (sheet, inner-padding: 8)
+    └── Spacer (Blank, flex)
+```
+
+## Chart Card Pattern
+
+```
+Chart wrapper (horizontal flow, margin-top: 11)
+└── Chart outer (horizontal flow)
+    └── Chart inner (vertical flow, padding: 8, bg: card background)
+        ├── Title bar (horizontal flow, fixed-size 46)
+        │   ├── Icon image (40x40, fixed-size 47, from branding/icons/)
+        │   ├── Chart title (Text object, margin: 4, margin-left: 10)
+        │   ├── Spacer (Blank, flex)
+        │   └── Info icon (fixed-size 38, margin: 4)
+        ├── Separator line (3px, margin-lr: 10, bg: separator color)
+        ├── Chart sheet area (flex, inner-padding: 8, worksheet header hidden)
+        └── Spacer (Blank, flex)
+```
+
+## Spacing Reference
+
+| Element | Property | Value |
+|---------|----------|-------|
+| Content container | outer margin | ~1.25% from edges |
+| Logo | padding | 7 (padding-left: 12) |
+| Dashboard title | margin | 4 (margin-bottom: 1) |
+| Filter bar | margin-top/bottom | 11 |
+| Filter label | margin | 4 |
+| KPI cards | margin-right | 16 (between cards) |
+| KPI accent bar | margin | 0, height 3 |
+| Chart card outer | margin-top | 11 |
+| Chart card inner | padding | 8 |
+| Chart title text | margin | 4 (margin-left: 10) |
+| Separator line | margin-right/left | 10 |
+| Sheet zone | inner padding | 8 |
+
+## Constraints
+
+- **Worksheet headers are hidden; titles are Text objects.** Turn off each
+  worksheet's built-in title (`Show Header`) and render the visible chart/dashboard
+  title as a separate **Text object**, so it can live in a header container with the
+  logo/icons and be placed freely. Tableau's built-in title is always pinned to the
+  top and can't be moved — the Text object gives full layout control.
+- **Collapsible filter panel via a Show/Hide button** (not Dynamic Zone Visibility):
+  a container revealed/hidden by a Show/Hide button.
+- **Tiled layout by default** — tiled horizontal/vertical containers for spacing
+  control; reserve floating for overlays (e.g. the Show/Hide filter panel).
+- **One color language, max 5 series colors** — cohesive analogous palette; don't
+  reach for a rainbow.
+- **No rounded corners** on `2024.2-2025.x` unless the analyst explicitly accepts a
+  non-Tableau-faithful mock.
+- **border-style: none** on all containers.
+- Charts have a white background; the dashboard has a light-gray background.
+- Use distribute-evenly layout for KPI rows and multi-chart rows.
+- Use `fixed-size` on structural elements (header bar, KPI rows, filter bars,
+  accent/separator bars, icons, logo) — only chart areas and main content flex.
+- Every `layout-flow` container must include at least one Spacer (Blank, flex) to
+  prevent layout collapse.
+- Any value taken from this reference MUST be listed under `## Fallback Decisions`
+  in the generated `DESIGN-TOKENS.md`.

--- a/skills/tableau-brand/scripts/brand.py
+++ b/skills/tableau-brand/scripts/brand.py
@@ -1,0 +1,755 @@
+"""Gate, validate, and commit the ``brand`` step of the tableau-dashboard-plugin.
+
+This is the executable core of the ``tableau-brand`` skill (CONTRACT.md step 4):
+the skippable step that extracts design tokens (palette, type, spacing) from the
+analyst's ``branding/`` into a ``DESIGN-TOKENS.md`` so the mock and the workbook
+match brand. The token *content* is authored by the model (reading ``branding.md``,
+scraping an org ``*.twb``, or running a short brand interview); this script owns the
+three things that must be **mechanically guaranteed** rather than left to model prose:
+
+1. **Entry gate** - brand refuses to run until ``init`` is ``approved`` in
+   ``STATE.md`` (and ``STATE.md`` exists at all). This mirrors the ordering rule in
+   CONTRACT.md §4.1. Brand has **no producer-gated required reads** (its input is the
+   analyst-owned ``branding/`` directory, CONTRACT.md §1/§3.1), so init being
+   approved - i.e. the project is initialized - is the only precondition.
+2. **DESIGN-TOKENS schema** - on approval the produced ``DESIGN-TOKENS.md`` must
+   contain the required core (``Colors``, ``Typography``, ``Spacing``) plus a
+   ``Fallback Decisions`` section. The first three are the palette/type/spacing the
+   step exists to capture; the fourth is the mechanical anchor for the rule that
+   *every value filled from a fallback default is explicitly flagged as guessed* -
+   the section must be present (even if it records "none").
+3. **Skip precondition + STATE.md transition** - the step is *skippable*, but only
+   once ``branding/branding.md`` exists. Branding drives how good the mock and the
+   Tableau spec can be, so the analyst may not skip into neutral styling with no
+   brand intent captured at all: ``--status skipped`` is **refused** unless
+   ``branding/branding.md`` is on disk. Committing either status flips every
+   downstream ``approved`` step to ``stale`` (CONTRACT.md §4.2) so the pipeline can
+   never silently disagree with a changed brand.
+
+The module is intentionally pure and stdlib-only (it does **not** import the router)
+so the contract test can call its functions directly, exactly like ``intake.py`` /
+``init.py`` / ``route.py``. The CLI exposes two subcommands the skill runs at two
+moments - ``precheck`` (before authoring) and ``commit`` (after approval). What the
+CLI prints to stdout is the program's *output*; diagnostics go through ``logging``.
+
+Keep ``STEP_ORDER`` below in lock-step with the ordered step list in CONTRACT.md §1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# --- Canonical constants (mirror of CONTRACT.md §1 / §2 / §3) ----------------
+
+STATE_FILENAME = "STATE.md"
+DESIGN_TOKENS_FILENAME = "DESIGN-TOKENS.md"
+
+#: The analyst-owned branding input directory (CONTRACT.md §3 lowercase = input).
+BRANDING_DIR = "branding"
+#: The brand spec inside it (preferred input) and its scaffold/ demo fallback (§3.1).
+BRANDING_SPEC = "branding/branding.md"
+SCAFFOLD_BRANDING_SPEC = "scaffold/branding/EXAMPLE-branding.md"
+
+#: Logo / icon assets that may live alongside the spec and get integrated.
+LOGO_STEMS = ("logo",)
+LOGO_SUFFIXES = (".svg", ".png", ".jpg", ".jpeg")
+ICONS_SUBDIR = "branding/icons"
+
+#: This step, and the upstream step whose approval gates it (CONTRACT.md §4.1).
+BRAND_STEP = "brand"
+INIT_STEP = "init"
+
+#: The 8 step names in canonical order (mirror of CONTRACT.md §1). Used to decide
+#: which steps are "downstream of brand" for staleness propagation (§4.2).
+STEP_ORDER: tuple[str, ...] = (
+    "init", "intake", "data", "brand", "plan", "mock", "spec", "build",
+)
+
+#: Statuses the commit subcommand may write for the brand step.
+COMMIT_STATUSES: tuple[str, ...] = ("approved", "skipped")
+
+#: DESIGN-TOKENS sections every approved token file must have: the palette, the
+#: type, the spacing the step exists to capture, plus the fallback-disclosure
+#: section that flags every guessed value (CONTRACT acceptance criteria).
+DESIGN_TOKENS_REQUIRED_SECTIONS: tuple[str, ...] = (
+    "Colors", "Typography", "Spacing", "Fallback Decisions",
+)
+
+#: Common but genuinely optional sections. Proposed while authoring, never required
+#: - not every brand ships a logo or custom icons or a fixed canvas size.
+DESIGN_TOKENS_RECOMMENDED_SECTIONS: tuple[str, ...] = (
+    "Source", "Dashboard Sizing", "Logo", "Icons",
+)
+
+#: The branding-source modes precheck reports, to drive the skill's branch.
+SOURCE_SPEC_AND_TWB = "spec+twb"   # branding.md AND an org .twb (enrich the spec)
+SOURCE_SPEC = "spec"               # branding.md only (extract from it)
+SOURCE_TWB = "twb"                 # an org .twb only (scrape it -> write branding.md)
+SOURCE_SCAFFOLD = "scaffold"       # only the scaffold/ demo example exists
+SOURCE_NONE = "none"               # nothing -> run the brand interview (<=10 Qs)
+
+
+# --- STATE.md reading --------------------------------------------------------
+
+# Matches a markdown ATX heading line, capturing its text (drops leading "#"s and
+# any trailing "#"s): "## Colors" -> "Colors".
+_HEADING_LINE = re.compile(r"^#{1,6}\s+(.*?)\s*#*\s*$")
+
+
+def parse_statuses(text: str) -> dict[str, str]:
+    """Parse the per-step statuses out of a STATE.md manifest.
+
+    Parsing is tolerant (matching the router's parser): only genuine
+    ``| order | step | skill | status |`` rows whose step name is known
+    contribute; header, separator, and stray rows are ignored.
+
+    Args:
+        text: The full contents of a ``STATE.md`` file.
+
+    Returns:
+        A ``{step_name: status}`` mapping (both lower-cased).
+    """
+    statuses: dict[str, str] = {}
+    in_steps = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        # Section headers toggle which parser applies.
+        if line.lower().startswith("## steps"):
+            in_steps = True
+            continue
+        if line.startswith("## "):  # any other section ends the Steps table
+            in_steps = False
+
+        if in_steps and line.startswith("|"):
+            cells = [cell.strip() for cell in line.strip("|").split("|")]
+            if len(cells) < 4:
+                continue
+            step_name, status = cells[1].lower(), cells[3].lower()
+            if step_name in STEP_ORDER:
+                statuses[step_name] = status
+    return statuses
+
+
+# --- DESIGN-TOKENS schema ----------------------------------------------------
+
+def _markdown_headings(text: str) -> list[str]:
+    """Extract the text of every markdown heading in a document.
+
+    Args:
+        text: Markdown document contents.
+
+    Returns:
+        The heading texts, in document order (e.g. ``["Colors", "Typography"]``).
+    """
+    return [
+        match.group(1).strip()
+        for raw_line in text.splitlines()
+        if (match := _HEADING_LINE.match(raw_line.strip()))
+    ]
+
+
+def validate_design_tokens(text: str) -> tuple[bool, list[str], list[str]]:
+    """Check a DESIGN-TOKENS file's section coverage against the canonical schema.
+
+    A token file is *valid* when it contains every **required** section; recommended
+    sections are reported when absent but never make it invalid (not every brand has
+    a logo, custom icons, or a fixed canvas). Section names are matched
+    case-insensitively as substrings of the document's headings, so a heading like
+    ``## Spacing Reference`` satisfies ``Spacing`` and extra custom sections are
+    always allowed.
+
+    Args:
+        text: The contents of a ``DESIGN-TOKENS.md`` file.
+
+    Returns:
+        A ``(ok, missing_required, missing_recommended)`` tuple. ``ok`` is True iff
+        ``missing_required`` is empty.
+    """
+    headings_blob = "\n".join(_markdown_headings(text)).lower()
+    missing_required = [
+        section for section in DESIGN_TOKENS_REQUIRED_SECTIONS
+        if section.lower() not in headings_blob
+    ]
+    missing_recommended = [
+        section for section in DESIGN_TOKENS_RECOMMENDED_SECTIONS
+        if section.lower() not in headings_blob
+    ]
+    return (not missing_required, missing_required, missing_recommended)
+
+
+def render_design_tokens_template() -> str:
+    """Return the canonical DESIGN-TOKENS template text this skill ships.
+
+    Reads ``references/DESIGN-TOKENS-TEMPLATE.md`` so there is a single source of
+    truth for the schema-complete starting token file - the same file the skill
+    hands the model to fill in. It is, by construction, schema-complete (contains
+    the required core).
+
+    Returns:
+        The template file contents.
+
+    Raises:
+        FileNotFoundError: If the bundled template is missing.
+    """
+    # This script lives in ``<skill>/scripts/``; references/ sits at the skill root.
+    template_path = (
+        Path(__file__).resolve().parent.parent / "references" / "DESIGN-TOKENS-TEMPLATE.md"
+    )
+    if not template_path.is_file():
+        raise FileNotFoundError(f"DESIGN-TOKENS template not found: {template_path}")
+    return template_path.read_text(encoding="utf-8-sig")
+
+
+def render_fallback_reference() -> str:
+    """Return the owned fallback-defaults reference this skill ships.
+
+    Reads ``references/tableau-design-tokens.md`` - the Tableau-default palette,
+    type, spacing, sizing, and constraints the model pulls from when a brand value
+    is unspecified. Every value taken from here MUST be disclosed under the token
+    file's ``## Fallback Decisions`` section.
+
+    Returns:
+        The reference file contents.
+
+    Raises:
+        FileNotFoundError: If the bundled reference is missing.
+    """
+    reference_path = (
+        Path(__file__).resolve().parent.parent / "references" / "tableau-design-tokens.md"
+    )
+    if not reference_path.is_file():
+        raise FileNotFoundError(f"Fallback token reference not found: {reference_path}")
+    return reference_path.read_text(encoding="utf-8-sig")
+
+
+# --- STATE.md rewriting ------------------------------------------------------
+
+def _format_step_row(cells: list[str]) -> str:
+    """Render a Steps-table row with the canonical column widths.
+
+    Matches the alignment ``init.render_state_md`` produces (``order<5 | step<6 |
+    skill<14 | status<8``) so a rewritten row stays visually consistent with the
+    rest of the table.
+
+    Args:
+        cells: The four cell values ``[order, step, skill, status]``.
+
+    Returns:
+        The formatted ``| ... |`` table row (no trailing newline).
+    """
+    order, step, skill, status = cells[0], cells[1], cells[2], cells[3]
+    return f"| {order:<5} | {step:<6} | {skill:<14} | {status:<8} |"
+
+
+def apply_status_updates(text: str, updates: dict[str, str]) -> str:
+    """Rewrite the status cell of one or more Steps-table rows.
+
+    Only rows inside the ``## Steps`` table whose step name is a key in ``updates``
+    are touched; every other line (metadata, prose, untouched rows) is preserved
+    byte-for-byte. The trailing newline of the input is preserved.
+
+    Args:
+        text: The full ``STATE.md`` contents.
+        updates: ``{step_name: new_status}`` for the rows to rewrite (step names
+            lower-cased).
+
+    Returns:
+        The updated ``STATE.md`` contents.
+    """
+    out_lines: list[str] = []
+    in_steps = False
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+
+        if stripped.lower().startswith("## steps"):
+            in_steps = True
+            out_lines.append(raw_line)
+            continue
+        if stripped.startswith("## "):  # any other section ends the Steps table
+            in_steps = False
+
+        if in_steps and stripped.startswith("|"):
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            if len(cells) >= 4 and cells[1].lower() in updates:
+                cells[3] = updates[cells[1].lower()]
+                out_lines.append(_format_step_row(cells))
+                continue
+
+        out_lines.append(raw_line)
+
+    result = "\n".join(out_lines)
+    if text.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def _downstream_stale_updates(statuses: dict[str, str]) -> dict[str, str]:
+    """Compute which downstream steps must flip to ``stale`` (CONTRACT.md §4.2).
+
+    Every step ordered after ``brand`` that is currently ``approved`` becomes
+    ``stale``; steps already ``pending`` / ``skipped`` / ``stale`` are left as-is.
+
+    Args:
+        statuses: The current ``{step_name: status}`` mapping.
+
+    Returns:
+        ``{step_name: "stale"}`` for each downstream step that was ``approved``.
+    """
+    brand_index = STEP_ORDER.index(BRAND_STEP)
+    return {
+        step: "stale"
+        for step in STEP_ORDER[brand_index + 1:]
+        if statuses.get(step) == "approved"
+    }
+
+
+# --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
+
+def entry_gate_blocker(project_root: Path) -> Optional[str]:
+    """Return why brand may not run yet, or ``None`` if it may.
+
+    Brand refuses to run unless ``STATE.md`` exists and ``init`` is ``approved``.
+    (Brand has no producer-gated required reads, so this is its only gate.)
+
+    Args:
+        project_root: The analyst's project directory.
+
+    Returns:
+        A human-readable blocker message, or ``None`` when the gate is open.
+    """
+    state_path = project_root / STATE_FILENAME
+    if not state_path.exists():
+        return (
+            "No STATE.md found. Run 'tableau-init' first to scaffold the project "
+            "and initialize STATE.md before running 'tableau-brand'."
+        )
+
+    init_status = parse_statuses(state_path.read_text(encoding="utf-8-sig")).get(
+        INIT_STEP, "pending"
+    )
+    if init_status != "approved":
+        return (
+            f"Step 'init' is '{init_status}', not 'approved'. Run 'tableau-init' "
+            f"first; 'tableau-brand' cannot run until init is approved."
+        )
+    return None
+
+
+# --- Branding-source detection -----------------------------------------------
+
+def _find_twb_files(project_root: Path) -> tuple[str, ...]:
+    """List org template workbooks (``*.twb``) under the production ``branding/``.
+
+    Args:
+        project_root: The analyst's project directory.
+
+    Returns:
+        Project-relative paths of any ``branding/*.twb`` files, sorted for stable
+        output (empty when none).
+    """
+    branding_path = project_root / BRANDING_DIR
+    if not branding_path.is_dir():
+        return ()
+    return tuple(
+        sorted(f"{BRANDING_DIR}/{twb.name}" for twb in branding_path.glob("*.twb"))
+    )
+
+
+def _find_brand_assets(project_root: Path) -> tuple[str, ...]:
+    """List logo / icon assets under the production ``branding/`` to integrate.
+
+    Args:
+        project_root: The analyst's project directory.
+
+    Returns:
+        Project-relative paths of any logo files (``branding/logo.*``) and the
+        ``branding/icons/`` directory when it holds at least one file. Sorted for
+        stable output (empty when none).
+    """
+    branding_path = project_root / BRANDING_DIR
+    if not branding_path.is_dir():
+        return ()
+
+    assets: list[str] = []
+    for asset in branding_path.iterdir():
+        if (
+            asset.is_file()
+            and asset.stem.lower() in LOGO_STEMS
+            and asset.suffix.lower() in LOGO_SUFFIXES
+        ):
+            assets.append(f"{BRANDING_DIR}/{asset.name}")
+
+    icons_path = project_root / ICONS_SUBDIR
+    if icons_path.is_dir() and any(icons_path.iterdir()):
+        assets.append(f"{ICONS_SUBDIR}/")
+
+    return tuple(sorted(assets))
+
+
+def _resolve_source_mode(
+    has_spec: bool, twb_files: tuple[str, ...], has_scaffold: bool
+) -> str:
+    """Pick which branding-source branch the skill should take (§3.1).
+
+    Production ``branding/`` always wins over the ``scaffold/`` demo example; within
+    production, an org ``.twb`` enriches an existing spec rather than replacing it.
+
+    Args:
+        has_spec: Whether production ``branding/branding.md`` exists.
+        twb_files: Production ``branding/*.twb`` files found.
+        has_scaffold: Whether the ``scaffold/`` demo example exists.
+
+    Returns:
+        One of :data:`SOURCE_SPEC_AND_TWB`, :data:`SOURCE_SPEC`, :data:`SOURCE_TWB`,
+        :data:`SOURCE_SCAFFOLD`, :data:`SOURCE_NONE`.
+    """
+    if has_spec and twb_files:
+        return SOURCE_SPEC_AND_TWB
+    if has_spec:
+        return SOURCE_SPEC
+    if twb_files:
+        return SOURCE_TWB
+    if has_scaffold:
+        return SOURCE_SCAFFOLD
+    return SOURCE_NONE
+
+
+# --- precheck ----------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PrecheckResult:
+    """The state brand needs to know before authoring design tokens.
+
+    Attributes:
+        can_run: True when the entry gate is open (init approved, STATE.md present).
+        blocker: Why brand cannot run, when ``can_run`` is False; else ``None``.
+        tokens_exist: Whether a ``DESIGN-TOKENS.md`` already exists at the project
+            root. When True the skill must offer refine-vs-overwrite, never silently
+            overwrite.
+        source_mode: Which branding source to use - one of the ``SOURCE_*`` modes.
+        has_branding_spec: Whether production ``branding/branding.md`` exists. This
+            is also the **skip precondition**: skipping is only allowed when True.
+        twb_files: Production ``branding/*.twb`` org templates found (to scrape).
+        assets: Logo / icon assets under ``branding/`` to integrate.
+        brand_status: The brand step's current status (to detect a re-run).
+    """
+
+    can_run: bool
+    blocker: Optional[str]
+    tokens_exist: bool
+    source_mode: str
+    has_branding_spec: bool
+    twb_files: tuple[str, ...]
+    assets: tuple[str, ...]
+    brand_status: str
+
+    @property
+    def can_skip(self) -> bool:
+        """bool: Whether the analyst may skip this step (branding.md must exist)."""
+        return self.has_branding_spec
+
+
+def precheck(project_dir: Path | str) -> PrecheckResult:
+    """Report whether brand may run, what it should read, and whether it may skip.
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`PrecheckResult`. When the entry gate is closed, ``can_run`` is
+        False and ``blocker`` explains why; the other fields are placeholders.
+    """
+    project_root = Path(project_dir)
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return PrecheckResult(
+            can_run=False,
+            blocker=blocker,
+            tokens_exist=False,
+            source_mode=SOURCE_NONE,
+            has_branding_spec=False,
+            twb_files=(),
+            assets=(),
+            brand_status="unknown",
+        )
+
+    has_spec = (project_root / BRANDING_SPEC).exists()
+    twb_files = _find_twb_files(project_root)
+    has_scaffold = (project_root / SCAFFOLD_BRANDING_SPEC).exists()
+    statuses = parse_statuses((project_root / STATE_FILENAME).read_text(encoding="utf-8-sig"))
+
+    return PrecheckResult(
+        can_run=True,
+        blocker=None,
+        tokens_exist=(project_root / DESIGN_TOKENS_FILENAME).exists(),
+        source_mode=_resolve_source_mode(has_spec, twb_files, has_scaffold),
+        has_branding_spec=has_spec,
+        twb_files=twb_files,
+        assets=_find_brand_assets(project_root),
+        brand_status=statuses.get(BRAND_STEP, "pending"),
+    )
+
+
+# --- commit ------------------------------------------------------------------
+
+@dataclass
+class CommitResult:
+    """Outcome of committing the brand step's result to STATE.md.
+
+    Attributes:
+        ok: True when STATE.md was updated; False when the commit was refused.
+        message: Human-readable explanation (the refusal reason when not ``ok``).
+        status_set: The status written for ``brand`` (``approved``/``skipped``), or
+            ``None`` when refused.
+        staled_steps: Downstream steps flipped to ``stale`` by this commit.
+        missing_required: Required token sections that were absent (only populated
+            on an approval refusal).
+        missing_recommended: Recommended token sections that were absent (reported
+            as an informational note; never blocks an approval).
+    """
+
+    ok: bool
+    message: str
+    status_set: Optional[str] = None
+    staled_steps: list[str] = field(default_factory=list)
+    missing_required: list[str] = field(default_factory=list)
+    missing_recommended: list[str] = field(default_factory=list)
+
+
+def commit(project_dir: Path | str, status: str) -> CommitResult:
+    """Record the brand step's result in STATE.md and propagate staleness.
+
+    On ``approved`` the project's ``DESIGN-TOKENS.md`` must exist and contain the
+    required core sections, or the commit is refused (so the model fixes it and
+    re-commits). On ``skipped`` the **skip precondition** applies: branding is too
+    important to skip blank, so ``branding/branding.md`` must exist first, else the
+    commit is refused. On either accepted status, every downstream ``approved`` step
+    is flipped to ``stale`` (CONTRACT.md §4.2) - a no-op on a first run, but the
+    guard that keeps a re-run from silently disagreeing with the rest of the pipeline.
+
+    Args:
+        project_dir: The analyst's project directory.
+        status: The status to record for ``brand`` - one of :data:`COMMIT_STATUSES`.
+
+    Returns:
+        A :class:`CommitResult`. ``ok`` is False (and STATE.md is left untouched)
+        when the entry gate is closed, an approval's token file is incomplete, or a
+        skip lacks ``branding/branding.md``.
+
+    Raises:
+        ValueError: If ``status`` is not an allowed commit status.
+    """
+    if status not in COMMIT_STATUSES:
+        allowed = " | ".join(COMMIT_STATUSES)
+        raise ValueError(f"Invalid brand status '{status}'. Allowed: {allowed}.")
+
+    project_root = Path(project_dir)
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return CommitResult(False, blocker)
+
+    missing_recommended: list[str] = []
+    if status == "approved":
+        tokens_path = project_root / DESIGN_TOKENS_FILENAME
+        if not tokens_path.exists():
+            return CommitResult(
+                False,
+                f"Cannot approve brand: '{DESIGN_TOKENS_FILENAME}' does not exist. "
+                f"Author it first, or commit '--status skipped' to skip this step "
+                f"(only possible once 'branding/branding.md' exists).",
+            )
+        ok, missing_required, missing_recommended = validate_design_tokens(
+            tokens_path.read_text(encoding="utf-8-sig")
+        )
+        if not ok:
+            return CommitResult(
+                False,
+                f"'{DESIGN_TOKENS_FILENAME}' is missing required section(s): "
+                f"{', '.join(missing_required)}. Add them and re-run commit.",
+                missing_required=missing_required,
+                missing_recommended=missing_recommended,
+            )
+    elif status == "skipped" and not (project_root / BRANDING_SPEC).exists():
+        # Skip precondition: branding is too important to skip with no brand intent
+        # on file. Force engagement (a spec, an org .twb, or the brand interview).
+        return CommitResult(
+            False,
+            f"Cannot skip brand: '{BRANDING_SPEC}' does not exist. Branding drives "
+            f"how well the mock and the Tableau spec turn out, so this step can't be "
+            f"skipped blank. Provide '{BRANDING_SPEC}', drop an org '*.twb' in "
+            f"'branding/', or answer the brand interview to generate it - then skip "
+            f"if you still want neutral tokens.",
+        )
+
+    state_path = project_root / STATE_FILENAME
+    text = state_path.read_text(encoding="utf-8-sig")
+    statuses = parse_statuses(text)
+
+    stale_updates = _downstream_stale_updates(statuses)
+    updates = {BRAND_STEP: status, **stale_updates}
+    state_path.write_text(apply_status_updates(text, updates), encoding="utf-8")
+
+    staled_steps = sorted(stale_updates, key=STEP_ORDER.index)
+    logger.info(f"Set brand -> {status}; marked stale: {staled_steps or 'none'}.")
+    return CommitResult(
+        ok=True,
+        message=f"brand -> {status}",
+        status_set=status,
+        staled_steps=staled_steps,
+        missing_recommended=missing_recommended,
+    )
+
+
+# --- CLI ---------------------------------------------------------------------
+
+def format_precheck(result: PrecheckResult) -> str:
+    """Render a :class:`PrecheckResult` as a human-readable block.
+
+    Args:
+        result: The precheck result to render.
+
+    Returns:
+        A multi-line, plain-ASCII string suitable for printing to the analyst.
+    """
+    # Plain ASCII only: this prints to the console, which on Windows is cp1252
+    # and would raise UnicodeEncodeError on emoji/box-drawing glyphs.
+    if not result.can_run:
+        return f"[BLOCKED] tableau-brand cannot run.\n{result.blocker}"
+
+    lines = ["[BRAND] precheck OK - tableau-brand can run."]
+    lines.append(f"  DESIGN-TOKENS.md exists : {'yes' if result.tokens_exist else 'no'}")
+    if result.tokens_exist:
+        lines.append(
+            "    -> tokens already exist; offer REFINE vs OVERWRITE - never silently "
+            "overwrite the analyst's work."
+        )
+
+    source_notes = {
+        SOURCE_SPEC_AND_TWB: (
+            f"branding/branding.md + org .twb ({', '.join(result.twb_files)}) - "
+            "scrape the .twb to ENRICH the existing branding.md, then build tokens."
+        ),
+        SOURCE_SPEC: "branding/branding.md (production spec) - extract tokens from it.",
+        SOURCE_TWB: (
+            f"org .twb only ({', '.join(result.twb_files)}) - scrape it, WRITE "
+            "branding/branding.md, then build tokens. Ask the analyst to confirm the "
+            ".twb is as THIN as possible so context does not explode."
+        ),
+        SOURCE_SCAFFOLD: (
+            f"{SCAFFOLD_BRANDING_SPEC} (DEMO fallback - say so; there is no production "
+            "branding/branding.md)."
+        ),
+        SOURCE_NONE: (
+            "none - run the brand interview (<=10 questions) and WRITE "
+            "branding/branding.md from the answers, then build tokens."
+        ),
+    }
+    lines.append(f"  source                  : {source_notes[result.source_mode]}")
+
+    if result.assets:
+        lines.append(f"  assets to integrate     : {', '.join(result.assets)}")
+
+    skip_note = (
+        "allowed (branding/branding.md exists)"
+        if result.can_skip
+        else "NOT allowed yet - branding/branding.md must exist first"
+    )
+    lines.append(f"  skip                    : {skip_note}")
+
+    rerun_note = (
+        " (re-run; downstream approved steps will be marked stale on commit)"
+        if result.brand_status in ("approved", "stale")
+        else ""
+    )
+    lines.append(f"  brand status            : {result.brand_status}{rerun_note}")
+    return "\n".join(lines)
+
+
+def format_commit(result: CommitResult) -> str:
+    """Render a :class:`CommitResult` as a human-readable block.
+
+    Args:
+        result: The commit result to render.
+
+    Returns:
+        A multi-line, plain-ASCII string suitable for printing to the analyst.
+    """
+    # Plain ASCII only (see format_precheck).
+    if not result.ok:
+        return f"[REFUSED] {result.message}"
+
+    lines = [f"[BRAND] {result.message}."]
+    if result.missing_recommended:
+        lines.append(
+            f"  note: tokens have no {', '.join(result.missing_recommended)} "
+            f"section(s) - optional, left as-is."
+        )
+    if result.staled_steps:
+        lines.append(
+            f"  downstream marked stale: {', '.join(result.staled_steps)} "
+            f"(re-run these in order)."
+        )
+    lines.append(
+        "  next: open a fresh conversation and run 'tableau-route' (or 'tableau-plan')."
+    )
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point: run ``precheck`` or ``commit`` and print the result.
+
+    Args:
+        argv: Argument list (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Process exit code: ``0`` on success, ``2`` when brand is blocked/refused or
+        on a usage error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Gate, validate, and commit the tableau-brand step.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    precheck_parser = subparsers.add_parser(
+        "precheck", help="Report whether brand may run, what to read, and skip-ability."
+    )
+    precheck_parser.add_argument(
+        "project_dir", nargs="?", default=".", help="Project directory (default: cwd)."
+    )
+
+    commit_parser = subparsers.add_parser(
+        "commit", help="Record brand's result in STATE.md and propagate staleness."
+    )
+    commit_parser.add_argument(
+        "project_dir", nargs="?", default=".", help="Project directory (default: cwd)."
+    )
+    commit_parser.add_argument(
+        "--status", required=True, choices=COMMIT_STATUSES,
+        help="Status to record for the brand step.",
+    )
+
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    if args.command == "precheck":
+        precheck_result = precheck(args.project_dir)
+        print(format_precheck(precheck_result))
+        return 0 if precheck_result.can_run else 2
+
+    commit_result = commit(args.project_dir, args.status)
+    print(format_commit(commit_result))
+    return 0 if commit_result.ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ _SKILL_SCRIPT_DIRS = (
     _REPO_ROOT / "skills" / "tableau-init" / "scripts",
     _REPO_ROOT / "skills" / "tableau-intake" / "scripts",
     _REPO_ROOT / "skills" / "tableau-data" / "scripts",
+    _REPO_ROOT / "skills" / "tableau-brand" / "scripts",
 )
 
 for _script_dir in _SKILL_SCRIPT_DIRS:

--- a/tests/test_brand.py
+++ b/tests/test_brand.py
@@ -1,0 +1,353 @@
+"""Contract test for tableau-brand (CONTRACT.md step 4, §3.1, §4.1, §4.2).
+
+``tableau-brand`` is the skippable design-token step. Its token *content* is
+model-authored, so this test pins the parts ``brand.py`` must mechanically
+guarantee:
+
+1. the entry gate (brand refuses until ``init`` is ``approved``, §4.1);
+2. the precheck signals the skill branches on (existing tokens, branding source
+   mode, logo/icon assets, and whether skip is allowed);
+3. the DESIGN-TOKENS schema - a required core (Colors, Typography, Spacing,
+   Fallback Decisions) is enforced while Logo/Icons/Sizing stay optional, and a
+   refined file that keeps custom sections still validates;
+4. the **skip precondition** - skipping is refused until ``branding/branding.md``
+   exists, because branding is too important to skip blank;
+5. the STATE.md transition + staleness propagation (§4.2), cross-checked by routing
+   the resulting manifest through the *router's* own ``compute_next_step``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import brand   # the skill under test (on sys.path via conftest.py)
+import init    # builds a realistic STATE.md the same way a real project would
+import route   # the router parses/routes the STATE.md brand writes
+
+TARGET_VERSION = "2024.2-2025.x"
+
+# A schema-complete token file (required core present) plus optional sections.
+FULL_TOKENS = (
+    "# Design Tokens\n\n"
+    "## Source\nbranding/branding.md\n\n"
+    "## Typography\nFont: Tableau Medium.\n\n"
+    "## Colors\nBlue #2e75b6.\n\n"
+    "## Spacing\nCard padding 8px.\n\n"
+    "## Dashboard Sizing\nRange, min 1100x800, max Flex.\n\n"
+    "## Fallback Decisions\nNone — all values came from the brand source.\n"
+)
+
+# Only the required core - valid even with no logo, icons, or explicit sizing.
+CORE_ONLY_TOKENS = (
+    "# Design Tokens\n\n"
+    "## Colors\nBlue #2e75b6.\n\n"
+    "## Typography\nFont: Tableau Medium.\n\n"
+    "## Spacing\nCard padding 8px.\n\n"
+    "## Fallback Decisions\nNone.\n"
+)
+
+# Missing required sections (has Colors but no Typography/Spacing/Fallbacks).
+INCOMPLETE_TOKENS = "# Design Tokens\n\n## Colors\nBlue #2e75b6.\n"
+
+
+def _write_state(project_dir: Path, **status_overrides: str) -> None:
+    """Write a canonical STATE.md, optionally overriding some step statuses.
+
+    Args:
+        project_dir: Directory to write ``STATE.md`` into.
+        **status_overrides: ``step=status`` pairs to apply on top of a fresh
+            manifest (e.g. ``brand="approved"``).
+    """
+    text = init.render_state_md(TARGET_VERSION)
+    if status_overrides:
+        text = brand.apply_status_updates(text, {k: v for k, v in status_overrides.items()})
+    (project_dir / "STATE.md").write_text(text, encoding="utf-8")
+
+
+def _write_branding_spec(project_dir: Path, body: str = "# Branding\nBlue brand.\n") -> None:
+    """Create a production ``branding/branding.md`` in the project.
+
+    Args:
+        project_dir: The project directory.
+        body: Spec contents (the brand step doesn't parse it here).
+    """
+    branding_dir = project_dir / "branding"
+    branding_dir.mkdir(exist_ok=True)
+    (branding_dir / "branding.md").write_text(body, encoding="utf-8")
+
+
+# --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
+
+def test_precheck_blocks_when_no_state(tmp_path):
+    """No STATE.md ⇒ brand cannot run; the blocker points at tableau-init."""
+    result = brand.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "tableau-init" in result.blocker
+
+
+def test_precheck_blocks_when_init_not_approved(tmp_path):
+    """init must be approved before brand runs (§4.1)."""
+    _write_state(tmp_path, init="pending")
+
+    result = brand.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "init" in result.blocker and "pending" in result.blocker
+
+
+def test_commit_refuses_when_init_not_approved(tmp_path):
+    """The same gate guards commit, not just precheck."""
+    _write_state(tmp_path, init="pending")
+    (tmp_path / "DESIGN-TOKENS.md").write_text(FULL_TOKENS, encoding="utf-8")
+
+    result = brand.commit(tmp_path, status="approved")
+
+    assert result.ok is False
+    assert "init" in result.message
+    # STATE.md must be untouched: brand stays pending.
+    assert route.parse_state(tmp_path / "STATE.md").statuses["brand"] == "pending"
+
+
+# --- Precheck signals --------------------------------------------------------
+
+def test_precheck_detects_existing_tokens(tmp_path):
+    """precheck reports whether DESIGN-TOKENS.md exists (refine-vs-overwrite signal)."""
+    _write_state(tmp_path)
+    assert brand.precheck(tmp_path).tokens_exist is False
+
+    (tmp_path / "DESIGN-TOKENS.md").write_text(FULL_TOKENS, encoding="utf-8")
+    assert brand.precheck(tmp_path).tokens_exist is True
+
+
+def test_source_mode_prefers_production_spec_over_scaffold(tmp_path):
+    """branding/branding.md > scaffold/ demo example > none (§3.1)."""
+    # A scaffolded project has only the scaffold/ demo example.
+    init.scaffold_project(tmp_path, target_version=TARGET_VERSION)
+    assert brand.precheck(tmp_path).source_mode == brand.SOURCE_SCAFFOLD
+
+    # Adding a production branding.md flips the source to the spec.
+    _write_branding_spec(tmp_path)
+    assert brand.precheck(tmp_path).source_mode == brand.SOURCE_SPEC
+
+
+def test_source_mode_none_when_nothing_present(tmp_path):
+    """With neither production branding/ nor the scaffold example, the source is none."""
+    _write_state(tmp_path)  # bare project: STATE.md only, no scaffold/ files
+
+    assert brand.precheck(tmp_path).source_mode == brand.SOURCE_NONE
+
+
+def test_source_mode_twb_only(tmp_path):
+    """An org .twb with no branding.md ⇒ 'twb' mode (scrape it, write branding.md)."""
+    _write_state(tmp_path)
+    branding_dir = tmp_path / "branding"
+    branding_dir.mkdir()
+    (branding_dir / "template.twb").write_text("<workbook/>", encoding="utf-8")
+
+    result = brand.precheck(tmp_path)
+
+    assert result.source_mode == brand.SOURCE_TWB
+    assert result.twb_files == ("branding/template.twb",)
+
+
+def test_source_mode_spec_plus_twb(tmp_path):
+    """branding.md + an org .twb ⇒ 'spec+twb' mode (enrich the spec from the .twb)."""
+    _write_state(tmp_path)
+    _write_branding_spec(tmp_path)
+    (tmp_path / "branding" / "org.twb").write_text("<workbook/>", encoding="utf-8")
+
+    result = brand.precheck(tmp_path)
+
+    assert result.source_mode == brand.SOURCE_SPEC_AND_TWB
+    assert result.twb_files == ("branding/org.twb",)
+
+
+def test_precheck_reports_logo_and_icon_assets(tmp_path):
+    """Logo files and a populated icons/ dir are surfaced for the model to integrate."""
+    _write_state(tmp_path)
+    _write_branding_spec(tmp_path)
+    (tmp_path / "branding" / "logo.svg").write_text("<svg/>", encoding="utf-8")
+    icons_dir = tmp_path / "branding" / "icons"
+    icons_dir.mkdir()
+    (icons_dir / "bar-chart.svg").write_text("<svg/>", encoding="utf-8")
+
+    assets = brand.precheck(tmp_path).assets
+
+    assert "branding/logo.svg" in assets
+    assert "branding/icons/" in assets
+
+
+# --- DESIGN-TOKENS schema ----------------------------------------------------
+
+def test_validate_tokens_required_core():
+    """A token file missing the required core is invalid and names what's missing."""
+    ok, missing_required, _ = brand.validate_design_tokens(INCOMPLETE_TOKENS)
+
+    assert ok is False
+    assert set(missing_required) == {"Typography", "Spacing", "Fallback Decisions"}
+
+
+def test_validate_tokens_recommended_are_optional():
+    """Core-only token file is valid; absent recommended sections are merely reported."""
+    ok, missing_required, missing_recommended = brand.validate_design_tokens(CORE_ONLY_TOKENS)
+
+    assert ok is True
+    assert missing_required == []
+    # Source/Dashboard Sizing/Logo/Icons absent — reported, but not a failure.
+    assert set(missing_recommended) == set(brand.DESIGN_TOKENS_RECOMMENDED_SECTIONS)
+
+
+def test_validate_tokens_allows_custom_sections_when_refining():
+    """A refined token file that keeps the core plus custom sections still validates."""
+    refined = CORE_ONLY_TOKENS + "\n## Constraints\nNo rounded corners.\n"
+
+    ok, missing_required, _ = brand.validate_design_tokens(refined)
+
+    assert ok is True and missing_required == []
+
+
+def test_shipped_template_is_schema_complete():
+    """The bundled DESIGN-TOKENS-TEMPLATE.md contains the required core."""
+    ok, missing_required, _ = brand.validate_design_tokens(brand.render_design_tokens_template())
+
+    assert ok is True and missing_required == []
+
+
+def test_fallback_reference_is_readable():
+    """The owned fallback-defaults reference ships and is non-empty."""
+    text = brand.render_fallback_reference()
+
+    assert "Fallback Design Tokens" in text
+
+
+# --- Commit: approve, skip, refuse -------------------------------------------
+
+def test_commit_approved_with_complete_tokens(tmp_path):
+    """A schema-complete token file commits: brand → approved in STATE.md."""
+    _write_state(tmp_path)
+    (tmp_path / "DESIGN-TOKENS.md").write_text(FULL_TOKENS, encoding="utf-8")
+
+    result = brand.commit(tmp_path, status="approved")
+
+    assert result.ok is True
+    assert route.parse_state(tmp_path / "STATE.md").statuses["brand"] == "approved"
+
+
+def test_commit_approved_refuses_incomplete_tokens(tmp_path):
+    """commit refuses to approve tokens missing the required core; STATE is untouched."""
+    _write_state(tmp_path)
+    (tmp_path / "DESIGN-TOKENS.md").write_text(INCOMPLETE_TOKENS, encoding="utf-8")
+
+    result = brand.commit(tmp_path, status="approved")
+
+    assert result.ok is False
+    assert "Typography" in result.message and "Fallback Decisions" in result.message
+    assert route.parse_state(tmp_path / "STATE.md").statuses["brand"] == "pending"
+
+
+def test_commit_approved_refuses_when_tokens_absent(tmp_path):
+    """Approving without a DESIGN-TOKENS.md on disk is refused (nothing to approve)."""
+    _write_state(tmp_path)
+
+    result = brand.commit(tmp_path, status="approved")
+
+    assert result.ok is False
+    assert "DESIGN-TOKENS.md" in result.message
+
+
+def test_commit_core_only_tokens_succeeds_and_notes_recommended(tmp_path):
+    """A core-only token file commits; missing recommended is just a note."""
+    _write_state(tmp_path)
+    (tmp_path / "DESIGN-TOKENS.md").write_text(CORE_ONLY_TOKENS, encoding="utf-8")
+
+    result = brand.commit(tmp_path, status="approved")
+
+    assert result.ok is True
+    assert set(result.missing_recommended) == set(brand.DESIGN_TOKENS_RECOMMENDED_SECTIONS)
+
+
+def test_commit_rejects_unknown_status(tmp_path):
+    """An out-of-vocabulary status is a programming error, not a silent no-op."""
+    _write_state(tmp_path)
+
+    with pytest.raises(ValueError, match="brand status"):
+        brand.commit(tmp_path, status="approve")  # typo: not in COMMIT_STATUSES
+
+
+# --- Skip precondition (brand-specific) --------------------------------------
+
+def test_skip_refused_without_branding_spec(tmp_path):
+    """Skip is refused when branding/branding.md does not exist (too important)."""
+    _write_state(tmp_path)
+
+    result = brand.commit(tmp_path, status="skipped")
+
+    assert result.ok is False
+    assert "branding/branding.md" in result.message
+    # STATE.md untouched: brand stays pending, not skipped.
+    assert route.parse_state(tmp_path / "STATE.md").statuses["brand"] == "pending"
+
+
+def test_precheck_can_skip_tracks_branding_spec(tmp_path):
+    """precheck.can_skip is False without branding.md, True once it exists."""
+    _write_state(tmp_path)
+    assert brand.precheck(tmp_path).can_skip is False
+
+    _write_branding_spec(tmp_path)
+    assert brand.precheck(tmp_path).can_skip is True
+
+
+def test_commit_skipped_succeeds_with_branding_spec_and_does_not_block(tmp_path):
+    """With branding.md present, skipping records 'skipped' and the pipeline continues."""
+    _write_state(tmp_path, intake="approved", data="approved")
+    _write_branding_spec(tmp_path)
+    # plan's ordering gate needs DATA-MODEL.md on disk (data is the producer).
+    (tmp_path / "DATA-MODEL.md").write_text("# Data Model\n", encoding="utf-8")
+
+    result = brand.commit(tmp_path, status="skipped")
+
+    assert result.ok is True
+    statuses = route.parse_state(tmp_path / "STATE.md").statuses
+    assert statuses["brand"] == "skipped"
+    # 'skipped' is resolved; the router advances past brand to plan.
+    assert route.compute_next_step(tmp_path).next_step == "plan"
+
+
+# --- Staleness propagation (CONTRACT.md §4.2) --------------------------------
+
+def test_rerun_marks_downstream_approved_steps_stale(tmp_path):
+    """Re-running brand flips downstream approved steps to stale; upstream untouched."""
+    # Mid-pipeline: upstream (intake, data) resolved; brand+plan+mock approved.
+    _write_state(
+        tmp_path, intake="approved", data="approved",
+        brand="approved", plan="approved", mock="approved",
+    )
+    (tmp_path / "DESIGN-TOKENS.md").write_text(FULL_TOKENS, encoding="utf-8")
+    # plan's ordering gate needs DATA-MODEL.md on disk for the router cross-check.
+    (tmp_path / "DATA-MODEL.md").write_text("# Data Model\n", encoding="utf-8")
+
+    result = brand.commit(tmp_path, status="approved")
+
+    assert result.ok is True
+    # plan and mock (downstream, approved) flip to stale, in canonical order.
+    assert result.staled_steps == ["plan", "mock"]
+
+    statuses = route.parse_state(tmp_path / "STATE.md").statuses
+    assert statuses["plan"] == "stale" and statuses["mock"] == "stale"
+    assert statuses["data"] == "approved"   # upstream — left as-is
+    assert statuses["brand"] == "approved"  # its own step re-approved
+
+    # Cross-check through the router: the first unresolved step is now stale 'plan'.
+    routed = route.compute_next_step(tmp_path)
+    assert routed.next_step == "plan" and "stale" in routed.reason.lower()
+
+
+def test_first_run_marks_nothing_stale(tmp_path):
+    """On a first approval there is nothing downstream approved, so nothing goes stale."""
+    _write_state(tmp_path)
+    (tmp_path / "DESIGN-TOKENS.md").write_text(FULL_TOKENS, encoding="utf-8")
+
+    result = brand.commit(tmp_path, status="approved")
+
+    assert result.ok is True and result.staled_steps == []


### PR DESCRIPTION
Closes #10.

Adds **step 4** of the `tableau-dashboard-plugin` workflow: the skippable design-token skill that turns the analyst's branding into a `DESIGN-TOKENS.md` (palette, type, spacing), so `tableau-mock` and `tableau-build` match brand. Structurally mirrors `tableau-intake`'s `precheck → author → commit` pattern.

## What it does
- **Two optional `branding/` inputs**: a `branding.md` spec and/or an org template `*.twb` (scraped to write/enrich `branding.md`), plus `logo`/`icons` integration. Precheck reports 5 source modes (`spec`, `spec+twb`, `twb`, `scaffold`, `none`).
- **Importance + thinness notices**: the skill tells the analyst branding drives mock/spec quality (don't skimp), and asks them to confirm any `.twb` is minimal before scraping so context doesn't explode.
- **≤10-question brand interview** (grill-me–style) when no branding exists → writes `branding.md`.
- **Skippable only once `branding/branding.md` exists** — enforced in `brand.py` (`commit --status skipped` is refused otherwise) and surfaced as `can_skip` in precheck.

## Design defaults (web-verified)
Native Tableau font family (Bold/Medium/Light); cohesive ≤5-color palette; Range sizing with no max (Flex; Automatic avoided); worksheet headers hidden with titles as **Text objects**; collapsible filter panel via a **Show/Hide button** (not DZV).

## Contract
- Required reads: none (input-driven). Entry gate: `init` approved. Honors ordering / staleness / naming / versioning.
- `CONTRACT.md §2`: documents that **skip preconditions are skill-specific** — brand only accepts `skipped` once `branding/branding.md` exists.

## Acceptance criteria
- [x] Extracts palette/type/spacing into `DESIGN-TOKENS.md` from `branding.md` or a `.twb`.
- [x] Every fallback-default value flagged (`## Fallback Decisions` required section).
- [x] Skip path records `skipped`, yields neutral styling, doesn't block the pipeline.
- [x] Honors CONTRACT.md (gate on `init` approved; re-run flips downstream to `stale`).
- [x] Contract test: skip path records `skipped` and downstream still runs with neutral tokens.

## Testing
24 new contract tests in `tests/test_brand.py`; full suite **137 passed**. CLI smoke confirmed all branches (blocked → scaffold → skip-refused → skip-allowed → approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)