### PR TITLE
feat: tableau-mock skill — interactive mock.html demo with coverage guard (Step 6 of 8)

### DIFF
--- a/skills/tableau-mock/SKILL.md
+++ b/skills/tableau-mock/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: tableau-mock
+description: Renders the interactive HTML demo (mock.html) for the tableau-dashboard-plugin workflow at the plan's screen size, populated from the real sample CSVs, so the analyst can share a realistic demo and validate direction before any Tableau work. Builds strictly from DASHBOARD-PLAN.md — every KPI, chart, filter, and interaction — and ends with a coverage checklist proving each plan element (screen size, every filter, every interaction) was rendered, so omissions are visible before the stakeholder sees it. Enforces readable slot sizing (no compressed, out-of-bounds, or empty-space-heavy charts). Reads DASHBOARD-PLAN.md and the sample CSVs, and DESIGN-TOKENS.md if present. Use when the user wants to build the mock, render the demo, or when tableau-route reports mock is next. Step 6 of 8 in the workflow.
+disable-model-invocation: true
+allowed-tools: Read, Write, Edit, AskUserQuestion, Bash(python *), Bash(python3 *)
+---
+
+# tableau-mock
+
+Step 6 of 8, and **non-skippable**. It turns the strict `DASHBOARD-PLAN.md` into an
+interactive `mock.html` demo — rendered at the plan's screen size and populated from the
+**real sample CSVs** — that the analyst shares so the stakeholder can validate the
+dashboard direction *before any Tableau work begins*. The mock ends with a **coverage
+checklist** proving every plan element was rendered, so nothing is silently dropped
+before the demo goes out.
+
+| | |
+|---|---|
+| **Reads** | **Required:** `DASHBOARD-PLAN.md` (from `plan`) — the blueprint, including the screen size and every element/filter/interaction id; and the sample CSVs (`data/*.csv`, demo fallback `scaffold/sample-data/*.csv`) — the real rows the demo shows. **Optional (enrich, never block):** `DESIGN-TOKENS.md` (from `brand`; absent ⇒ neutral styling). |
+| **Writes** | `mock-version/<v_N>/mock.html` — a full standalone deliverable copy (CONTRACT.md §4.3). |
+| **STATE.md update** | Sets `mock` = `approved` and `current_version` to the target `v_N`; flips every downstream `approved` step (`spec`/`build`) to `stale` on a re-run (CONTRACT.md §4.2). |
+| **Entry gate** | Refuses to run until `plan` is resolved **and** `DASHBOARD-PLAN.md` exists, **and** `data` is resolved **and** a sample CSV exists (CONTRACT.md §4.1). |
+| **Next step** | `tableau-spec` (or `tableau-route` to confirm). |
+
+The mechanical guarantees — the entry gate, the **coverage checklist** (every plan
+element rendered), the **slot-sizing guard** (no compressed / out-of-bounds /
+empty-space-heavy layouts), the version bump, and the STATE.md transition — live in
+`mock.py` (CLI) and `coverage.py` (the checklist + guard core). Your job is the judgment
+part: designing a faithful, attractive demo that renders the plan at its screen size with
+real data. Run the script at the points below; do not hand-edit `STATE.md`.
+
+## The two conventions the coverage check depends on
+
+`coverage.py` decides "rendered" mechanically, so the mock **must** carry two machine-readable
+markers (see `references/MOCK-SKELETON.html` for a working example):
+
+1. **`data-plan-id="<id>"`** on every rendered KPI, chart, filter control, and interaction
+   trigger. The `<id>` must match the plan's Elements / Filters / Interactions tables
+   **exactly**. A plan id with no matching `data-plan-id` is a **coverage gap** that blocks
+   approval — this is what makes "every element rendered" a guarantee, not a hope.
+2. **An embedded JSON layout manifest** — one `<script type="application/json" id="mock-layout">`
+   block giving the `canvas` size and a pixel box `{id, x, y, width, height}` for every
+   **element** id (KPIs/charts; filters and interactions need no box). The slot-sizing guard
+   reads it; the `canvas` width/height **must equal** the plan's Screen Size dimensions.
+
+## How to run
+
+1. **Precheck.** From the project directory, run:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/mock.py" precheck "<project-dir>"
+   ```
+
+   (Use `python3` if `python` is unavailable.) If it prints `[BLOCKED]`, relay the reason
+   and **stop** — the analyst must resolve the named upstream step (`tableau-plan` for the
+   blueprint, `tableau-data` for the samples) first. Otherwise note its signals: the
+   **canvas size** to render at, the **coverage targets** (element/filter/interaction
+   counts), the **target version path** to write `mock.html` into (and whether this run
+   **bumps the version** because the mock was already approved), and whether
+   `DESIGN-TOKENS.md` is present.
+
+2. **Read the inputs.** Read `DASHBOARD-PLAN.md` in full — its Screen Size, Layout Grid,
+   Elements, Filters, and Interactions tables are your build list; use the ids verbatim.
+   Read the **sample CSVs** (`data/*.csv`, or `scaffold/sample-data/*.csv` — if you fall
+   back to the demo samples, **say so**) and populate every chart/KPI from the real rows —
+   do not invent numbers. If `DESIGN-TOKENS.md` is present, apply its colors/typography;
+   if absent, use neutral styling.
+
+3. **Author `mock.html`** at the precheck's **target version path**
+   (`mock-version/<v_N>/mock.html`). Render at the plan's screen size, lay out every
+   element in its planned slot, wire the filters and interactions, and tag everything with
+   `data-plan-id` + embed the `mock-layout` manifest (see the two conventions above and
+   `references/MOCK-SKELETON.html`). When **refining** an existing mock at this version,
+   `Edit` it in place. Keep the file **self-contained** (inline CSS/JS; no external fetches)
+   so the analyst can open and share it directly.
+
+4. **Slot sizing.** Give each element a readable box inside the canvas — not so small it
+   compresses (the guard rejects boxes under ~80×56px), not overflowing the canvas
+   (out-of-bounds), and collectively filling the canvas (the guard rejects layouts that
+   leave it mostly empty). Make the manifest boxes match what you actually render.
+
+5. **Self-check, then present.** Validate the draft before showing it:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/mock.py" validate "<project-dir>"
+   ```
+
+   It prints the **coverage checklist** (one line per screen size / element / filter /
+   interaction, each `[x]` rendered or `[ ] <- MISSING`) and the **slot-sizing guard**
+   result. If it prints `[INVALID]`, fix the flagged gaps/violations and re-run. When it
+   prints `[OK]`, **show the checklist to the analyst** (it's the proof nothing was
+   dropped) and present the mock for approval.
+
+6. **Commit** — only after the analyst approves:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/mock.py" commit "<project-dir>"
+   ```
+
+   Commit re-runs the full coverage + guard check (mock is non-skippable, so it only ever
+   sets `approved`). If it prints `[REFUSED]`, fix what the checklist names and re-run. On
+   success it records `mock` = `approved`, sets `current_version` to the target `v_N`, and
+   reports any downstream steps it marked `stale`. Relay the summary and tell the analyst
+   to open a fresh conversation and run the next step (`tableau-spec`, or `tableau-route`
+   to confirm).
+
+## Shared interactions vocabulary (CONTRACT.md §6)
+
+The plan's interactions use these intent-level terms; render each so its intent is
+demonstrable in the demo (the Tableau construct is chosen later, in `spec`):
+
+| term | render in the mock as |
+|------|------------------------|
+| `toggle panel` | a control that shows/hides a region. |
+| `swap view` | a control that replaces one chart with an alternative in the same slot. |
+| `drill` | click-through between hierarchy levels (year → quarter → month) in place. |
+| `cross-filter` | clicking marks in one chart filters the others. |
+| `highlight` | clicking/hovering marks highlights related marks elsewhere (no filtering). |
+| `parameter swap` | a control that changes a measure/dimension/threshold across views. |
+
+## Notes
+
+- **Non-skippable.** The workflow has no demo without the mock; `commit` only ever sets
+  `approved`.
+- **Versioned deliverable.** `mock.html` lives under `mock-version/<v_N>/` (CONTRACT.md
+  §4.3): re-running **after approval** bumps `current_version` to a fresh `v_N` and writes
+  a full standalone copy there, preserving prior versions; re-running **before** approval
+  overwrites the current `v_N`. The target path is reported by `precheck`.
+- **Real data, real field names.** Populate from the sample CSVs and reference the same
+  field names the plan uses — that's how the demo lines up with the data model and, later,
+  the workbook.
+
+> The full `STATE.md` schema and the ordering / staleness / versioning rules live in
+> `CONTRACT.md` at the repo root. This skill restates only its own slice; `mock.py` /
+> `coverage.py` are the executable mirror of the contract it enforces.

--- a/skills/tableau-mock/references/MOCK-SKELETON.html
+++ b/skills/tableau-mock/references/MOCK-SKELETON.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<!--
+  tableau-mock skeleton. This shows the two conventions mock.py's coverage checklist
+  and slot-sizing guard depend on - copy them, then build the real demo on top:
+
+    1. data-plan-id="<id>"  on every rendered KPI/chart/filter/interaction control.
+       The <id> must match the plan's Elements/Filters/Interactions tables exactly.
+       A plan id with no matching data-plan-id is a COVERAGE GAP and blocks approval.
+
+    2. A single <script type="application/json" id="mock-layout"> manifest declaring the
+       canvas size and a pixel box {id, x, y, width, height} for every ELEMENT id (the
+       KPIs/charts - not filters or interactions). The guard checks each box is in-bounds,
+       readable (>= 80x56px), and that boxes fill >= 45% of the canvas. The canvas
+       width/height MUST equal the plan's Screen Size dimensions.
+
+  The canvas size is NOT fixed by this skill - it comes from the plan's `## Screen Size`
+  section. The 1366x768 below is only the example the DASHBOARD-PLAN template ships with;
+  replace it with your plan's actual dimensions everywhere it appears.
+
+  Populate every chart from the REAL sample CSVs (read them; do not invent numbers).
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Dashboard Mock</title>
+  <style>
+    body { margin: 0; font-family: system-ui, sans-serif; background: #f4f5f7; }
+    /* The canvas is the fixed design size from the plan's Screen Size section. */
+    .canvas { position: relative; width: 1366px; height: 768px; margin: 16px auto; background: #fff; }
+    .filter-bar { display: flex; gap: 12px; padding: 12px; height: 56px; box-sizing: border-box; }
+    .kpi-row { display: flex; gap: 12px; padding: 0 12px; }
+    .kpi { flex: 1; min-height: 120px; border: 1px solid #e1e4e8; border-radius: 6px; padding: 12px; }
+    .chart { border: 1px solid #e1e4e8; border-radius: 6px; margin: 12px; min-height: 360px; }
+  </style>
+</head>
+<body>
+  <div class="canvas">
+
+    <!-- Filters: one control per plan Filters-row id. -->
+    <div class="filter-bar">
+      <select data-plan-id="flt-region"><option>All regions</option></select>
+      <input  data-plan-id="flt-date" type="month">
+    </div>
+
+    <!-- Elements: KPIs and charts, each tagged with its plan Elements-row id. -->
+    <div class="kpi-row">
+      <div class="kpi" data-plan-id="kpi-revenue"><div>Revenue</div><strong>$1.2M</strong></div>
+      <div class="kpi" data-plan-id="kpi-orders"><div>Orders</div><strong>3,418</strong></div>
+    </div>
+
+    <!-- Interactions: tag the control/handle that drives each plan Interactions-row id.
+         (e.g. clicking this chart cross-filters the others.) -->
+    <div class="chart" data-plan-id="chart-region" data-interaction="int-region-filter">
+      bar chart: revenue by region (from sample CSV)
+    </div>
+    <div class="chart" data-plan-id="chart-trend">line chart: revenue over time</div>
+
+    <!-- An interaction that has no element of its own still needs its id rendered,
+         e.g. on the control that triggers it: -->
+    <button data-plan-id="int-region-filter" hidden>region cross-filter</button>
+  </div>
+
+  <!-- Slot-sizing manifest: a box for every ELEMENT id. Canvas == plan Screen Size. -->
+  <script type="application/json" id="mock-layout">
+  {
+    "canvas": { "width": 1366, "height": 768 },
+    "elements": [
+      { "id": "kpi-revenue",  "x": 12,  "y": 68,  "width": 665, "height": 120 },
+      { "id": "kpi-orders",   "x": 689, "y": 68,  "width": 665, "height": 120 },
+      { "id": "chart-region", "x": 12,  "y": 200, "width": 665, "height": 360 },
+      { "id": "chart-trend",  "x": 689, "y": 200, "width": 665, "height": 360 }
+    ]
+  }
+  </script>
+</body>
+</html>

--- a/skills/tableau-mock/scripts/coverage.py
+++ b/skills/tableau-mock/scripts/coverage.py
@@ -1,0 +1,392 @@
+"""The coverage + slot-sizing core of the tableau-mock skill (CONTRACT.md step 6).
+
+This is the testable heart of ``tableau-mock``, kept pure (stdlib-only, no STATE.md, no
+filesystem) so the contract test can drive it directly. It owns two jobs:
+
+1. **Coverage** - parse the strict ``DASHBOARD-PLAN.md`` into the set of things the demo
+   must render (the screen size, every KPI/chart, every filter, every interaction), parse
+   the produced ``mock.html`` for what it actually rendered, and build a **coverage
+   checklist** matching the two. A plan element is "rendered" iff its plan ``id`` appears
+   as a ``data-plan-id="<id>"`` attribute in the markup; any plan id with no match is a
+   coverage **gap** that blocks approval. This is the guarantee that the mock can never
+   silently drop a requirement.
+2. **Slot-sizing guard** - read the embedded JSON layout manifest (each element's pixel
+   box) and reject boxes that fall outside the canvas (**out-of-bounds**), are too small
+   to read (**compressed**), or that collectively leave the canvas mostly empty
+   (**empty-space-heavy**), so the demo looks professional.
+
+``mock.py`` owns the STATE.md / versioning / entry-gate plumbing and the CLI; it imports
+:func:`validate_mock` and :func:`parse_plan_coverage` from here.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+#: The id-string the plan uses for a "no filters" / "no interactions" sentinel row
+#: (DASHBOARD-PLAN-TEMPLATE.md). It is not a real element, so coverage skips it.
+NONE_ID = "none"
+
+#: The <script type="application/json" id="..."> block the mock embeds for the guard.
+LAYOUT_MANIFEST_ID = "mock-layout"
+
+# --- Slot-sizing guard thresholds --------------------------------------------
+# ponytail: hand-tuned readability heuristics, not physics. A box narrower/shorter
+# than these reads as unusably compressed; a canvas filled below MIN_FILL_RATIO reads
+# as empty-space-heavy. The fill check sums box areas and so undercounts overlap - good
+# enough to catch a sparse layout. Tune here if they misfire on real plans.
+MIN_ELEMENT_WIDTH_PX = 80
+MIN_ELEMENT_HEIGHT_PX = 56
+MIN_FILL_RATIO = 0.45  # element boxes must cover >= 45% of the canvas area
+
+
+# --- Plan parsing: the expected coverage -------------------------------------
+
+# A markdown table separator cell: "---", ":---", "---:", ":---:".
+_SEPARATOR_CELL = re.compile(r"^:?-+:?$")
+
+# The design canvas in the plan's Screen Size section: "1366 x 768", "1366x768px".
+_DIMENSIONS = re.compile(r"(\d{2,5})\s*[x×]\s*(\d{2,5})", re.IGNORECASE)
+
+
+def _markdown_tables(text: str) -> list[list[list[str]]]:
+    """Split a markdown document into its pipe tables.
+
+    Contiguous runs of lines beginning with ``|`` are grouped into one table; each
+    table is a list of rows, each row a list of trimmed cell strings.
+
+    Args:
+        text: Markdown document contents.
+
+    Returns:
+        A list of tables (each a list of cell-rows).
+    """
+    tables: list[list[list[str]]] = []
+    current: list[list[str]] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("|"):
+            current.append([cell.strip() for cell in line.strip("|").split("|")])
+            continue
+        if current:
+            tables.append(current)
+            current = []
+    if current:
+        tables.append(current)
+    return tables
+
+
+def _is_separator_row(cells: list[str]) -> bool:
+    """Return True if a table row is the ``|---|---|`` header/body separator."""
+    non_empty = [cell for cell in cells if cell]
+    return bool(non_empty) and all(_SEPARATOR_CELL.match(cell) for cell in non_empty)
+
+
+def _screen_size_block(text: str) -> str:
+    """Return the text between the ``## Screen Size`` heading and the next heading.
+
+    Args:
+        text: The contents of a ``DASHBOARD-PLAN.md`` file.
+
+    Returns:
+        The Screen Size section body, or the whole document if the heading is absent
+        (so dimension parsing still gets a chance on a non-standard plan).
+    """
+    out: list[str] = []
+    capturing = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.lower().startswith("## screen size"):
+            capturing = True
+            continue
+        if capturing and stripped.startswith("## "):
+            break
+        if capturing:
+            out.append(line)
+    return "\n".join(out) if out else text
+
+
+@dataclass(frozen=True)
+class PlanCoverage:
+    """The set of things a mock.html must render to fully cover its plan.
+
+    Attributes:
+        canvas: The planned design canvas ``(width, height)`` in px, or ``None`` if the
+            Screen Size dimensions could not be parsed.
+        element_ids: KPI/chart ids (the id-table that has a ``slot`` column). These also
+            need a geometry box in the layout manifest.
+        filter_ids: Filter ids (excludes the ``none`` sentinel).
+        interaction_ids: Interaction ids (excludes the ``none`` sentinel).
+    """
+
+    canvas: Optional[tuple[int, int]]
+    element_ids: list[str]
+    filter_ids: list[str]
+    interaction_ids: list[str]
+
+    @property
+    def all_ids(self) -> list[str]:
+        """list[str]: Every plan id that must appear as a ``data-plan-id`` in the mock."""
+        return [*self.element_ids, *self.filter_ids, *self.interaction_ids]
+
+
+def parse_plan_coverage(text: str) -> PlanCoverage:
+    """Extract the canvas size and every element/filter/interaction id from a plan.
+
+    The plan's id-tables (first column header ``id``) are categorised by their other
+    headers: a ``slot`` column marks the Elements table, an ``interaction`` column the
+    Interactions table, everything else (a ``field``/``control`` table) the Filters
+    table. The ``none`` sentinel row is dropped.
+
+    Args:
+        text: The contents of a ``DASHBOARD-PLAN.md`` file.
+
+    Returns:
+        A :class:`PlanCoverage`.
+    """
+    dims_match = _DIMENSIONS.search(_screen_size_block(text))
+    canvas = (
+        (int(dims_match.group(1)), int(dims_match.group(2))) if dims_match else None
+    )
+
+    element_ids: list[str] = []
+    filter_ids: list[str] = []
+    interaction_ids: list[str] = []
+
+    for table in _markdown_tables(text):
+        rows = [row for row in table if not _is_separator_row(row)]
+        if len(rows) < 2:
+            continue
+        header = [cell.lower() for cell in rows[0]]
+        if not header or header[0] != "id":
+            continue
+
+        ids = [
+            row[0].strip()
+            for row in rows[1:]
+            if row and row[0].strip() and row[0].strip().lower() != NONE_ID
+        ]
+        if "slot" in header:
+            element_ids.extend(ids)
+        elif "interaction" in header:
+            interaction_ids.extend(ids)
+        else:
+            filter_ids.extend(ids)
+
+    return PlanCoverage(canvas, element_ids, filter_ids, interaction_ids)
+
+
+# --- Mock parsing: what the HTML actually rendered ---------------------------
+
+_DATA_PLAN_ID = re.compile(r"""data-plan-id\s*=\s*["']([^"']+)["']""")
+_LAYOUT_SCRIPT = re.compile(
+    r"""<script[^>]*\bid\s*=\s*["']"""
+    + re.escape(LAYOUT_MANIFEST_ID)
+    + r"""["'][^>]*>(.*?)</script>""",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def rendered_plan_ids(html: str) -> set[str]:
+    """Return every ``data-plan-id`` value present in the mock HTML.
+
+    A plan element is "rendered" iff its id appears as a ``data-plan-id`` attribute,
+    so this set is what the coverage checklist matches the plan against.
+
+    Args:
+        html: The contents of a ``mock.html`` file.
+
+    Returns:
+        The set of rendered plan ids.
+    """
+    return {match.group(1).strip() for match in _DATA_PLAN_ID.finditer(html)}
+
+
+def parse_layout_manifest(html: str) -> Optional[dict]:
+    """Parse the embedded JSON layout manifest from the mock HTML.
+
+    Args:
+        html: The contents of a ``mock.html`` file.
+
+    Returns:
+        The parsed manifest dict, or ``None`` if the script block is absent or its body
+        is not a valid JSON object.
+    """
+    match = _LAYOUT_SCRIPT.search(html)
+    if not match:
+        return None
+    try:
+        parsed = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+# --- Coverage checklist + slot-sizing guard ----------------------------------
+
+@dataclass(frozen=True)
+class CoverageItem:
+    """One row of the coverage checklist.
+
+    Attributes:
+        kind: ``"screen size"``, ``"element"``, ``"filter"``, or ``"interaction"``.
+        label: The id (or canvas size) being checked.
+        rendered: Whether the mock renders it.
+    """
+
+    kind: str
+    label: str
+    rendered: bool
+
+
+@dataclass(frozen=True)
+class MockValidation:
+    """Result of validating a ``mock.html`` against its plan.
+
+    Attributes:
+        ok: True iff every plan element is rendered and the slot-sizing guard passes.
+        coverage: The coverage checklist (one item per plan element + screen size).
+        guard_violations: Slot-sizing problems (out-of-bounds / compressed / empty).
+        missing_boxes: Element ids with no geometry box in the layout manifest.
+        notes: Non-fatal observations (e.g. plan had no parseable canvas).
+    """
+
+    ok: bool
+    coverage: list[CoverageItem]
+    guard_violations: list[str]
+    missing_boxes: list[str]
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def gaps(self) -> list[CoverageItem]:
+        """list[CoverageItem]: Coverage rows the mock failed to render."""
+        return [item for item in self.coverage if not item.rendered]
+
+
+def slot_sizing_violations(
+    manifest: Optional[dict], element_ids: list[str]
+) -> tuple[list[str], list[str]]:
+    """Run the slot-sizing guard against the layout manifest.
+
+    Rejects element boxes that are out-of-bounds (outside the canvas), compressed
+    (below the minimum readable width/height), or that collectively leave the canvas
+    mostly empty (empty-space-heavy). A box is expected for every plan element id.
+
+    Args:
+        manifest: The parsed layout manifest, or ``None`` if absent/invalid.
+        element_ids: The plan's element ids (each needs a box).
+
+    Returns:
+        ``(violations, missing_boxes)`` - guard problem strings, and element ids with
+        no declared box.
+    """
+    if not element_ids:
+        return [], []  # nothing visual to size (e.g. an all-filter plan)
+    if manifest is None:
+        return (
+            [f"no '{LAYOUT_MANIFEST_ID}' JSON layout manifest found (or invalid JSON) "
+             "- the slot-sizing guard cannot run"],
+            list(element_ids),
+        )
+
+    canvas = manifest.get("canvas") or {}
+    try:
+        canvas_w = float(canvas.get("width"))
+        canvas_h = float(canvas.get("height"))
+    except (TypeError, ValueError):
+        return ["layout manifest has no numeric canvas {width, height}"], list(element_ids)
+
+    boxes = {
+        str(box.get("id")): box
+        for box in manifest.get("elements", [])
+        if isinstance(box, dict) and box.get("id") is not None
+    }
+    violations: list[str] = []
+    missing_boxes: list[str] = []
+    covered_area = 0.0
+
+    for element_id in element_ids:
+        box = boxes.get(element_id)
+        if box is None:
+            missing_boxes.append(element_id)
+            continue
+        try:
+            x, y = float(box["x"]), float(box["y"])
+            width, height = float(box["width"]), float(box["height"])
+        except (KeyError, TypeError, ValueError):
+            violations.append(
+                f"element '{element_id}' has a malformed box (need x/y/width/height)"
+            )
+            continue
+
+        if x < 0 or y < 0 or x + width > canvas_w or y + height > canvas_h:
+            violations.append(
+                f"element '{element_id}' is out-of-bounds: box "
+                f"({x:g},{y:g},{width:g}x{height:g}) escapes the {canvas_w:g}x{canvas_h:g} canvas"
+            )
+        if width < MIN_ELEMENT_WIDTH_PX or height < MIN_ELEMENT_HEIGHT_PX:
+            violations.append(
+                f"element '{element_id}' is compressed: {width:g}x{height:g}px is below the "
+                f"{MIN_ELEMENT_WIDTH_PX}x{MIN_ELEMENT_HEIGHT_PX}px readable minimum"
+            )
+        covered_area += max(width, 0) * max(height, 0)
+
+    canvas_area = canvas_w * canvas_h
+    if canvas_area > 0 and covered_area / canvas_area < MIN_FILL_RATIO:
+        violations.append(
+            f"layout is empty-space-heavy: elements cover {covered_area / canvas_area:.0%} of "
+            f"the canvas, below the {MIN_FILL_RATIO:.0%} minimum"
+        )
+    return violations, missing_boxes
+
+
+def validate_mock(plan_text: str, html: str) -> MockValidation:
+    """Build the coverage checklist and run the slot-sizing guard for a mock.
+
+    Coverage: every plan element/filter/interaction id must appear as a
+    ``data-plan-id`` in the HTML, and the planned canvas size must be declared in the
+    layout manifest. Guard: every element box must be in-bounds, readable, and the
+    layout must not be empty-space-heavy. The mock is valid iff there are no coverage
+    gaps, no missing boxes, and no guard violations.
+
+    Args:
+        plan_text: The contents of ``DASHBOARD-PLAN.md``.
+        html: The contents of the ``mock.html`` under validation.
+
+    Returns:
+        A :class:`MockValidation`.
+    """
+    spec = parse_plan_coverage(plan_text)
+    rendered = rendered_plan_ids(html)
+    manifest = parse_layout_manifest(html)
+    notes: list[str] = []
+    items: list[CoverageItem] = []
+
+    # Screen size: the manifest's canvas must match the plan's design dimensions.
+    if spec.canvas is None:
+        notes.append(
+            "plan has no parseable Screen Size dimensions - screen-size coverage skipped"
+        )
+    else:
+        plan_w, plan_h = spec.canvas
+        canvas = (manifest or {}).get("canvas") or {}
+        rendered_size = (canvas.get("width"), canvas.get("height"))
+        items.append(CoverageItem(
+            "screen size", f"{plan_w}x{plan_h}px", rendered_size == (plan_w, plan_h),
+        ))
+
+    for element_id in spec.element_ids:
+        items.append(CoverageItem("element", element_id, element_id in rendered))
+    for filter_id in spec.filter_ids:
+        items.append(CoverageItem("filter", filter_id, filter_id in rendered))
+    for interaction_id in spec.interaction_ids:
+        items.append(CoverageItem("interaction", interaction_id, interaction_id in rendered))
+
+    guard_violations, missing_boxes = slot_sizing_violations(manifest, spec.element_ids)
+
+    has_gap = any(not item.rendered for item in items)
+    ok = not has_gap and not guard_violations and not missing_boxes
+    return MockValidation(ok, items, guard_violations, missing_boxes, notes)

--- a/skills/tableau-mock/scripts/mock.py
+++ b/skills/tableau-mock/scripts/mock.py
@@ -1,0 +1,670 @@
+"""Gate, version, and commit the ``mock`` step of the tableau-dashboard-plugin.
+
+This is the orchestration core of the ``tableau-mock`` skill (CONTRACT.md step 6): the
+non-skippable step that turns the strict ``DASHBOARD-PLAN.md`` into an interactive
+``mock.html`` demo populated from the real sample CSVs. The mock *markup* is authored by
+the model; the coverage checklist and slot-sizing guard live in :mod:`coverage`. This
+module owns the parts that touch ``STATE.md`` and the filesystem:
+
+1. **Entry gate** - mock refuses to run until both required reads are present and their
+   producers resolved (CONTRACT.md §4.1): ``DASHBOARD-PLAN.md`` (from ``plan``) - the
+   blueprint it builds against - and at least one sample CSV under ``data/`` (from
+   ``data``), with the ``scaffold/sample-data/`` demo as the accepted fallback (§3.1).
+2. **Versioning** - the mock is a *deliverable* written under ``mock-version/v_N/``
+   (CONTRACT.md §4.3): committing after a prior approval bumps ``current_version`` to a
+   fresh ``v_N`` (preserving the previous copy); before approval it overwrites the
+   current one.
+3. **STATE.md transition** - committing flips ``mock`` to ``approved`` and propagates
+   staleness to ``spec``/``build`` (§4.2), so the spec and workbook can never silently
+   disagree with a re-rendered mock.
+
+The module is pure and stdlib-only (it does **not** import the router) so the contract
+test can call its functions directly, exactly like ``plan.py`` / ``tableau-data``'s
+``state.py``. The CLI exposes ``precheck`` (before authoring - reports the target version
+dir + the coverage targets), ``validate`` (the coverage checklist + guard on a draft),
+and ``commit`` (after approval). Program output goes to stdout; diagnostics through
+``logging``.
+
+Keep ``STEP_ORDER`` in lock-step with CONTRACT.md §1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from coverage import (
+    LAYOUT_MANIFEST_ID,
+    MockValidation,
+    parse_plan_coverage,
+    validate_mock,
+)
+
+logger = logging.getLogger(__name__)
+
+# --- Canonical constants (mirror of CONTRACT.md §1 / §3 / §4.3) --------------
+
+STATE_FILENAME = "STATE.md"
+PLAN_FILENAME = "DASHBOARD-PLAN.md"
+MOCK_FILENAME = "mock.html"
+VERSION_DIR = "mock-version"
+DESIGN_TOKENS_FILENAME = "DESIGN-TOKENS.md"
+
+#: Required reads that gate this step, and their producer steps (CONTRACT.md §4.1).
+PLAN_STEP = "plan"
+DATA_STEP = "data"
+#: The sample CSV gate is satisfied by production data/ OR the scaffold/ demo (§3.1).
+CSV_GLOBS: tuple[str, ...] = ("data/*.csv", "scaffold/sample-data/*.csv")
+
+#: This step.
+MOCK_STEP = "mock"
+
+#: The 8 step names in canonical order (mirror of CONTRACT.md §1). Used to decide
+#: which steps are "downstream of mock" for staleness propagation (§4.2).
+STEP_ORDER: tuple[str, ...] = (
+    "init", "intake", "data", "brand", "plan", "mock", "spec", "build",
+)
+
+#: Statuses that satisfy the ordering gate - the producer step is "resolved" (§4.1).
+RESOLVED_STATUSES = frozenset({"approved", "skipped"})
+
+
+# --- STATE.md reading (shared shape with plan.py / route.py) -----------------
+
+def parse_statuses(text: str) -> dict[str, str]:
+    """Parse the per-step statuses out of a STATE.md manifest.
+
+    Parsing is tolerant (matching the router's parser): only genuine
+    ``| order | step | skill | status |`` rows whose step name is known contribute;
+    header, separator, and stray rows are ignored.
+
+    Args:
+        text: The full contents of a ``STATE.md`` file.
+
+    Returns:
+        A ``{step_name: status}`` mapping (both lower-cased).
+    """
+    statuses: dict[str, str] = {}
+    in_steps = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        # Section headers toggle which parser applies.
+        if line.lower().startswith("## steps"):
+            in_steps = True
+            continue
+        if line.startswith("## "):  # any other section ends the Steps table
+            in_steps = False
+
+        if in_steps and line.startswith("|"):
+            cells = [cell.strip() for cell in line.strip("|").split("|")]
+            if len(cells) < 4:
+                continue
+            step_name, status = cells[1].lower(), cells[3].lower()
+            if step_name in STEP_ORDER:
+                statuses[step_name] = status
+    return statuses
+
+
+# Matches the ``- current_version: v_3`` metadata line, capturing prefix/value/suffix.
+_CURRENT_VERSION_LINE = re.compile(
+    r"^(\s*-\s*current_version\s*:\s*)(\S+)(.*)$", re.MULTILINE
+)
+
+
+def read_current_version(text: str) -> str:
+    """Read the ``current_version`` metadata value from STATE.md.
+
+    Args:
+        text: The full contents of a ``STATE.md`` file.
+
+    Returns:
+        The recorded version (e.g. ``"v_2"``), or ``"v_1"`` if no line is present.
+    """
+    match = _CURRENT_VERSION_LINE.search(text)
+    return match.group(2) if match else "v_1"
+
+
+def bump_version(version: str) -> str:
+    """Return the next version directory name after ``version``.
+
+    ``v_3`` -> ``v_4``. A malformed value falls back to ``v_2`` (one past the implicit
+    ``v_1``) so a hand-broken manifest still advances rather than crashing.
+
+    Args:
+        version: The current version string (e.g. ``"v_3"``).
+
+    Returns:
+        The bumped version string (e.g. ``"v_4"``).
+    """
+    match = re.match(r"^v_(\d+)$", version.strip())
+    return f"v_{int(match.group(1)) + 1}" if match else "v_2"
+
+
+def set_current_version(text: str, version: str) -> str:
+    """Rewrite the ``- current_version: ...`` metadata line in a STATE.md manifest.
+
+    Only the value is replaced; any trailing inline comment (e.g. ``# v_1, v_2, ...``)
+    and every other line are preserved. If no line exists the text is returned
+    unchanged (older manifests stay valid). Mirrors ``state.set_data_mode``.
+
+    Args:
+        text: The full ``STATE.md`` contents.
+        version: The new version to record (e.g. ``"v_2"``).
+
+    Returns:
+        The updated ``STATE.md`` contents.
+    """
+    return _CURRENT_VERSION_LINE.sub(
+        lambda m: f"{m.group(1)}{version}{m.group(3)}", text, count=1
+    )
+
+
+def target_version(current_version: str, mock_status: str) -> str:
+    """Decide which ``v_N`` the next mock.html should be written into (CONTRACT.md §4.3).
+
+    Re-running a deliverable **after its step was approved** bumps to a fresh version,
+    preserving the prior copy; re-running before approval overwrites the current one.
+
+    Args:
+        current_version: The ``current_version`` recorded in STATE.md.
+        mock_status: The mock step's current status.
+
+    Returns:
+        The version directory name to write the mock into.
+    """
+    return bump_version(current_version) if mock_status == "approved" else current_version
+
+
+# --- STATE.md rewriting (shared shape with plan.py / state.py) ---------------
+
+def _format_step_row(cells: list[str]) -> str:
+    """Render a Steps-table row with the canonical column widths.
+
+    Matches the alignment ``init.render_state_md`` produces (``order<5 | step<6 |
+    skill<14 | status<8``) so a rewritten row stays visually consistent.
+
+    Args:
+        cells: The four cell values ``[order, step, skill, status]``.
+
+    Returns:
+        The formatted ``| ... |`` table row (no trailing newline).
+    """
+    order, step, skill, status = cells[0], cells[1], cells[2], cells[3]
+    return f"| {order:<5} | {step:<6} | {skill:<14} | {status:<8} |"
+
+
+def apply_status_updates(text: str, updates: dict[str, str]) -> str:
+    """Rewrite the status cell of one or more Steps-table rows.
+
+    Only rows inside the ``## Steps`` table whose step name is a key in ``updates`` are
+    touched; every other line (metadata, prose, untouched rows) is preserved
+    byte-for-byte. The trailing newline of the input is preserved.
+
+    Args:
+        text: The full ``STATE.md`` contents.
+        updates: ``{step_name: new_status}`` for the rows to rewrite (lower-cased).
+
+    Returns:
+        The updated ``STATE.md`` contents.
+    """
+    out_lines: list[str] = []
+    in_steps = False
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+
+        if stripped.lower().startswith("## steps"):
+            in_steps = True
+            out_lines.append(raw_line)
+            continue
+        if stripped.startswith("## "):  # any other section ends the Steps table
+            in_steps = False
+
+        if in_steps and stripped.startswith("|"):
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            if len(cells) >= 4 and cells[1].lower() in updates:
+                cells[3] = updates[cells[1].lower()]
+                out_lines.append(_format_step_row(cells))
+                continue
+
+        out_lines.append(raw_line)
+
+    result = "\n".join(out_lines)
+    if text.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def _downstream_stale_updates(statuses: dict[str, str]) -> dict[str, str]:
+    """Compute which downstream steps must flip to ``stale`` (CONTRACT.md §4.2).
+
+    Every step ordered after ``mock`` that is currently ``approved`` becomes ``stale``;
+    steps already ``pending`` / ``skipped`` / ``stale`` are left as-is.
+
+    Args:
+        statuses: The current ``{step_name: status}`` mapping.
+
+    Returns:
+        ``{step_name: "stale"}`` for each downstream step that was ``approved``.
+    """
+    mock_index = STEP_ORDER.index(MOCK_STEP)
+    return {
+        step: "stale"
+        for step in STEP_ORDER[mock_index + 1:]
+        if statuses.get(step) == "approved"
+    }
+
+
+# --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
+
+def _has_csv(project_root: Path) -> bool:
+    """Return True if any sample CSV exists in data/ or the scaffold/ demo (§3.1)."""
+    return any(next(project_root.glob(pattern), None) is not None for pattern in CSV_GLOBS)
+
+
+def entry_gate_blocker(project_root: Path) -> Optional[str]:
+    """Return why mock may not run yet, or ``None`` if it may.
+
+    Mock refuses to run unless ``STATE.md`` exists and, for each required read
+    (CONTRACT.md §4.1): ``plan`` is resolved and ``DASHBOARD-PLAN.md`` exists, and
+    ``data`` is resolved and at least one sample CSV is present (production ``data/``
+    or the ``scaffold/`` demo).
+
+    Args:
+        project_root: The analyst's project directory.
+
+    Returns:
+        A human-readable blocker message, or ``None`` when the gate is open.
+    """
+    state_path = project_root / STATE_FILENAME
+    if not state_path.exists():
+        return (
+            "No STATE.md found. Run 'tableau-init' first to scaffold the project "
+            "and initialize STATE.md before running 'tableau-mock'."
+        )
+
+    statuses = parse_statuses(state_path.read_text(encoding="utf-8-sig"))
+
+    plan_status = statuses.get(PLAN_STEP, "pending")
+    if plan_status not in RESOLVED_STATUSES:
+        return (
+            f"Step 'plan' is '{plan_status}', not resolved. Run 'tableau-plan' first; "
+            f"'tableau-mock' builds directly from '{PLAN_FILENAME}'."
+        )
+    if not (project_root / PLAN_FILENAME).exists():
+        return (
+            f"'{PLAN_FILENAME}' is missing on disk even though step 'plan' is "
+            f"'{plan_status}'. Re-run 'tableau-plan' to regenerate it."
+        )
+
+    data_status = statuses.get(DATA_STEP, "pending")
+    if data_status not in RESOLVED_STATUSES:
+        return (
+            f"Step 'data' is '{data_status}', not resolved. Run 'tableau-data' first; "
+            f"'tableau-mock' populates the demo from the sample CSVs."
+        )
+    if not _has_csv(project_root):
+        return (
+            "No sample CSV found in 'data/' or 'scaffold/sample-data/' even though step "
+            "'data' is resolved. Re-run 'tableau-data' to regenerate the samples."
+        )
+    return None
+
+
+# --- precheck ----------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PrecheckResult:
+    """The state mock needs before authoring a mock.html.
+
+    Attributes:
+        can_run: True when the entry gate is open (plan + data resolved, artifacts present).
+        blocker: Why mock cannot run, when ``can_run`` is False; else ``None``.
+        target_version: The ``v_N`` directory the mock.html should be written into.
+        target_path: ``mock-version/<target_version>/mock.html`` (where to author).
+        is_rerun_after_approval: True when this run bumps the version (mock was approved).
+        mock_exists: Whether the target mock.html already exists (refine vs author fresh).
+        tokens_present: Whether ``DESIGN-TOKENS.md`` exists (else neutral styling).
+        canvas: The planned ``(width, height)`` to render at, or ``None`` if unparseable.
+        element_count, filter_count, interaction_count: Sizes of the coverage sets.
+    """
+
+    can_run: bool
+    blocker: Optional[str]
+    target_version: str
+    target_path: str
+    is_rerun_after_approval: bool
+    mock_exists: bool
+    tokens_present: bool
+    canvas: Optional[tuple[int, int]]
+    element_count: int
+    filter_count: int
+    interaction_count: int
+
+
+def precheck(project_dir: Path | str) -> PrecheckResult:
+    """Report whether mock may run, where to write it, and what it must cover.
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`PrecheckResult`. When the entry gate is closed, ``can_run`` is False
+        and ``blocker`` explains why; the other fields are placeholders.
+    """
+    project_root = Path(project_dir)
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return PrecheckResult(
+            False, blocker, "v_1", "", False, False, False, None, 0, 0, 0
+        )
+
+    text = (project_root / STATE_FILENAME).read_text(encoding="utf-8-sig")
+    mock_status = parse_statuses(text).get(MOCK_STEP, "pending")
+    version = target_version(read_current_version(text), mock_status)
+    target_rel = f"{VERSION_DIR}/{version}/{MOCK_FILENAME}"
+
+    spec = parse_plan_coverage(
+        (project_root / PLAN_FILENAME).read_text(encoding="utf-8-sig")
+    )
+    return PrecheckResult(
+        can_run=True,
+        blocker=None,
+        target_version=version,
+        target_path=target_rel,
+        is_rerun_after_approval=(mock_status == "approved"),
+        mock_exists=(project_root / target_rel).exists(),
+        tokens_present=(project_root / DESIGN_TOKENS_FILENAME).exists(),
+        canvas=spec.canvas,
+        element_count=len(spec.element_ids),
+        filter_count=len(spec.filter_ids),
+        interaction_count=len(spec.interaction_ids),
+    )
+
+
+# --- commit ------------------------------------------------------------------
+
+@dataclass
+class CommitResult:
+    """Outcome of committing the mock step's result to STATE.md.
+
+    Attributes:
+        ok: True when STATE.md was updated; False when the commit was refused.
+        message: Human-readable explanation (the refusal reason when not ``ok``).
+        version: The version directory the (attempted) mock lives in.
+        staled_steps: Downstream steps flipped to ``stale`` by this commit.
+        validation: The coverage/guard result that gated the commit, when one ran.
+    """
+
+    ok: bool
+    message: str
+    version: str = "v_1"
+    staled_steps: list[str] = field(default_factory=list)
+    validation: Optional[MockValidation] = None
+
+
+def commit(project_dir: Path | str) -> CommitResult:
+    """Validate the target mock.html and approve the mock step, propagating staleness.
+
+    The mock is non-skippable, so commit only ever sets ``approved``. The target
+    ``mock-version/<v_N>/mock.html`` must exist and pass :func:`coverage.validate_mock`
+    (full coverage + slot-sizing guard) or the commit is refused. On success
+    ``current_version`` is set to the target version (a bump on a re-run after approval,
+    CONTRACT.md §4.3), ``mock`` is approved, and every downstream ``approved`` step
+    (``spec``/``build``) is flipped to ``stale`` (§4.2).
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`CommitResult`. ``ok`` is False (STATE.md untouched) when the entry
+        gate is closed or the mock is missing / has coverage gaps / fails the guard.
+    """
+    project_root = Path(project_dir)
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return CommitResult(False, blocker)
+
+    text = (project_root / STATE_FILENAME).read_text(encoding="utf-8-sig")
+    statuses = parse_statuses(text)
+    mock_status = statuses.get(MOCK_STEP, "pending")
+    version = target_version(read_current_version(text), mock_status)
+    mock_path = project_root / VERSION_DIR / version / MOCK_FILENAME
+
+    if not mock_path.exists():
+        return CommitResult(
+            False,
+            f"Cannot approve mock: '{VERSION_DIR}/{version}/{MOCK_FILENAME}' does not "
+            f"exist. Author it first (render the plan at its screen size).",
+            version=version,
+        )
+
+    plan_text = (project_root / PLAN_FILENAME).read_text(encoding="utf-8-sig")
+    validation = validate_mock(plan_text, mock_path.read_text(encoding="utf-8-sig"))
+    if not validation.ok:
+        reasons: list[str] = []
+        if validation.gaps:
+            reasons.append(
+                "coverage gaps: "
+                + ", ".join(f"{item.kind} '{item.label}'" for item in validation.gaps)
+            )
+        if validation.missing_boxes:
+            reasons.append("no layout box for: " + ", ".join(validation.missing_boxes))
+        if validation.guard_violations:
+            reasons.append("; ".join(validation.guard_violations))
+        return CommitResult(
+            False,
+            f"'{MOCK_FILENAME}' does not fully cover the plan - {'; '.join(reasons)}. "
+            f"Fix and re-run commit.",
+            version=version,
+            validation=validation,
+        )
+
+    stale_updates = _downstream_stale_updates(statuses)
+    updated = apply_status_updates(text, {MOCK_STEP: "approved", **stale_updates})
+    updated = set_current_version(updated, version)
+    (project_root / STATE_FILENAME).write_text(updated, encoding="utf-8")
+
+    staled_steps = sorted(stale_updates, key=STEP_ORDER.index)
+    logger.info(
+        f"Set mock -> approved at {version}; marked stale: {staled_steps or 'none'}."
+    )
+    return CommitResult(
+        ok=True,
+        message=f"mock -> approved ({version})",
+        version=version,
+        staled_steps=staled_steps,
+        validation=validation,
+    )
+
+
+# --- CLI ---------------------------------------------------------------------
+
+def format_precheck(result: PrecheckResult) -> str:
+    """Render a :class:`PrecheckResult` as a human-readable block.
+
+    Args:
+        result: The precheck result to render.
+
+    Returns:
+        A multi-line, plain-ASCII string suitable for printing to the analyst.
+    """
+    # Plain ASCII only: this prints to a Windows cp1252 console, which would raise
+    # UnicodeEncodeError on emoji / box-drawing glyphs.
+    if not result.can_run:
+        return f"[BLOCKED] tableau-mock cannot run.\n{result.blocker}"
+
+    canvas = (
+        f"{result.canvas[0]}x{result.canvas[1]}px" if result.canvas
+        else "UNKNOWN (plan has no parseable Screen Size)"
+    )
+    lines = [
+        "[MOCK] precheck OK - tableau-mock can run.",
+        f"  render at      : {canvas} (from DASHBOARD-PLAN.md Screen Size).",
+        f"  must cover     : {result.element_count} element(s), "
+        f"{result.filter_count} filter(s), {result.interaction_count} interaction(s).",
+        f"  write mock to  : {result.target_path}",
+    ]
+    if result.is_rerun_after_approval:
+        lines.append(
+            f"    -> re-run after approval: version bumped to {result.target_version} "
+            f"(prior version preserved; CONTRACT.md §4.3)."
+        )
+    if result.mock_exists:
+        lines.append("    -> a mock.html already exists at this version; refine it in place.")
+    lines.append(
+        f"  DESIGN-TOKENS.md: {'present' if result.tokens_present else 'absent - neutral styling'}"
+        " (optional read)."
+    )
+    lines.append(
+        f"  tag every rendered KPI/chart/filter/interaction with data-plan-id=\"<id>\" "
+        f"and embed the '{LAYOUT_MANIFEST_ID}' JSON layout manifest, or coverage fails."
+    )
+    return "\n".join(lines)
+
+
+def format_validation(validation: MockValidation) -> str:
+    """Render a :class:`MockValidation` as the coverage checklist + guard report.
+
+    Args:
+        validation: The validation result to render.
+
+    Returns:
+        A multi-line, plain-ASCII string suitable for printing to the analyst.
+    """
+    # Plain ASCII only (see format_precheck): [x]/[ ] checkboxes, no Unicode ticks.
+    lines = ["Coverage checklist (plan -> mock):"]
+    for item in validation.coverage:
+        mark = "x" if item.rendered else " "
+        gap = "" if item.rendered else "   <- MISSING from mock"
+        lines.append(f"  [{mark}] {item.kind}: {item.label}{gap}")
+    for missing in validation.missing_boxes:
+        lines.append(
+            f"  [ ] element '{missing}': no geometry box in layout manifest   <- MISSING"
+        )
+
+    lines.append("Slot-sizing guard:")
+    if validation.guard_violations:
+        for violation in validation.guard_violations:
+            lines.append(f"  [ ] {violation}")
+    else:
+        lines.append("  [x] all element boxes in-bounds, readable, and the canvas is well-filled.")
+
+    for note in validation.notes:
+        lines.append(f"  note: {note}")
+
+    lines.append(
+        "[OK] mock.html fully covers the plan." if validation.ok
+        else "[INVALID] mock.html does not fully cover the plan - fix the items above and re-run."
+    )
+    return "\n".join(lines)
+
+
+def format_commit(result: CommitResult) -> str:
+    """Render a :class:`CommitResult` as a human-readable block.
+
+    Args:
+        result: The commit result to render.
+
+    Returns:
+        A multi-line, plain-ASCII string suitable for printing to the analyst.
+    """
+    # Plain ASCII only (see format_precheck).
+    if not result.ok:
+        text = f"[REFUSED] {result.message}"
+        if result.validation is not None:
+            text += "\n" + format_validation(result.validation)
+        return text
+
+    lines = [f"[MOCK] {result.message}."]
+    if result.staled_steps:
+        lines.append(
+            f"  downstream marked stale: {', '.join(result.staled_steps)} "
+            f"(re-run these in order)."
+        )
+    lines.append(f"  deliverable: {VERSION_DIR}/{result.version}/{MOCK_FILENAME}")
+    lines.append(
+        "  next: open a fresh conversation and run 'tableau-spec' (or 'tableau-route')."
+    )
+    return "\n".join(lines)
+
+
+def _target_mock_path(project_dir: Path) -> Path:
+    """Resolve the mock.html path for the target version (for the validate subcommand).
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        The path to the mock.html the next commit would validate.
+    """
+    state_path = project_dir / STATE_FILENAME
+    if not state_path.exists():
+        return project_dir / VERSION_DIR / "v_1" / MOCK_FILENAME
+    text = state_path.read_text(encoding="utf-8-sig")
+    mock_status = parse_statuses(text).get(MOCK_STEP, "pending")
+    version = target_version(read_current_version(text), mock_status)
+    return project_dir / VERSION_DIR / version / MOCK_FILENAME
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point: run ``precheck``, ``validate``, or ``commit`` and print it.
+
+    Args:
+        argv: Argument list (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Process exit code: ``0`` on success, ``2`` when mock is blocked/refused/invalid
+        or on a usage error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Gate, validate, and commit the tableau-mock step.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for name, help_text in (
+        ("precheck", "Report whether mock may run, where to write it, and what to cover."),
+        ("validate", "Coverage checklist + slot-sizing guard on the target mock.html."),
+        ("commit", "Approve the mock in STATE.md (versioned) and propagate staleness."),
+    ):
+        sub = subparsers.add_parser(name, help=help_text)
+        sub.add_argument(
+            "project_dir", nargs="?", default=".", help="Project directory (default: cwd)."
+        )
+
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    project_dir = Path(args.project_dir)
+
+    if args.command == "precheck":
+        precheck_result = precheck(project_dir)
+        print(format_precheck(precheck_result))
+        return 0 if precheck_result.can_run else 2
+
+    if args.command == "validate":
+        mock_path = _target_mock_path(project_dir)
+        plan_path = project_dir / PLAN_FILENAME
+        if not mock_path.exists() or not plan_path.exists():
+            missing = MOCK_FILENAME if not mock_path.exists() else PLAN_FILENAME
+            print(f"[INVALID] '{missing}' not found (expected mock at '{mock_path}').")
+            return 2
+        validation = validate_mock(
+            plan_path.read_text(encoding="utf-8-sig"),
+            mock_path.read_text(encoding="utf-8-sig"),
+        )
+        print(format_validation(validation))
+        return 0 if validation.ok else 2
+
+    commit_result = commit(project_dir)
+    print(format_commit(commit_result))
+    return 0 if commit_result.ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/tableau-plan/SKILL.md
+++ b/skills/tableau-plan/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: tableau-plan
+description: Produces the strict DASHBOARD-PLAN.md for the tableau-dashboard-plugin workflow — the complete blueprint tableau-mock and tableau-build build against. Decides screen size here (so slot sizing is correct downstream), lays out a grid of named slots, and assigns every KPI, chart, filter, and interaction a stable id that later steps reference. Reads DATA-MODEL.md (field names) and, if present, PRD.md and DESIGN-TOKENS.md; proposes extra KPIs and patterns beyond the literal request. Use when the user wants to plan the dashboard, lay out KPIs/charts/filters, or when tableau-route reports plan is next. Step 5 of 8 in the workflow.
+disable-model-invocation: true
+allowed-tools: Read, Write, Edit, AskUserQuestion, Bash(python *), Bash(python3 *)
+---
+
+# tableau-plan
+
+Step 5 of 8, and **non-skippable**. It turns the request and the data model into a
+strict, complete `DASHBOARD-PLAN.md` — the single blueprint `tableau-mock` (the HTML
+demo) and, downstream, `tableau-build` (the `.twb`) build against. The plan is
+deliberately strict so the **mock can never silently drop a requirement**: screen size,
+the layout grid, and every element/filter/interaction are pinned down here, each with a
+**stable id** that later steps reference.
+
+| | |
+|---|---|
+| **Reads** | **Required:** `DATA-MODEL.md` (from `data`) — the real field names to plan against. **Optional (enrich, never block):** `PRD.md` (from `intake`; falls back to root `DASHBOARD-REQUEST.md`, then the `scaffold/` demo) and `DESIGN-TOKENS.md` (from `brand`; absent ⇒ neutral styling). |
+| **Writes** | `DASHBOARD-PLAN.md` at the project root (latest approved truth; overwritten in place). |
+| **STATE.md update** | Sets `plan` = `approved`; flips every downstream `approved` step (`mock`/`spec`/`build`) to `stale` on a re-run (CONTRACT.md §4.2). |
+| **Entry gate** | Refuses to run until `data` is resolved **and** `DATA-MODEL.md` exists (CONTRACT.md §4.1). |
+| **Next step** | `tableau-mock` (or `tableau-route` to confirm). |
+
+The mechanical guarantees — the entry gate, the strict-schema check (required sections,
+stable unique ids, shared interaction vocabulary), and the STATE.md transition — live in
+`plan.py`, this skill's executable mirror of the contract. Your job is the judgment part:
+designing a layout that fits the request and the screen, mapping elements to real fields,
+and **proposing extra value** beyond what was asked. Run the script at the points below;
+do not hand-edit `STATE.md`.
+
+## How to run
+
+1. **Precheck.** From the project directory, run:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/plan.py" precheck "<project-dir>"
+   ```
+
+   (Use `python3` if `python` is unavailable.) If it prints `[BLOCKED]`, relay the
+   reason and **stop** — the analyst must run `tableau-data` first (plan needs
+   `DATA-MODEL.md`). Otherwise note its signals: whether a `DASHBOARD-PLAN.md` already
+   exists (refine vs overwrite), the **requirements source** (`PRD.md`, the raw request,
+   the `scaffold/` demo, or none), and whether `DESIGN-TOKENS.md` is present.
+
+2. **Refine vs overwrite.** If precheck reports a `DASHBOARD-PLAN.md` already exists, use
+   **AskUserQuestion** to offer **Refine** (keep its ids/structure, update values) or
+   **Overwrite** (author fresh). **Never silently overwrite** the analyst's plan — its
+   ids are referenced by any mock/spec/build already built.
+
+3. **Read the inputs.** Always read `DATA-MODEL.md` for the exact field names and types
+   (use them verbatim in the `columns` cells). Read the **requirements source** precheck
+   reported for what to build; if it was the `scaffold/` demo, **say so** (you're demoing,
+   not using a real request). If `DESIGN-TOKENS.md` is present, let it inform layout
+   density and sizing; if absent, plan for neutral styling.
+
+4. **Decide the screen size first.** Pick `mode` (fixed / range / automatic) and the
+   design `dimensions`, and record the rationale (primary device / embed target). Every
+   slot size is relative to this canvas, so it is decided **here**, not in the mock.
+
+5. **Author `DASHBOARD-PLAN.md`.** Write (or `Edit`, when refining) the plan at the
+   project root using `references/DASHBOARD-PLAN-TEMPLATE.md` as the structure. It must
+   contain every **required** section:
+
+   | section | what goes there |
+   |---------|-----------------|
+   | `## Screen Size` | Mode + design dimensions + rationale. |
+   | `## Layout Grid` | Named slots with position + size (the `slot` ids elements reference). |
+   | `## Elements` | Per-element table `id \| type \| columns \| slot \| size` — every KPI and chart. |
+   | `## Filters` | `id \| field \| control type \| scope \| default` — every filter (a single `none` row if there are none). |
+   | `## Interactions` | `id \| interaction \| source \| target \| detail` — the `interaction` term **must** come from the shared vocabulary below. |
+
+   Plus the recommended `## Summary` and `## Suggestions` (and optional `## Data Gaps`).
+
+   **Stable ids are the contract.** Give every KPI, chart, filter, and interaction a
+   short, stable, unique id (e.g. `kpi-revenue`, `chart-trend`, `flt-region`,
+   `int-region-filter`). Later steps reference these — don't renumber them on a refine.
+
+6. **Propose extra value.** Beyond the literal request, suggest additional KPIs and
+   interesting patterns the data supports (a discount-impact view, a segment mix, a
+   target-vs-actual delta) in `## Suggestions`. Surface anything the request wants that
+   the data **cannot** support under `## Data Gaps` — better visible here than dropped in
+   the mock.
+
+7. **Self-check, then present.** Validate the draft before showing it:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/plan.py" validate "<project-dir>"
+   ```
+
+   If it prints `[INVALID]`, fix the named sections/ids/terms and re-run. When it prints
+   `[OK]`, present the plan to the analyst for approval.
+
+8. **Commit** — only after the analyst approves:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/plan.py" commit "<project-dir>"
+   ```
+
+   Commit re-validates the plan (plan is non-skippable, so it only ever sets `approved`).
+   If it prints `[REFUSED]`, fix what it names and re-run. On success it records `plan` =
+   `approved` and reports any downstream steps it marked `stale`. Relay the summary and
+   tell the analyst to open a fresh conversation and run the next step (`tableau-mock`, or
+   `tableau-route` to confirm).
+
+## Shared interactions vocabulary (CONTRACT.md §6)
+
+The `interaction` column must use one of these intent-level terms, so `plan` → `mock` →
+`spec` all mean the same thing. The Tableau construct is chosen later, in `spec`.
+
+| term | meaning |
+|------|---------|
+| `toggle panel` | Show/hide a region of the dashboard on demand. |
+| `swap view` | Replace one chart with an alternative in the same slot (bar ⇄ line). |
+| `drill` | Move between levels of a hierarchy (year → quarter → month) in place. |
+| `cross-filter` | Selecting marks in one chart filters the others. |
+| `highlight` | Selecting marks highlights related marks elsewhere without filtering. |
+| `parameter swap` | A control changes a measure/dimension/threshold across the dashboard. |
+
+If a requested interaction fits none of these, add the term to **CONTRACT.md §6 first**
+(with its intent and Tableau construct), then use it here — keep plan, mock, and spec
+aligned.
+
+## Notes
+
+- **Non-skippable.** Unlike `intake`/`brand`, `plan` cannot be skipped — the mock and
+  workbook have no blueprint without it. `commit` only ever sets `approved`.
+- **Root file, no version bump.** `DASHBOARD-PLAN.md` lives at the project root and is
+  overwritten in place; re-running flips downstream `approved` steps to `stale`
+  (CONTRACT.md §4.2/§4.3). It does **not** create a version directory.
+- **Plan against real fields.** The `columns` cells must use the exact field names from
+  `DATA-MODEL.md` — that's how the mock and the `.twb` line up with the data, and how
+  **Replace Data Source** swaps in live data later.
+
+> The full `STATE.md` schema and the ordering / staleness / versioning rules live in
+> `CONTRACT.md` at the repo root. This skill restates only its own slice; `plan.py` is
+> the executable mirror of the contract it enforces.

--- a/skills/tableau-plan/references/DASHBOARD-PLAN-TEMPLATE.md
+++ b/skills/tableau-plan/references/DASHBOARD-PLAN-TEMPLATE.md
@@ -1,0 +1,83 @@
+# Dashboard Plan: <dashboard name>
+
+> Strict plan for the tableau-dashboard-plugin workflow. **Every required section below
+> must be present and complete** — `tableau-mock` builds directly from this file, so an
+> incomplete plan is rejected and blocks the mock. Every KPI, chart, filter, and
+> interaction carries a **stable `id`** that later steps (mock, spec, build) reference;
+> ids must be unique across the whole plan. Interactions use the shared vocabulary
+> (CONTRACT.md §6). Replace every `<...>` and keep the table structures intact.
+
+## Summary
+
+<1–3 sentences: what this dashboard is for, who reads it, what decisions it drives, and
+the update cadence. (Optional but strongly recommended.)>
+
+## Screen Size
+
+Screen size is decided **here**, not in `tableau-mock`, so slot sizing is correct
+downstream.
+
+- **mode**: fixed                 # fixed | range | automatic
+- **dimensions**: 1366 x 768 px   # the design canvas; the slot sizes below are relative to this
+- **rationale**: <primary viewing device / embed target that drives this size>
+
+## Layout Grid
+
+The named slots that elements are placed into, with position and size (relative to the
+canvas above). Element rows reference these slot names.
+
+| slot        | position             | size           |
+|-------------|----------------------|----------------|
+| filter-bar  | top, full width      | 100% x 56px    |
+| kpi-row     | below filter-bar     | 100% x 120px   |
+| chart-main  | middle-left          | 60% x 360px    |
+| chart-side  | middle-right         | 40% x 360px    |
+
+## Elements
+
+Every KPI and chart. `id` is stable and unique; `type` is `kpi` or `chart` (or a chart
+kind, e.g. `chart:line`); `columns` are the DATA-MODEL.md field(s) used; `slot` must be
+one of the Layout Grid slots above; `size` is the footprint within that slot.
+
+| id           | type        | columns                       | slot       | size       |
+|--------------|-------------|-------------------------------|------------|------------|
+| kpi-revenue  | kpi         | revenue                       | kpi-row    | 1/4 of row |
+| kpi-orders   | kpi         | order_id (distinct count)     | kpi-row    | 1/4 of row |
+| chart-trend  | chart:line  | order_date, revenue, region   | chart-main | fills slot |
+| chart-region | chart:bar   | region, revenue               | chart-side | fills slot |
+
+## Filters
+
+Every filter. `scope` lists which elements (by id) it affects. If the dashboard has no
+filters, keep this section and write a single row with `id` = `none`.
+
+| id         | field      | control type     | scope                      | default    |
+|------------|------------|------------------|----------------------------|------------|
+| flt-date   | order_date | date range       | all                        | last 12 mo |
+| flt-region | region     | dropdown (multi) | chart-trend, chart-region  | All        |
+
+## Interactions
+
+Every interaction (action). The `interaction` column **must** use a term from the shared
+vocabulary (CONTRACT.md §6): `toggle panel`, `swap view`, `drill`, `cross-filter`,
+`highlight`, `parameter swap`. `source` and `target` reference element ids. If there are
+no interactions, keep this section with a single row `id` = `none`, `interaction` =
+`toggle panel` (or remove the table and write "None").
+
+| id                  | interaction  | source       | target                    | detail                              |
+|---------------------|--------------|--------------|---------------------------|-------------------------------------|
+| int-region-filter   | cross-filter | chart-region | chart-trend, kpi-revenue  | click a region to filter the others |
+| int-trend-highlight | highlight    | chart-trend  | chart-region              | hover a month to highlight it       |
+
+## Suggestions
+
+Additional KPIs or patterns **beyond the literal request** — value the data supports that
+the analyst did not ask for. Mark each clearly as a suggestion, not a requirement.
+
+1. <a suggested KPI/chart and why it helps the audience>
+2. <an interesting pattern the data supports, e.g. discount-impact or segment mix>
+
+## Data Gaps
+
+<Anything the request wants that the data cannot support — surfaced here, before the mock,
+so it is visible rather than silently dropped. Write "None" if there are no gaps.>

--- a/skills/tableau-plan/scripts/plan.py
+++ b/skills/tableau-plan/scripts/plan.py
@@ -1,0 +1,762 @@
+"""Gate, validate, and commit the ``plan`` step of the tableau-dashboard-plugin.
+
+This is the executable core of the ``tableau-plan`` skill (CONTRACT.md step 5): the
+non-skippable step that turns the request + data model into a strict, complete
+``DASHBOARD-PLAN.md``. The plan *content* is authored by the model; this script owns
+the parts that must be **mechanically guaranteed** rather than left to model prose:
+
+1. **Entry gate** - plan refuses to run until its required read ``DATA-MODEL.md`` is
+   present and its producer step ``data`` is resolved (CONTRACT.md §4.1). Screen size,
+   layout, and every element are decided against real field names, so the data model
+   must exist first.
+2. **Plan schema** - on approval the produced ``DASHBOARD-PLAN.md`` must contain every
+   **required** section (screen size, layout grid, elements, filters, interactions) so
+   ``tableau-mock`` can never silently drop a requirement. The validator also enforces
+   that every KPI / chart / filter / action carries a **stable, unique id** and that
+   each interaction uses a term from the shared vocabulary (CONTRACT.md §6).
+3. **STATE.md transition** - committing flips ``plan`` to ``approved`` and propagates
+   staleness (CONTRACT.md §4.2): re-running flips every downstream ``approved`` step
+   (``mock`` / ``spec`` / ``build``) to ``stale`` so the demo and workbook can never
+   silently disagree with a changed plan.
+
+The module is intentionally pure and stdlib-only (it does **not** import the router)
+so the contract test can call its functions directly, exactly like ``init.py`` /
+``intake.py`` / ``route.py``. The CLI exposes three subcommands the skill runs at three
+moments - ``precheck`` (before authoring), ``validate`` (to self-check a draft), and
+``commit`` (after approval). What the CLI prints to stdout is the program's *output*;
+diagnostics go through ``logging``.
+
+Keep ``STEP_ORDER`` and ``INTERACTION_VOCABULARY`` below in lock-step with CONTRACT.md
+§1 and §6 respectively.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# --- Canonical constants (mirror of CONTRACT.md §1 / §3 / §6) ----------------
+
+STATE_FILENAME = "STATE.md"
+PLAN_FILENAME = "DASHBOARD-PLAN.md"
+
+#: The required read that gates this step, and its producer step (CONTRACT.md §4.1).
+DATA_MODEL_FILENAME = "DATA-MODEL.md"
+DATA_STEP = "data"
+
+#: Optional reads that enrich the plan but never block it (CONTRACT.md §1). PRD.md is
+#: preferred; the raw request (production, then the scaffold/ demo) is the fallback.
+PRD_FILENAME = "PRD.md"
+REQUEST_FILENAME = "DASHBOARD-REQUEST.md"
+SCAFFOLD_REQUEST = "scaffold/EXAMPLE-DASHBOARD-REQUEST.md"
+DESIGN_TOKENS_FILENAME = "DESIGN-TOKENS.md"
+
+#: This step.
+PLAN_STEP = "plan"
+
+#: The 8 step names in canonical order (mirror of CONTRACT.md §1). Used to decide
+#: which steps are "downstream of plan" for staleness propagation (§4.2).
+STEP_ORDER: tuple[str, ...] = (
+    "init", "intake", "data", "brand", "plan", "mock", "spec", "build",
+)
+
+#: Statuses that satisfy the ordering gate - the producer step is "resolved" (§4.1).
+RESOLVED_STATUSES = frozenset({"approved", "skipped"})
+
+#: Plan sections that MUST be present, or the plan is rejected and the mock is blocked.
+#: Screen size is decided here (not in mock) so slot sizing is correct downstream.
+PLAN_REQUIRED_SECTIONS: tuple[str, ...] = (
+    "Screen Size", "Layout Grid", "Elements", "Filters", "Interactions",
+)
+
+#: Recommended sections - proposed while planning, reported when absent, never blocking.
+#: "Suggestions" is where the skill proposes KPIs/patterns beyond the literal request.
+PLAN_RECOMMENDED_SECTIONS: tuple[str, ...] = ("Summary", "Suggestions")
+
+#: The shared interactions vocabulary (CONTRACT.md §6). The Interactions table's
+#: ``interaction`` column must use one of these intent-level terms so plan -> mock ->
+#: spec stay aligned.
+INTERACTION_VOCABULARY: tuple[str, ...] = (
+    "toggle panel", "swap view", "drill", "cross-filter", "highlight", "parameter swap",
+)
+_INTERACTION_TERMS = frozenset(INTERACTION_VOCABULARY)
+
+
+# --- STATE.md reading (shared shape with intake.py / route.py) ---------------
+
+def _resolve_state_path(target: Path) -> Path:
+    """Resolve the STATE.md path for a project directory or a direct file path.
+
+    Args:
+        target: Either a project directory (which may contain ``STATE.md``) or a
+            path to a ``STATE.md`` file directly.
+
+    Returns:
+        The path where ``STATE.md`` is expected. It may or may not exist.
+    """
+    if target.is_dir():
+        return target / STATE_FILENAME
+    return target
+
+
+def parse_statuses(text: str) -> dict[str, str]:
+    """Parse the per-step statuses out of a STATE.md manifest.
+
+    Parsing is tolerant (matching the router's parser): only genuine
+    ``| order | step | skill | status |`` rows whose step name is known contribute;
+    header, separator, and stray rows are ignored.
+
+    Args:
+        text: The full contents of a ``STATE.md`` file.
+
+    Returns:
+        A ``{step_name: status}`` mapping (both lower-cased).
+    """
+    statuses: dict[str, str] = {}
+    in_steps = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        # Section headers toggle which parser applies.
+        if line.lower().startswith("## steps"):
+            in_steps = True
+            continue
+        if line.startswith("## "):  # any other section ends the Steps table
+            in_steps = False
+
+        if in_steps and line.startswith("|"):
+            cells = [cell.strip() for cell in line.strip("|").split("|")]
+            if len(cells) < 4:
+                continue
+            step_name, status = cells[1].lower(), cells[3].lower()
+            if step_name in STEP_ORDER:
+                statuses[step_name] = status
+    return statuses
+
+
+# --- Plan schema -------------------------------------------------------------
+
+# Matches a markdown ATX heading line, capturing its text (drops leading "#"s and
+# any trailing "#"s): "## Layout Grid" -> "Layout Grid".
+_HEADING_LINE = re.compile(r"^#{1,6}\s+(.*?)\s*#*\s*$")
+
+# A markdown table separator cell: "---", ":---", "---:", ":---:".
+_SEPARATOR_CELL = re.compile(r"^:?-+:?$")
+
+
+def _markdown_headings(text: str) -> list[str]:
+    """Extract the text of every markdown heading in a document.
+
+    Args:
+        text: Markdown document contents.
+
+    Returns:
+        The heading texts, in document order (e.g. ``["Screen Size", "Elements"]``).
+    """
+    return [
+        match.group(1).strip()
+        for raw_line in text.splitlines()
+        if (match := _HEADING_LINE.match(raw_line.strip()))
+    ]
+
+
+def _markdown_tables(text: str) -> list[list[list[str]]]:
+    """Split a markdown document into its pipe tables.
+
+    Contiguous runs of lines beginning with ``|`` are grouped into one table; each
+    table is a list of rows, each row a list of trimmed cell strings.
+
+    Args:
+        text: Markdown document contents.
+
+    Returns:
+        A list of tables (each a list of cell-rows).
+    """
+    tables: list[list[list[str]]] = []
+    current: list[list[str]] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("|"):
+            current.append([cell.strip() for cell in line.strip("|").split("|")])
+            continue
+        if current:
+            tables.append(current)
+            current = []
+    if current:
+        tables.append(current)
+    return tables
+
+
+def _is_separator_row(cells: list[str]) -> bool:
+    """Return True if a table row is the ``|---|---|`` header/body separator.
+
+    Args:
+        cells: The row's trimmed cell values.
+
+    Returns:
+        True when every non-empty cell looks like a separator dash run.
+    """
+    non_empty = [cell for cell in cells if cell]
+    return bool(non_empty) and all(_SEPARATOR_CELL.match(cell) for cell in non_empty)
+
+
+def _validate_id_tables(text: str) -> list[str]:
+    """Check stable-id and interaction-vocabulary rules across the plan's tables.
+
+    Every table whose first column header is ``id`` (the Elements, Filters, and
+    Interactions tables) is checked: each data row must carry a non-empty id, ids must
+    be unique across the whole plan (later steps reference them), and any table with an
+    ``interaction`` column must use only the shared vocabulary (CONTRACT.md §6).
+
+    Args:
+        text: The contents of a ``DASHBOARD-PLAN.md`` file.
+
+    Returns:
+        A list of human-readable problem strings (empty when all id-tables are clean).
+    """
+    problems: list[str] = []
+    all_ids: list[str] = []
+
+    for table in _markdown_tables(text):
+        rows = [row for row in table if not _is_separator_row(row)]
+        if len(rows) < 2:  # need a header plus at least one data row to matter
+            continue
+        header = [cell.lower() for cell in rows[0]]
+        if not header or header[0] != "id":
+            continue  # not an id-bearing table (e.g. the Layout Grid's slot table)
+
+        term_index = header.index("interaction") if "interaction" in header else None
+        for row in rows[1:]:
+            row_id = row[0].strip() if row else ""
+            if not row_id:
+                problems.append("an id-table row has an empty 'id' cell")
+                continue
+            all_ids.append(row_id)
+            if term_index is not None and len(row) > term_index:
+                term = row[term_index].strip()
+                if term and term.lower() not in _INTERACTION_TERMS:
+                    problems.append(
+                        f"interaction '{row_id}' uses term '{term}', not in the shared "
+                        f"vocabulary ({', '.join(INTERACTION_VOCABULARY)})"
+                    )
+
+    duplicates = sorted({rid for rid in all_ids if all_ids.count(rid) > 1})
+    problems.extend(
+        f"duplicate id '{dup}' - ids must be unique across the plan" for dup in duplicates
+    )
+    return problems
+
+
+@dataclass(frozen=True)
+class PlanValidation:
+    """Result of validating a ``DASHBOARD-PLAN.md`` against the strict schema.
+
+    Attributes:
+        ok: True iff the plan is complete - no required section is missing and no
+            id/vocabulary problem was found.
+        missing_required: Required sections absent from the plan (CONTRACT.md schema).
+        missing_recommended: Recommended sections absent (reported, never blocking).
+        problems: Stable-id / interaction-vocabulary problems (see
+            :func:`_validate_id_tables`).
+    """
+
+    ok: bool
+    missing_required: list[str]
+    missing_recommended: list[str]
+    problems: list[str]
+
+
+def validate_plan(text: str) -> PlanValidation:
+    """Validate a plan's section coverage, stable ids, and interaction vocabulary.
+
+    A plan is *valid* when it contains every required section and has no id or
+    vocabulary problem. Section names are matched case-insensitively as substrings of
+    the document's headings, so a plan that keeps richer headings (e.g.
+    ``## Screen Size & Device``) still validates, and extra custom sections are allowed.
+
+    Args:
+        text: The contents of a ``DASHBOARD-PLAN.md`` file.
+
+    Returns:
+        A :class:`PlanValidation`.
+    """
+    headings_blob = "\n".join(_markdown_headings(text)).lower()
+    missing_required = [
+        section for section in PLAN_REQUIRED_SECTIONS
+        if section.lower() not in headings_blob
+    ]
+    missing_recommended = [
+        section for section in PLAN_RECOMMENDED_SECTIONS
+        if section.lower() not in headings_blob
+    ]
+    problems = _validate_id_tables(text)
+    ok = not missing_required and not problems
+    return PlanValidation(ok, missing_required, missing_recommended, problems)
+
+
+def render_plan_template() -> str:
+    """Return the canonical DASHBOARD-PLAN template text this skill ships.
+
+    Reads ``references/DASHBOARD-PLAN-TEMPLATE.md`` so there is a single source of
+    truth for the strict schema - the same file the skill hands the model to fill in.
+    It is, by construction, schema-complete (all required sections, unique ids, valid
+    interaction terms).
+
+    Returns:
+        The template file contents.
+
+    Raises:
+        FileNotFoundError: If the bundled template is missing.
+    """
+    # This script lives in ``<skill>/scripts/``; references/ sits at the skill root.
+    template_path = (
+        Path(__file__).resolve().parent.parent / "references" / "DASHBOARD-PLAN-TEMPLATE.md"
+    )
+    if not template_path.is_file():
+        raise FileNotFoundError(f"Plan template not found: {template_path}")
+    return template_path.read_text(encoding="utf-8-sig")
+
+
+# --- STATE.md rewriting (shared shape with intake.py) ------------------------
+
+def _format_step_row(cells: list[str]) -> str:
+    """Render a Steps-table row with the canonical column widths.
+
+    Matches the alignment ``init.render_state_md`` produces (``order<5 | step<6 |
+    skill<14 | status<8``) so a rewritten row stays visually consistent.
+
+    Args:
+        cells: The four cell values ``[order, step, skill, status]``.
+
+    Returns:
+        The formatted ``| ... |`` table row (no trailing newline).
+    """
+    order, step, skill, status = cells[0], cells[1], cells[2], cells[3]
+    return f"| {order:<5} | {step:<6} | {skill:<14} | {status:<8} |"
+
+
+def apply_status_updates(text: str, updates: dict[str, str]) -> str:
+    """Rewrite the status cell of one or more Steps-table rows.
+
+    Only rows inside the ``## Steps`` table whose step name is a key in ``updates`` are
+    touched; every other line (metadata, prose, untouched rows) is preserved
+    byte-for-byte. The trailing newline of the input is preserved.
+
+    Args:
+        text: The full ``STATE.md`` contents.
+        updates: ``{step_name: new_status}`` for the rows to rewrite (step names
+            lower-cased).
+
+    Returns:
+        The updated ``STATE.md`` contents.
+    """
+    out_lines: list[str] = []
+    in_steps = False
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+
+        if stripped.lower().startswith("## steps"):
+            in_steps = True
+            out_lines.append(raw_line)
+            continue
+        if stripped.startswith("## "):  # any other section ends the Steps table
+            in_steps = False
+
+        if in_steps and stripped.startswith("|"):
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            if len(cells) >= 4 and cells[1].lower() in updates:
+                cells[3] = updates[cells[1].lower()]
+                out_lines.append(_format_step_row(cells))
+                continue
+
+        out_lines.append(raw_line)
+
+    result = "\n".join(out_lines)
+    if text.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def _downstream_stale_updates(statuses: dict[str, str]) -> dict[str, str]:
+    """Compute which downstream steps must flip to ``stale`` (CONTRACT.md §4.2).
+
+    Every step ordered after ``plan`` that is currently ``approved`` becomes ``stale``;
+    steps already ``pending`` / ``skipped`` / ``stale`` are left as-is.
+
+    Args:
+        statuses: The current ``{step_name: status}`` mapping.
+
+    Returns:
+        ``{step_name: "stale"}`` for each downstream step that was ``approved``.
+    """
+    plan_index = STEP_ORDER.index(PLAN_STEP)
+    return {
+        step: "stale"
+        for step in STEP_ORDER[plan_index + 1:]
+        if statuses.get(step) == "approved"
+    }
+
+
+# --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
+
+def entry_gate_blocker(project_root: Path) -> Optional[str]:
+    """Return why plan may not run yet, or ``None`` if it may.
+
+    Plan refuses to run unless ``STATE.md`` exists, its required read's producer
+    (``data``) is resolved, and ``DATA-MODEL.md`` actually exists on disk (CONTRACT.md
+    §4.1). ``intake`` and ``brand`` are *optional* reads and never gate plan.
+
+    Args:
+        project_root: The analyst's project directory.
+
+    Returns:
+        A human-readable blocker message, or ``None`` when the gate is open.
+    """
+    state_path = project_root / STATE_FILENAME
+    if not state_path.exists():
+        return (
+            "No STATE.md found. Run 'tableau-init' first to scaffold the project "
+            "and initialize STATE.md before running 'tableau-plan'."
+        )
+
+    data_status = parse_statuses(state_path.read_text(encoding="utf-8-sig")).get(
+        DATA_STEP, "pending"
+    )
+    if data_status not in RESOLVED_STATUSES:
+        return (
+            f"Step 'data' is '{data_status}', not resolved. Run 'tableau-data' first; "
+            f"'tableau-plan' needs '{DATA_MODEL_FILENAME}' before it can plan against "
+            f"real field names."
+        )
+
+    if not (project_root / DATA_MODEL_FILENAME).exists():
+        return (
+            f"'{DATA_MODEL_FILENAME}' is missing on disk even though step 'data' is "
+            f"'{data_status}'. Re-run 'tableau-data' to regenerate it."
+        )
+    return None
+
+
+# --- precheck ----------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PrecheckResult:
+    """The state plan needs to know before authoring a DASHBOARD-PLAN.md.
+
+    Attributes:
+        can_run: True when the entry gate is open (data resolved, DATA-MODEL.md present).
+        blocker: Why plan cannot run, when ``can_run`` is False; else ``None``.
+        plan_exists: Whether a ``DASHBOARD-PLAN.md`` already exists (refine vs overwrite).
+        requirements_source: Where the request will be read from - ``"PRD.md"``
+            (preferred), ``REQUEST_FILENAME``, ``SCAFFOLD_REQUEST`` (demo fallback), or
+            ``"none"`` (plan against the data model alone).
+        tokens_present: Whether ``DESIGN-TOKENS.md`` exists (else neutral styling).
+        plan_status: The plan step's current status (to detect a re-run).
+    """
+
+    can_run: bool
+    blocker: Optional[str]
+    plan_exists: bool
+    requirements_source: str
+    tokens_present: bool
+    plan_status: str
+
+
+def _resolve_requirements_source(project_root: Path) -> str:
+    """Pick the requirements input, preferring the PRD, then the raw request (§3.1).
+
+    Args:
+        project_root: The analyst's project directory.
+
+    Returns:
+        ``PRD_FILENAME``, ``REQUEST_FILENAME``, ``SCAFFOLD_REQUEST``, or ``"none"``.
+    """
+    if (project_root / PRD_FILENAME).exists():
+        return PRD_FILENAME
+    if (project_root / REQUEST_FILENAME).exists():
+        return REQUEST_FILENAME
+    if (project_root / SCAFFOLD_REQUEST).exists():
+        return SCAFFOLD_REQUEST
+    return "none"
+
+
+def precheck(project_dir: Path | str) -> PrecheckResult:
+    """Report whether plan may run and what it should read.
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`PrecheckResult`. When the entry gate is closed, ``can_run`` is False
+        and ``blocker`` explains why; the other fields are placeholders.
+    """
+    project_root = Path(project_dir)
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return PrecheckResult(False, blocker, False, "none", False, "unknown")
+
+    statuses = parse_statuses((project_root / STATE_FILENAME).read_text(encoding="utf-8-sig"))
+    return PrecheckResult(
+        can_run=True,
+        blocker=None,
+        plan_exists=(project_root / PLAN_FILENAME).exists(),
+        requirements_source=_resolve_requirements_source(project_root),
+        tokens_present=(project_root / DESIGN_TOKENS_FILENAME).exists(),
+        plan_status=statuses.get(PLAN_STEP, "pending"),
+    )
+
+
+# --- commit ------------------------------------------------------------------
+
+@dataclass
+class CommitResult:
+    """Outcome of committing the plan step's result to STATE.md.
+
+    Attributes:
+        ok: True when STATE.md was updated; False when the commit was refused.
+        message: Human-readable explanation (the refusal reason when not ``ok``).
+        staled_steps: Downstream steps flipped to ``stale`` by this commit.
+        missing_required: Required plan sections that were absent (on a refusal).
+        missing_recommended: Recommended sections absent (informational note).
+        problems: Stable-id / vocabulary problems that blocked approval (on a refusal).
+    """
+
+    ok: bool
+    message: str
+    staled_steps: list[str] = field(default_factory=list)
+    missing_required: list[str] = field(default_factory=list)
+    missing_recommended: list[str] = field(default_factory=list)
+    problems: list[str] = field(default_factory=list)
+
+
+def commit(project_dir: Path | str) -> CommitResult:
+    """Validate and approve the plan in STATE.md, propagating staleness.
+
+    Plan is **non-skippable**, so commit only ever sets ``approved``. The project's
+    ``DASHBOARD-PLAN.md`` must exist and pass :func:`validate_plan` (all required
+    sections, unique non-empty ids, vocabulary-conformant interactions) or the commit
+    is refused so the model fixes it and re-commits. On success every downstream
+    ``approved`` step is flipped to ``stale`` (CONTRACT.md §4.2) - a no-op on a first
+    run, but the guard that keeps a re-run from silently disagreeing with the mock,
+    spec, and workbook.
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`CommitResult`. ``ok`` is False (and STATE.md is left untouched) when
+        the entry gate is closed or the plan is incomplete/invalid.
+    """
+    project_root = Path(project_dir)
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return CommitResult(False, blocker)
+
+    plan_path = project_root / PLAN_FILENAME
+    if not plan_path.exists():
+        return CommitResult(
+            False,
+            f"Cannot approve plan: '{PLAN_FILENAME}' does not exist. Author it first "
+            f"using references/DASHBOARD-PLAN-TEMPLATE.md.",
+        )
+
+    validation = validate_plan(plan_path.read_text(encoding="utf-8-sig"))
+    if not validation.ok:
+        reasons: list[str] = []
+        if validation.missing_required:
+            reasons.append(
+                f"missing required section(s): {', '.join(validation.missing_required)}"
+            )
+        if validation.problems:
+            reasons.append("; ".join(validation.problems))
+        return CommitResult(
+            False,
+            f"'{PLAN_FILENAME}' is incomplete - {'; '.join(reasons)}. Fix and re-run commit.",
+            missing_required=validation.missing_required,
+            missing_recommended=validation.missing_recommended,
+            problems=validation.problems,
+        )
+
+    state_path = project_root / STATE_FILENAME
+    text = state_path.read_text(encoding="utf-8-sig")
+    statuses = parse_statuses(text)
+
+    stale_updates = _downstream_stale_updates(statuses)
+    updates = {PLAN_STEP: "approved", **stale_updates}
+    state_path.write_text(apply_status_updates(text, updates), encoding="utf-8")
+
+    staled_steps = sorted(stale_updates, key=STEP_ORDER.index)
+    logger.info(f"Set plan -> approved; marked stale: {staled_steps or 'none'}.")
+    return CommitResult(
+        ok=True,
+        message="plan -> approved",
+        staled_steps=staled_steps,
+        missing_recommended=validation.missing_recommended,
+    )
+
+
+# --- CLI ---------------------------------------------------------------------
+
+def format_precheck(result: PrecheckResult) -> str:
+    """Render a :class:`PrecheckResult` as a human-readable block.
+
+    Args:
+        result: The precheck result to render.
+
+    Returns:
+        A multi-line, plain-ASCII string suitable for printing to the analyst.
+    """
+    # Plain ASCII only: this prints to the console, which on Windows is cp1252
+    # and would raise UnicodeEncodeError on emoji/box-drawing glyphs.
+    if not result.can_run:
+        return f"[BLOCKED] tableau-plan cannot run.\n{result.blocker}"
+
+    lines = ["[PLAN] precheck OK - tableau-plan can run.", "  DATA-MODEL.md: present (required read)."]
+    lines.append(f"  DASHBOARD-PLAN.md exists : {'yes' if result.plan_exists else 'no'}")
+    if result.plan_exists:
+        lines.append(
+            "    -> a plan already exists; offer REFINE vs OVERWRITE - never silently "
+            "overwrite the analyst's work."
+        )
+
+    if result.requirements_source == "none":
+        lines.append(
+            "  requirements : none found - plan against DATA-MODEL.md and confirm scope "
+            "with the analyst."
+        )
+    elif result.requirements_source == SCAFFOLD_REQUEST:
+        lines.append(
+            f"  requirements : {SCAFFOLD_REQUEST} (DEMO fallback - say so; no PRD.md or "
+            f"root {REQUEST_FILENAME})."
+        )
+    else:
+        lines.append(f"  requirements : {result.requirements_source} (used to shape the plan).")
+
+    lines.append(
+        f"  DESIGN-TOKENS.md: {'present' if result.tokens_present else 'absent - neutral styling'}"
+        " (optional read)."
+    )
+
+    rerun_note = (
+        " (re-run; downstream approved steps will be marked stale on commit)"
+        if result.plan_status in ("approved", "stale")
+        else ""
+    )
+    lines.append(f"  plan status  : {result.plan_status}{rerun_note}")
+    return "\n".join(lines)
+
+
+def format_validation(validation: PlanValidation) -> str:
+    """Render a :class:`PlanValidation` as a human-readable block.
+
+    Args:
+        validation: The validation result to render.
+
+    Returns:
+        A multi-line, plain-ASCII string suitable for printing to the analyst.
+    """
+    # Plain ASCII only (see format_precheck).
+    if validation.ok:
+        lines = ["[OK] DASHBOARD-PLAN.md is complete (all required sections, unique ids)."]
+        if validation.missing_recommended:
+            lines.append(
+                f"  note: no {', '.join(validation.missing_recommended)} section(s) - "
+                f"optional, but 'Suggestions' is where you propose extra value."
+            )
+        return "\n".join(lines)
+
+    lines = ["[INVALID] DASHBOARD-PLAN.md is incomplete."]
+    if validation.missing_required:
+        lines.append(f"  missing required section(s): {', '.join(validation.missing_required)}")
+    for problem in validation.problems:
+        lines.append(f"  problem: {problem}")
+    return "\n".join(lines)
+
+
+def format_commit(result: CommitResult) -> str:
+    """Render a :class:`CommitResult` as a human-readable block.
+
+    Args:
+        result: The commit result to render.
+
+    Returns:
+        A multi-line, plain-ASCII string suitable for printing to the analyst.
+    """
+    # Plain ASCII only (see format_precheck).
+    if not result.ok:
+        return f"[REFUSED] {result.message}"
+
+    lines = [f"[PLAN] {result.message}."]
+    if result.missing_recommended:
+        lines.append(
+            f"  note: plan has no {', '.join(result.missing_recommended)} section(s) "
+            f"- optional, left as-is."
+        )
+    if result.staled_steps:
+        lines.append(
+            f"  downstream marked stale: {', '.join(result.staled_steps)} "
+            f"(re-run these in order)."
+        )
+    lines.append(
+        "  next: open a fresh conversation and run 'tableau-mock' (or 'tableau-route')."
+    )
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point: run ``precheck``, ``validate``, or ``commit`` and print it.
+
+    Args:
+        argv: Argument list (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Process exit code: ``0`` on success, ``2`` when plan is blocked/refused/invalid
+        or on a usage error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Gate, validate, and commit the tableau-plan step.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for name, help_text in (
+        ("precheck", "Report whether plan may run and what to read."),
+        ("validate", "Check a draft DASHBOARD-PLAN.md against the strict schema."),
+        ("commit", "Approve the plan in STATE.md and propagate staleness."),
+    ):
+        sub = subparsers.add_parser(name, help=help_text)
+        sub.add_argument(
+            "project_dir", nargs="?", default=".", help="Project directory (default: cwd)."
+        )
+
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    if args.command == "precheck":
+        precheck_result = precheck(args.project_dir)
+        print(format_precheck(precheck_result))
+        return 0 if precheck_result.can_run else 2
+
+    if args.command == "validate":
+        plan_path = Path(args.project_dir) / PLAN_FILENAME
+        if not plan_path.exists():
+            print(f"[INVALID] '{PLAN_FILENAME}' not found in '{args.project_dir}'.")
+            return 2
+        validation = validate_plan(plan_path.read_text(encoding="utf-8-sig"))
+        print(format_validation(validation))
+        return 0 if validation.ok else 2
+
+    commit_result = commit(args.project_dir)
+    print(format_commit(commit_result))
+    return 0 if commit_result.ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ _SKILL_SCRIPT_DIRS = (
     _REPO_ROOT / "skills" / "tableau-data" / "scripts",
     _REPO_ROOT / "skills" / "tableau-brand" / "scripts",
     _REPO_ROOT / "skills" / "tableau-plan" / "scripts",
+    _REPO_ROOT / "skills" / "tableau-mock" / "scripts",
 )
 
 for _script_dir in _SKILL_SCRIPT_DIRS:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ _SKILL_SCRIPT_DIRS = (
     _REPO_ROOT / "skills" / "tableau-intake" / "scripts",
     _REPO_ROOT / "skills" / "tableau-data" / "scripts",
     _REPO_ROOT / "skills" / "tableau-brand" / "scripts",
+    _REPO_ROOT / "skills" / "tableau-plan" / "scripts",
 )
 
 for _script_dir in _SKILL_SCRIPT_DIRS:

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,0 +1,455 @@
+"""Contract test for tableau-mock (CONTRACT.md step 6, §4.1, §4.2, §4.3).
+
+``tableau-mock`` turns the strict ``DASHBOARD-PLAN.md`` into an interactive ``mock.html``
+demo. The markup is model-authored, so this test pins the parts the scripts must guarantee
+mechanically, split across the two modules:
+
+* :mod:`coverage` (pure core) - parsing the plan into its coverage set, matching that
+  against what the mock rendered (``data-plan-id``), the layout manifest, and the
+  slot-sizing guard (out-of-bounds / compressed / empty-space-heavy);
+* :mod:`mock` (orchestration) - the entry gate (§4.1), deliverable versioning (§4.3),
+  and the STATE.md ``approved`` + downstream-``stale`` transition (§4.2), cross-checked
+  through the *router* so the manifest mock writes actually routes onward.
+"""
+
+from pathlib import Path
+
+import coverage  # the pure coverage/guard core (on sys.path via conftest.py)
+import init  # builds a realistic STATE.md the same way a real project would
+import mock  # the orchestration under test
+import route  # the router parses/routes the STATE.md mock writes
+
+TARGET_VERSION = "2024.2-2025.x"
+
+# A schema-complete plan mirroring test_plan's: canvas 1366x768, 2 elements, 1 filter,
+# 1 interaction. parse_plan_coverage categorises the id-tables by their headers.
+FULL_PLAN = (
+    "# Dashboard Plan: Sales\n\n"
+    "## Screen Size\n- mode: fixed\n- dimensions: 1366 x 768 px\n\n"
+    "## Elements\n"
+    "| id          | type       | columns      | slot    | size       |\n"
+    "|-------------|------------|--------------|---------|------------|\n"
+    "| kpi-revenue | kpi        | revenue      | kpi-row | 1/4 of row |\n"
+    "| chart-trend | chart:line | order_date   | chart-a | fills slot |\n\n"
+    "## Filters\n"
+    "| id         | field  | control type     | scope | default |\n"
+    "|------------|--------|------------------|-------|---------|\n"
+    "| flt-region | region | dropdown (multi) | all   | All     |\n\n"
+    "## Interactions\n"
+    "| id                | interaction  | source      | target      | detail        |\n"
+    "|-------------------|--------------|-------------|-------------|---------------|\n"
+    "| int-region-filter | cross-filter | chart-trend | kpi-revenue | click filters |\n"
+)
+
+
+def _mock_html(
+    ids=("kpi-revenue", "chart-trend", "flt-region", "int-region-filter"),
+    canvas=(1366, 768),
+    boxes=(
+        {"id": "kpi-revenue", "x": 0, "y": 0, "width": 1366, "height": 300},
+        {"id": "chart-trend", "x": 0, "y": 300, "width": 1366, "height": 400},
+    ),
+) -> str:
+    """Render a mock.html that covers ``FULL_PLAN`` (override args to break one thing).
+
+    Args:
+        ids: Plan ids to tag with ``data-plan-id`` (drop one to force a coverage gap).
+        canvas: The manifest ``(width, height)`` (mismatch to fail screen-size coverage).
+        boxes: Element geometry boxes for the layout manifest.
+
+    Returns:
+        A self-contained mock.html string.
+    """
+    tagged = "\n".join(f'<div data-plan-id="{plan_id}"></div>' for plan_id in ids)
+    manifest = {"canvas": {"width": canvas[0], "height": canvas[1]}, "elements": list(boxes)}
+    import json
+
+    return (
+        f"<!doctype html><html><body>\n{tagged}\n"
+        f'<script type="application/json" id="{coverage.LAYOUT_MANIFEST_ID}">'
+        f"{json.dumps(manifest)}</script>\n</body></html>"
+    )
+
+
+def _state_with(project_dir: Path, **status_overrides: str) -> None:
+    """Write a canonical STATE.md, optionally overriding some step statuses.
+
+    Args:
+        project_dir: Directory to write ``STATE.md`` into.
+        **status_overrides: ``step=status`` pairs to apply on top of a fresh manifest.
+    """
+    text = init.render_state_md(TARGET_VERSION)
+    if status_overrides:
+        text = mock.apply_status_updates(text, dict(status_overrides))
+    (project_dir / "STATE.md").write_text(text, encoding="utf-8")
+
+
+def _ready_project(project_dir: Path, **status_overrides: str) -> None:
+    """Open mock's entry gate: plan+data resolved, DASHBOARD-PLAN.md and a CSV on disk.
+
+    Args:
+        project_dir: The project directory to populate.
+        **status_overrides: Extra ``step=status`` overrides (merged after plan/data).
+    """
+    _state_with(project_dir, plan="approved", data="approved", **status_overrides)
+    (project_dir / "DASHBOARD-PLAN.md").write_text(FULL_PLAN, encoding="utf-8")
+    data_dir = project_dir / "data"
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / "x.csv").write_text("region,revenue\nWest,10\n", encoding="utf-8")
+
+
+def _write_mock(project_dir: Path, version: str, html: str) -> None:
+    """Write ``html`` to ``mock-version/<version>/mock.html`` under the project."""
+    version_dir = project_dir / mock.VERSION_DIR / version
+    version_dir.mkdir(parents=True, exist_ok=True)
+    (version_dir / mock.MOCK_FILENAME).write_text(html, encoding="utf-8")
+
+
+# --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
+
+def test_precheck_blocks_when_no_state(tmp_path):
+    """No STATE.md => mock cannot run; the blocker points at tableau-init."""
+    result = mock.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "tableau-init" in result.blocker
+
+
+def test_precheck_blocks_when_plan_not_resolved(tmp_path):
+    """plan must be resolved before mock runs (§4.1)."""
+    _state_with(tmp_path, plan="pending", data="approved")
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(FULL_PLAN, encoding="utf-8")
+
+    result = mock.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "plan" in result.blocker and "pending" in result.blocker
+
+
+def test_precheck_blocks_when_plan_file_missing(tmp_path):
+    """Even with plan approved, a missing DASHBOARD-PLAN.md on disk blocks mock (§4.1)."""
+    _state_with(tmp_path, plan="approved", data="approved")  # no plan file written
+
+    result = mock.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "DASHBOARD-PLAN.md" in result.blocker
+
+
+def test_precheck_blocks_when_data_not_resolved(tmp_path):
+    """data must be resolved too - mock populates the demo from the sample CSVs (§4.1)."""
+    _state_with(tmp_path, plan="approved", data="pending")
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(FULL_PLAN, encoding="utf-8")
+
+    result = mock.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "data" in result.blocker and "pending" in result.blocker
+
+
+def test_precheck_blocks_when_no_csv(tmp_path):
+    """With data resolved but no CSV on disk, the gate stays closed (§4.1)."""
+    _state_with(tmp_path, plan="approved", data="approved")
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(FULL_PLAN, encoding="utf-8")
+
+    result = mock.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "CSV" in result.blocker
+
+
+def test_scaffold_sample_csv_satisfies_the_data_gate(tmp_path):
+    """The scaffold/sample-data/ demo CSV is an accepted fallback for the data gate (§3.1)."""
+    _state_with(tmp_path, plan="approved", data="approved")
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(FULL_PLAN, encoding="utf-8")
+    sample_dir = tmp_path / "scaffold" / "sample-data"
+    sample_dir.mkdir(parents=True)
+    (sample_dir / "demo.csv").write_text("region,revenue\nWest,10\n", encoding="utf-8")
+
+    assert mock.precheck(tmp_path).can_run is True
+
+
+def test_optional_steps_do_not_gate_mock(tmp_path):
+    """intake/brand are optional reads: mock runs with them pending (§1)."""
+    _ready_project(tmp_path, intake="pending", brand="pending")
+
+    assert mock.precheck(tmp_path).can_run is True
+
+
+# --- Precheck signals --------------------------------------------------------
+
+def test_precheck_reports_canvas_and_coverage_targets(tmp_path):
+    """precheck surfaces the canvas size and element/filter/interaction counts to render."""
+    _ready_project(tmp_path)
+
+    result = mock.precheck(tmp_path)
+
+    assert result.can_run is True
+    assert result.canvas == (1366, 768)
+    assert result.element_count == 2
+    assert result.filter_count == 1
+    assert result.interaction_count == 1
+
+
+def test_precheck_reports_target_version_path_and_rerun(tmp_path):
+    """First run targets v_1 (no bump); a post-approval re-run bumps to v_2 (§4.3)."""
+    _ready_project(tmp_path)
+    first = mock.precheck(tmp_path)
+    assert first.target_version == "v_1"
+    assert first.target_path == "mock-version/v_1/mock.html"
+    assert first.is_rerun_after_approval is False
+    assert first.mock_exists is False
+
+    # Simulate a prior approval: mock approved, v_1 on disk.
+    _ready_project(tmp_path, mock="approved")
+    _write_mock(tmp_path, "v_1", _mock_html())
+    rerun = mock.precheck(tmp_path)
+    assert rerun.target_version == "v_2"
+    assert rerun.is_rerun_after_approval is True
+
+
+def test_precheck_reports_design_tokens_presence(tmp_path):
+    """precheck surfaces whether DESIGN-TOKENS.md is available (optional read)."""
+    _ready_project(tmp_path)
+    assert mock.precheck(tmp_path).tokens_present is False
+
+    (tmp_path / "DESIGN-TOKENS.md").write_text("## Colors\n", encoding="utf-8")
+    assert mock.precheck(tmp_path).tokens_present is True
+
+
+# --- Plan coverage parsing (coverage.py) -------------------------------------
+
+def test_parse_plan_coverage_categorises_id_tables():
+    """The plan's id-tables are split into elements/filters/interactions by their headers."""
+    spec = coverage.parse_plan_coverage(FULL_PLAN)
+
+    assert spec.canvas == (1366, 768)
+    assert spec.element_ids == ["kpi-revenue", "chart-trend"]
+    assert spec.filter_ids == ["flt-region"]
+    assert spec.interaction_ids == ["int-region-filter"]
+    assert spec.all_ids == [
+        "kpi-revenue", "chart-trend", "flt-region", "int-region-filter",
+    ]
+
+
+def test_parse_plan_coverage_drops_none_sentinel():
+    """A ``none`` sentinel row (no-filters/no-interactions) is not counted as coverage."""
+    no_filters = FULL_PLAN.replace(
+        "| flt-region | region | dropdown (multi) | all   | All     |",
+        "| none       | -      | -                | -     | -       |",
+    )
+
+    spec = coverage.parse_plan_coverage(no_filters)
+
+    assert spec.filter_ids == []
+
+
+def test_rendered_plan_ids_reads_data_plan_id_attrs():
+    """Every ``data-plan-id`` value in the markup is what coverage matches against."""
+    assert coverage.rendered_plan_ids(_mock_html()) == {
+        "kpi-revenue", "chart-trend", "flt-region", "int-region-filter",
+    }
+
+
+def test_parse_layout_manifest_returns_none_on_missing_or_bad_json():
+    """A missing or non-JSON manifest block parses to None (guard then reports it)."""
+    assert coverage.parse_layout_manifest("<html></html>") is None
+    bad = (
+        f'<script type="application/json" id="{coverage.LAYOUT_MANIFEST_ID}">'
+        "{not json}</script>"
+    )
+    assert coverage.parse_layout_manifest(bad) is None
+
+
+# --- validate_mock: the coverage checklist + guard ---------------------------
+
+def test_validate_full_mock_passes():
+    """A mock rendering every id, matching canvas, with readable full-canvas boxes is OK."""
+    validation = coverage.validate_mock(FULL_PLAN, _mock_html())
+
+    assert validation.ok is True
+    assert validation.gaps == []
+    assert validation.guard_violations == []
+    assert validation.missing_boxes == []
+
+
+def test_validate_flags_coverage_gap_for_unrendered_id():
+    """A plan id absent from the markup is a coverage gap that fails validation."""
+    html = _mock_html(ids=("kpi-revenue", "chart-trend", "flt-region"))  # drops interaction
+
+    validation = coverage.validate_mock(FULL_PLAN, html)
+
+    assert validation.ok is False
+    assert any(item.label == "int-region-filter" for item in validation.gaps)
+
+
+def test_validate_flags_screen_size_mismatch():
+    """A manifest canvas that differs from the plan's Screen Size fails screen-size coverage."""
+    validation = coverage.validate_mock(FULL_PLAN, _mock_html(canvas=(1280, 720)))
+
+    assert validation.ok is False
+    assert any(
+        item.kind == "screen size" and not item.rendered for item in validation.coverage
+    )
+
+
+def test_validate_flags_missing_element_box():
+    """An element with a data-plan-id but no geometry box is a missing box (blocks approval)."""
+    html = _mock_html(
+        boxes=({"id": "kpi-revenue", "x": 0, "y": 0, "width": 1366, "height": 700},),
+    )  # chart-trend has no box
+
+    validation = coverage.validate_mock(FULL_PLAN, html)
+
+    assert validation.ok is False
+    assert "chart-trend" in validation.missing_boxes
+
+
+def test_guard_flags_out_of_bounds_box():
+    """A box escaping the canvas is an out-of-bounds guard violation."""
+    html = _mock_html(
+        boxes=(
+            {"id": "kpi-revenue", "x": 0, "y": 0, "width": 1366, "height": 300},
+            {"id": "chart-trend", "x": 0, "y": 300, "width": 1366, "height": 500},  # 800>768
+        ),
+    )
+
+    validation = coverage.validate_mock(FULL_PLAN, html)
+
+    assert validation.ok is False
+    assert any("out-of-bounds" in v for v in validation.guard_violations)
+
+
+def test_guard_flags_compressed_box():
+    """A box below the readable minimum size is a 'compressed' guard violation."""
+    html = _mock_html(
+        boxes=(
+            {"id": "kpi-revenue", "x": 0, "y": 0, "width": 1366, "height": 700},
+            {"id": "chart-trend", "x": 0, "y": 700, "width": 40, "height": 20},  # tiny
+        ),
+    )
+
+    validation = coverage.validate_mock(FULL_PLAN, html)
+
+    assert validation.ok is False
+    assert any("compressed" in v for v in validation.guard_violations)
+
+
+def test_guard_flags_empty_space_heavy_layout():
+    """Element boxes covering below the fill ratio flag an empty-space-heavy layout."""
+    html = _mock_html(
+        boxes=(
+            {"id": "kpi-revenue", "x": 0, "y": 0, "width": 100, "height": 100},
+            {"id": "chart-trend", "x": 0, "y": 120, "width": 100, "height": 100},
+        ),
+    )  # ~20k px of a 1.05M canvas => ~2%
+
+    validation = coverage.validate_mock(FULL_PLAN, html)
+
+    assert validation.ok is False
+    assert any("empty-space-heavy" in v for v in validation.guard_violations)
+
+
+# --- Versioning helpers (CONTRACT.md §4.3) -----------------------------------
+
+def test_target_version_bumps_only_after_approval():
+    """Re-running after approval bumps the version; before approval it overwrites."""
+    assert mock.target_version("v_1", "pending") == "v_1"
+    assert mock.target_version("v_1", "approved") == "v_2"
+    assert mock.bump_version("v_3") == "v_4"
+
+
+def test_set_and_read_current_version_round_trip():
+    """set_current_version rewrites the metadata line read_current_version reads back."""
+    text = init.render_state_md(TARGET_VERSION)
+    assert mock.read_current_version(text) == "v_1"
+
+    updated = mock.set_current_version(text, "v_2")
+    assert mock.read_current_version(updated) == "v_2"
+    assert "# v_1, v_2, ..." in updated  # trailing inline comment preserved
+
+
+# --- Commit: approve, refuse (CONTRACT.md §4.1, §4.3) ------------------------
+
+def test_commit_refuses_when_gate_closed(tmp_path):
+    """The entry gate guards commit, not just precheck; STATE.md stays untouched."""
+    _state_with(tmp_path, plan="pending", data="approved")
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(FULL_PLAN, encoding="utf-8")
+
+    result = mock.commit(tmp_path)
+
+    assert result.ok is False
+    assert "plan" in result.message
+    assert route.parse_state(tmp_path / "STATE.md").statuses["mock"] == "pending"
+
+
+def test_commit_refuses_when_mock_absent(tmp_path):
+    """Approving without a mock.html on disk is refused (nothing to approve)."""
+    _ready_project(tmp_path)
+
+    result = mock.commit(tmp_path)
+
+    assert result.ok is False
+    assert "mock.html" in result.message
+    assert route.parse_state(tmp_path / "STATE.md").statuses["mock"] == "pending"
+
+
+def test_commit_refuses_mock_with_coverage_gap(tmp_path):
+    """commit re-runs the coverage check; a gap is refused and STATE.md is untouched."""
+    _ready_project(tmp_path)
+    _write_mock(tmp_path, "v_1", _mock_html(ids=("kpi-revenue", "chart-trend", "flt-region")))
+
+    result = mock.commit(tmp_path)
+
+    assert result.ok is False
+    assert route.parse_state(tmp_path / "STATE.md").statuses["mock"] == "pending"
+
+
+def test_commit_approves_valid_mock(tmp_path):
+    """A mock that fully covers the plan commits: mock -> approved, current_version set."""
+    _ready_project(tmp_path)
+    _write_mock(tmp_path, "v_1", _mock_html())
+
+    result = mock.commit(tmp_path)
+
+    assert result.ok is True
+    assert result.version == "v_1"
+    statuses = route.parse_state(tmp_path / "STATE.md").statuses
+    assert statuses["mock"] == "approved"
+
+
+# --- Staleness propagation (CONTRACT.md §4.2) --------------------------------
+
+def test_rerun_after_approval_bumps_version_and_stales_downstream(tmp_path):
+    """A post-approval re-run writes v_2, and flips downstream approved steps to stale."""
+    # Upstream steps resolved too, so the router's cross-check reaches the stale 'spec'.
+    _ready_project(
+        tmp_path,
+        intake="approved", brand="approved",
+        mock="approved", spec="approved", build="approved",
+    )
+    _write_mock(tmp_path, "v_2", _mock_html())  # target after approval is v_2 (§4.3)
+
+    result = mock.commit(tmp_path)
+
+    assert result.ok is True
+    assert result.version == "v_2"
+    assert result.staled_steps == ["spec", "build"]
+
+    statuses = route.parse_state(tmp_path / "STATE.md").statuses
+    assert statuses["mock"] == "approved"
+    assert statuses["spec"] == "stale" and statuses["build"] == "stale"
+
+    # Cross-check through the router: the first unresolved step is now stale 'spec'.
+    routed = route.compute_next_step(tmp_path)
+    assert routed.next_step == "spec" and "stale" in routed.reason.lower()
+
+
+def test_first_run_marks_nothing_stale(tmp_path):
+    """On a first approval there is nothing downstream approved, so nothing goes stale."""
+    _ready_project(tmp_path)
+    _write_mock(tmp_path, "v_1", _mock_html())
+
+    result = mock.commit(tmp_path)
+
+    assert result.ok is True and result.staled_steps == []

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,316 @@
+"""Contract test for tableau-plan (CONTRACT.md step 5, §4.1, §4.2, §6).
+
+``tableau-plan`` produces the strict ``DASHBOARD-PLAN.md`` the mock builds against. The
+plan prose is model-authored, so this test pins the parts ``plan.py`` must guarantee
+mechanically:
+
+1. the entry gate (plan refuses until ``data`` is resolved AND ``DATA-MODEL.md`` exists,
+   §4.1 — note that ``intake``/``brand`` are optional reads and never gate plan);
+2. the precheck signals the skill branches on (existing plan, requirements source);
+3. the strict schema — every required section present, every KPI/chart/filter/action with
+   a stable, unique id, and interactions drawn from the shared vocabulary (§6);
+4. the STATE.md transition + staleness propagation (§4.2), cross-checked by routing the
+   resulting manifest through the *router's* own ``compute_next_step``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import init  # builds a realistic STATE.md the same way a real project would
+import plan  # the skill under test (on sys.path via conftest.py)
+import route  # the router parses/routes the STATE.md plan writes
+
+TARGET_VERSION = "2024.2-2025.x"
+
+# A schema-complete plan: all required sections, unique ids, valid interaction terms.
+FULL_PLAN = (
+    "# Dashboard Plan: Sales\n\n"
+    "## Summary\nFor the VP of Sales.\n\n"
+    "## Screen Size\n- mode: fixed\n- dimensions: 1366 x 768 px\n\n"
+    "## Layout Grid\n"
+    "| slot     | position | size         |\n"
+    "|----------|----------|--------------|\n"
+    "| kpi-row  | top      | 100% x 120px |\n"
+    "| chart-a  | middle   | 100% x 360px |\n\n"
+    "## Elements\n"
+    "| id          | type       | columns      | slot    | size       |\n"
+    "|-------------|------------|--------------|---------|------------|\n"
+    "| kpi-revenue | kpi        | revenue      | kpi-row | 1/4 of row |\n"
+    "| chart-trend | chart:line | order_date   | chart-a | fills slot |\n\n"
+    "## Filters\n"
+    "| id         | field  | control type     | scope | default |\n"
+    "|------------|--------|------------------|-------|---------|\n"
+    "| flt-region | region | dropdown (multi) | all   | All     |\n\n"
+    "## Interactions\n"
+    "| id                | interaction  | source      | target      | detail        |\n"
+    "|-------------------|--------------|-------------|-------------|---------------|\n"
+    "| int-region-filter | cross-filter | chart-trend | kpi-revenue | click filters |\n\n"
+    "## Suggestions\n1. A discount-impact view.\n"
+)
+
+
+def _state_with(project_dir: Path, **status_overrides: str) -> None:
+    """Write a canonical STATE.md, optionally overriding some step statuses.
+
+    Args:
+        project_dir: Directory to write ``STATE.md`` into.
+        **status_overrides: ``step=status`` pairs to apply on top of a fresh manifest.
+    """
+    text = init.render_state_md(TARGET_VERSION)
+    if status_overrides:
+        text = plan.apply_status_updates(text, dict(status_overrides))
+    (project_dir / "STATE.md").write_text(text, encoding="utf-8")
+
+
+def _ready_project(project_dir: Path, **status_overrides: str) -> None:
+    """Set up a project where plan's entry gate is open (data approved + DATA-MODEL.md).
+
+    Args:
+        project_dir: The project directory to populate.
+        **status_overrides: Extra ``step=status`` overrides (merged after ``data``).
+    """
+    _state_with(project_dir, data="approved", **status_overrides)
+    (project_dir / "DATA-MODEL.md").write_text("## Data source: `x.csv`\n", encoding="utf-8")
+    # A real CSV on disk too, so downstream gates (e.g. mock) see the data artifact.
+    data_dir = project_dir / "data"
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / "x.csv").write_text("region,revenue\nWest,10\n", encoding="utf-8")
+
+
+# --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
+
+def test_precheck_blocks_when_no_state(tmp_path):
+    """No STATE.md ⇒ plan cannot run; the blocker points at tableau-init."""
+    result = plan.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "tableau-init" in result.blocker
+
+
+def test_precheck_blocks_when_data_not_resolved(tmp_path):
+    """data must be resolved before plan runs (§4.1)."""
+    _state_with(tmp_path, data="pending")
+    (tmp_path / "DATA-MODEL.md").write_text("x", encoding="utf-8")
+
+    result = plan.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "data" in result.blocker and "pending" in result.blocker
+
+
+def test_precheck_blocks_when_data_model_missing(tmp_path):
+    """Even with data approved, a missing DATA-MODEL.md on disk blocks plan (§4.1)."""
+    _state_with(tmp_path, data="approved")  # no DATA-MODEL.md written
+
+    result = plan.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "DATA-MODEL.md" in result.blocker
+
+
+def test_intake_and_brand_do_not_gate_plan(tmp_path):
+    """intake/brand are optional reads: plan runs with them pending (§1)."""
+    _ready_project(tmp_path, intake="pending", brand="pending")
+
+    assert plan.precheck(tmp_path).can_run is True
+
+
+def test_commit_refuses_when_data_not_resolved(tmp_path):
+    """The same gate guards commit, not just precheck; STATE.md stays untouched."""
+    _state_with(tmp_path, data="pending")
+    (tmp_path / "DATA-MODEL.md").write_text("x", encoding="utf-8")
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(FULL_PLAN, encoding="utf-8")
+
+    result = plan.commit(tmp_path)
+
+    assert result.ok is False
+    assert "data" in result.message
+    assert route.parse_state(tmp_path / "STATE.md").statuses["plan"] == "pending"
+
+
+# --- Precheck signals --------------------------------------------------------
+
+def test_precheck_detects_existing_plan(tmp_path):
+    """precheck reports whether a DASHBOARD-PLAN.md already exists (refine-vs-overwrite)."""
+    _ready_project(tmp_path)
+    assert plan.precheck(tmp_path).plan_exists is False
+
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(FULL_PLAN, encoding="utf-8")
+    assert plan.precheck(tmp_path).plan_exists is True
+
+
+def test_requirements_source_prefers_prd_then_request(tmp_path):
+    """PRD.md > root DASHBOARD-REQUEST.md > scaffold demo > none (§3.1)."""
+    _ready_project(tmp_path)
+    assert plan.precheck(tmp_path).requirements_source == "none"
+
+    (tmp_path / "scaffold").mkdir()
+    (tmp_path / "scaffold" / "EXAMPLE-DASHBOARD-REQUEST.md").write_text("demo", encoding="utf-8")
+    assert plan.precheck(tmp_path).requirements_source == plan.SCAFFOLD_REQUEST
+
+    (tmp_path / "DASHBOARD-REQUEST.md").write_text("req", encoding="utf-8")
+    assert plan.precheck(tmp_path).requirements_source == "DASHBOARD-REQUEST.md"
+
+    (tmp_path / "PRD.md").write_text("prd", encoding="utf-8")
+    assert plan.precheck(tmp_path).requirements_source == "PRD.md"
+
+
+def test_precheck_reports_design_tokens_presence(tmp_path):
+    """precheck surfaces whether DESIGN-TOKENS.md is available (optional read)."""
+    _ready_project(tmp_path)
+    assert plan.precheck(tmp_path).tokens_present is False
+
+    (tmp_path / "DESIGN-TOKENS.md").write_text("## Colors\n", encoding="utf-8")
+    assert plan.precheck(tmp_path).tokens_present is True
+
+
+# --- Plan schema -------------------------------------------------------------
+
+def test_validate_full_plan_passes():
+    """A schema-complete plan validates clean."""
+    validation = plan.validate_plan(FULL_PLAN)
+
+    assert validation.ok is True
+    assert validation.missing_required == []
+    assert validation.problems == []
+
+
+def test_validate_rejects_missing_required_section():
+    """A plan missing a required section is invalid and names it (blocks the mock)."""
+    without_interactions = FULL_PLAN.split("## Interactions")[0]
+
+    validation = plan.validate_plan(without_interactions)
+
+    assert validation.ok is False
+    assert "Interactions" in validation.missing_required
+
+
+def test_validate_rejects_duplicate_ids():
+    """Stable ids must be unique across the plan — a collision is rejected."""
+    dup = FULL_PLAN.replace("int-region-filter", "kpi-revenue")  # clashes with the KPI id
+
+    validation = plan.validate_plan(dup)
+
+    assert validation.ok is False
+    assert any("duplicate id 'kpi-revenue'" in problem for problem in validation.problems)
+
+
+def test_validate_rejects_empty_id():
+    """A row in an id-table with a blank id is rejected (every element needs an id)."""
+    blank = FULL_PLAN.replace(
+        "| kpi-revenue | kpi        | revenue      | kpi-row | 1/4 of row |",
+        "|             | kpi        | revenue      | kpi-row | 1/4 of row |",
+    )
+
+    validation = plan.validate_plan(blank)
+
+    assert validation.ok is False
+    assert any("empty 'id'" in problem for problem in validation.problems)
+
+
+def test_validate_rejects_unknown_interaction_term():
+    """Interactions must use the shared vocabulary (§6); an off-list term is rejected."""
+    bad = FULL_PLAN.replace("cross-filter", "zoom-and-pan")
+
+    validation = plan.validate_plan(bad)
+
+    assert validation.ok is False
+    assert any("zoom-and-pan" in problem for problem in validation.problems)
+
+
+def test_validate_accepts_all_vocabulary_terms():
+    """Every shared-vocabulary term is accepted in the interaction column (§6)."""
+    for term in plan.INTERACTION_VOCABULARY:
+        text = FULL_PLAN.replace("cross-filter", term)
+        assert plan.validate_plan(text).ok is True, term
+
+
+def test_validate_reports_missing_recommended_without_failing():
+    """An absent recommended section is reported but never makes a plan invalid."""
+    no_summary = FULL_PLAN.replace("## Summary\nFor the VP of Sales.\n\n", "")
+
+    validation = plan.validate_plan(no_summary)
+
+    assert validation.ok is True
+    assert "Summary" in validation.missing_recommended
+
+
+def test_shipped_template_is_schema_complete():
+    """The bundled DASHBOARD-PLAN-TEMPLATE.md passes its own validator (the anchor)."""
+    validation = plan.validate_plan(plan.render_plan_template())
+
+    assert validation.ok is True, (validation.missing_required, validation.problems)
+
+
+# --- Commit: approve, refuse -------------------------------------------------
+
+def test_commit_approves_complete_plan(tmp_path):
+    """A schema-complete plan commits: plan → approved in STATE.md."""
+    _ready_project(tmp_path)
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(FULL_PLAN, encoding="utf-8")
+
+    result = plan.commit(tmp_path)
+
+    assert result.ok is True
+    assert route.parse_state(tmp_path / "STATE.md").statuses["plan"] == "approved"
+
+
+def test_commit_refuses_incomplete_plan(tmp_path):
+    """commit refuses a plan missing a required section, and STATE.md is untouched."""
+    _ready_project(tmp_path)
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(
+        FULL_PLAN.split("## Filters")[0], encoding="utf-8"
+    )
+
+    result = plan.commit(tmp_path)
+
+    assert result.ok is False
+    assert "Filters" in result.message
+    assert route.parse_state(tmp_path / "STATE.md").statuses["plan"] == "pending"
+
+
+def test_commit_refuses_when_plan_absent(tmp_path):
+    """Approving without a DASHBOARD-PLAN.md on disk is refused (nothing to approve)."""
+    _ready_project(tmp_path)
+
+    result = plan.commit(tmp_path)
+
+    assert result.ok is False
+    assert "DASHBOARD-PLAN.md" in result.message
+
+
+# --- Staleness propagation (CONTRACT.md §4.2) --------------------------------
+
+def test_rerun_marks_downstream_approved_steps_stale(tmp_path):
+    """Re-running plan flips downstream approved steps (mock/spec/build) to stale."""
+    # Upstream steps resolved too, so the router's cross-check reaches the stale 'mock'.
+    _ready_project(
+        tmp_path,
+        intake="approved", brand="approved",
+        plan="approved", mock="approved", spec="approved",
+    )
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(FULL_PLAN, encoding="utf-8")
+
+    result = plan.commit(tmp_path)
+
+    assert result.ok is True
+    assert result.staled_steps == ["mock", "spec"]
+
+    statuses = route.parse_state(tmp_path / "STATE.md").statuses
+    assert statuses["mock"] == "stale" and statuses["spec"] == "stale"
+    assert statuses["plan"] == "approved"  # its own step re-approved
+
+    # Cross-check through the router: the first unresolved step is now stale 'mock'.
+    routed = route.compute_next_step(tmp_path)
+    assert routed.next_step == "mock" and "stale" in routed.reason.lower()
+
+
+def test_first_run_marks_nothing_stale(tmp_path):
+    """On a first approval there is nothing downstream approved, so nothing goes stale."""
+    _ready_project(tmp_path)
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(FULL_PLAN, encoding="utf-8")
+
+    result = plan.commit(tmp_path)
+
+    assert result.ok is True and result.staled_steps == []


### PR DESCRIPTION
## What

Adds **`tableau-mock`** — Step 6 of 8, non-skippable. It turns the strict
`DASHBOARD-PLAN.md` into a self-contained interactive `mock.html` demo, rendered at the
plan's screen size and populated from the **real sample CSVs**, so the analyst can share a
realistic demo and validate direction *before any Tableau work begins*.

## How it enforces the contract

- **Entry gate (§4.1)** — refuses to run until `plan` is resolved and `DASHBOARD-PLAN.md`
  exists, and `data` is resolved and a sample CSV is present (production `data/` or the
  `scaffold/sample-data/` demo fallback).
- **Coverage guarantee** — "every plan element rendered" is mechanical, not hope: each plan
  id must appear as a `data-plan-id` marker, proven by a coverage checklist. Missing ids
  block approval.
- **Slot-sizing guard** — reads an embedded JSON layout manifest and rejects
  out-of-bounds / compressed / empty-space-heavy layouts; the manifest canvas must equal
  the plan's Screen Size.
- **Versioning (§4.3)** — `mock.html` is a deliverable under `mock-version/v_N/`;
  re-running after approval bumps the version and preserves prior copies.
- **STATE.md transition (§4.2)** — commit sets `mock` = `approved`, sets `current_version`,
  and flips downstream `approved` steps (`spec`/`build`) to `stale`.

## Files

- `skills/tableau-mock/SKILL.md` — the skill prose + run flow (precheck → author → validate → commit).
- `skills/tableau-mock/scripts/mock.py` — entry gate, versioning, STATE.md transition, CLI.
- `skills/tableau-mock/scripts/coverage.py` — pure coverage checklist + slot-sizing guard core.
- `skills/tableau-mock/references/MOCK-SKELETON.html` — worked example of the two required markers.

## Tests

- `tests/test_mock.py` — **29 contract tests**: entry gate, precheck signals, plan coverage
  parsing, `validate_mock` (gaps / missing boxes / all guard violations), versioning helpers,
  and commit approve/refuse + staleness cross-checked through the router.
- `tests/conftest.py` — add `tableau-mock/scripts` to `sys.path`.

Full suite: **187 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)