### PR TITLE
feat: tableau-spec skill — map mock to IMPLEMENTATION-SPEC.md (Step 7 of 8)

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -246,9 +246,18 @@ Two kinds of outputs, two storage strategies:
   current copy. Re-running one of these skills updates the root file and triggers staleness (§4.2);
   it does **not** create a new version directory.
 - **Deliverables = standalone versioned copies.** `mock.html`, `IMPLEMENTATION-SPEC.md`, and
-  `dashboard.twbx` are written under `mock-version/v_N/`. Re-running a deliverable skill **after its
-  step was approved** bumps `current_version` to a new `v_N` and writes a full standalone copy there,
-  preserving prior versions. (Re-running before approval overwrites the current `v_N`.)
+  `dashboard.twbx` are written under `mock-version/v_N/`, all three sharing the **same** `v_N`
+  directory. A version is anchored by its **mock**: `mock.html` is the leading deliverable, and
+  **only `tableau-mock` bumps `current_version`**. Re-running `tableau-mock` after its step was
+  approved bumps to a new `v_N`, writes the fresh `mock.html` there, and stales `spec`/`build`
+  (§4.2) so they re-run into that new version — producing a full standalone copy, prior versions
+  preserved. (Re-running mock before approval overwrites the current `v_N`.)
+- **`spec` and `build` never bump `current_version`.** They are downstream deliverables that write
+  into the mock's current `v_N`, always beside the `mock.html` they were derived from, and
+  **overwrite in place** on a re-run (whether the step was `approved` or `stale`). A new *spec* or
+  *build* version is created only by re-running the mock (which bumps and stales them); this keeps
+  each `v_N` internally coherent (one mock + its spec + its workbook) and avoids a bumped version
+  dir that is missing the mock it depends on.
 
 ---
 

--- a/skills/tableau-spec/SKILL.md
+++ b/skills/tableau-spec/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: tableau-spec
+description: Translates the approved HTML mock (mock.html) into an IMPLEMENTATION-SPEC.md for the tableau-dashboard-plugin workflow, mapping every mock element to a concrete Tableau construct so the build step never has to guess. Reconciles coverage the mirror of the mock's checklist so nothing is left unmapped, and applies a simplest-primitive guard defaulting each element to the simplest sufficient Tableau primitive and forcing an explicit justification for any escalation to an advanced feature (Dynamic Zone Visibility, LOD, table calculation, parameter action), so the workbook is not over-engineered. Reads the approved mock.html and DASHBOARD-PLAN.md. Use when the user wants to write the implementation spec, map the mock to Tableau, or when tableau-route reports spec is next. Step 7 of 8 in the workflow.
+disable-model-invocation: true
+allowed-tools: Read, Write, Edit, AskUserQuestion, Bash(python *), Bash(python3 *)
+---
+
+# tableau-spec
+
+Step 7 of 8, and **non-skippable**. It turns the approved `mock.html` into an
+`IMPLEMENTATION-SPEC.md` that maps **every** mock element to a concrete Tableau construct,
+so `tableau-build` builds from an explicit spec instead of guessing. It ends with a
+**coverage reconciliation** — the mirror of the mock's checklist — proving every mock
+element is mapped, and applies a **simplest-primitive guard** so the workbook uses the
+simplest construct that does the job.
+
+| | |
+|---|---|
+| **Reads** | **Required:** `mock-version/<v_N>/mock.html` (from `mock`) — the elements to map, tagged with `data-plan-id`; and `DASHBOARD-PLAN.md` (from `plan`) — the shared element/filter/interaction ids and the interaction intents (CONTRACT.md §6). |
+| **Writes** | `mock-version/<v_N>/IMPLEMENTATION-SPEC.md` — a standalone deliverable copy (CONTRACT.md §4.3). |
+| **STATE.md update** | Sets `spec` = `approved`; flips a downstream `approved` `build` step to `stale` on a re-run (CONTRACT.md §4.2). Does **not** touch `current_version` — only `tableau-mock` bumps it (§4.3). |
+| **Entry gate** | Refuses to run until `plan` is resolved **and** `DASHBOARD-PLAN.md` exists, **and** `mock` is resolved **and** `mock.html` exists at `current_version` (CONTRACT.md §4.1). |
+| **Next step** | `tableau-build` (or `tableau-route` to confirm). |
+
+The mechanical guarantees — the entry gate, the **coverage reconciliation** (every mock
+element mapped, nothing unmapped), the **simplest-primitive guard** (any advanced feature
+carries a justification), the version bump, and the STATE.md transition — live in
+`spec.py` (CLI) and `reconcile.py` (the reconciliation + guard core). Your job is the
+judgment part: choosing the right, simplest Tableau construct for each element and
+justifying any escalation. Run the script at the points below; do not hand-edit `STATE.md`.
+
+## The one convention the reconciliation depends on
+
+`reconcile.py` decides "mapped" mechanically, so the spec **must** carry a single
+**Element Mapping table** (see `references/IMPLEMENTATION-SPEC-TEMPLATE.md`):
+
+- The table's first column header is **`id`** and it has a column whose header contains
+  **`construct`** and one whose header contains **`justif`**.
+- **One row per mock element**, with the `id` matching a `data-plan-id` from `mock.html`
+  **exactly**. A mock id with no row is an **unmapped element** that blocks approval — this
+  is what makes "nothing unmapped" a guarantee.
+- The **construct** cell names the Tableau construct; the **justification** cell explains
+  any escalation (leave it blank / `-` for a simple primitive).
+
+## The simplest-primitive guard
+
+Default every element to the **simplest sufficient** Tableau primitive. Only escalate to an
+advanced feature when the simpler option genuinely cannot do the job — and when you do,
+**write why in the justification cell** (what simpler alternative you rejected and the
+concrete reason). The guard flags these advanced features when their justification is blank:
+
+| advanced feature | simpler default to justify against |
+|------------------|-------------------------------------|
+| **Dynamic Zone Visibility (DZV)** | a show/hide button container |
+| **LOD expression** (`{FIXED ...}`) | a plain aggregate (`SUM`, `AVG`) or the view's default grain |
+| **table calculation** (`WINDOW_*`, `RUNNING_*`, `INDEX()`, `RANK`) | a native aggregate or quick table calc on the view |
+| **parameter action** | a filter action / highlight action, or a static parameter |
+
+The concrete "what's simplest for this interaction" knowledge lives in the validated
+snippet library. Map the shared interaction terms to their **simplest** construct first
+(CONTRACT.md §6): `cross-filter` → a **Filter action** (`Use as Filter`); `highlight` → a
+**Highlight action**; `drill` → a **hierarchy** expand/collapse; `swap view` / `toggle
+panel` / `parameter swap` → these legitimately need DZV / parameter — justify them.
+
+## How to run
+
+1. **Precheck.** From the project directory, run:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/spec.py" precheck "<project-dir>"
+   ```
+
+   (Use `python3` if `python` is unavailable.) If it prints `[BLOCKED]`, relay the reason
+   and **stop** — the analyst must resolve the named upstream step (`tableau-mock` for the
+   approved mock, `tableau-plan` for the blueprint) first. Otherwise note its signals: the
+   **mock path** to map from, the **list of element ids** every one of which needs a
+   mapping row, and the **target path** to write `IMPLEMENTATION-SPEC.md` into (the mock's
+   `current_version` — spec writes beside the `mock.html` it maps and never bumps the version).
+
+2. **Read the inputs.** Read `mock.html` at the reported mock path — its `data-plan-id`
+   attributes are your exact mapping list. Read `DASHBOARD-PLAN.md` for what each id *is*
+   (KPI / chart kind / filter / interaction) and the interaction intents, so you map to the
+   right construct.
+
+3. **Author `IMPLEMENTATION-SPEC.md`** at the precheck's **target path**. Fill the Element
+   Mapping table with one row per mock element, defaulting to the simplest primitive and
+   justifying every escalation. Add the supporting detail the build needs (calculated
+   fields, data source / joins, actions, parameters) following the template. When
+   **refining** an existing spec at this version, `Edit` it in place.
+
+4. **Self-check, then present.** Validate the draft before showing it:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/spec.py" validate "<project-dir>"
+   ```
+
+   It prints the **reconciliation checklist** (one line per mock element, each `[x]` mapped
+   or `[ ]` unmapped / unjustified-escalation) and the guard result. If it prints
+   `[INVALID]`, map the missing element(s) / add the missing justification(s) and re-run.
+   When it prints `[OK]`, **show the checklist to the analyst** (it's the proof nothing was
+   dropped and nothing is over-engineered) and present the spec for approval.
+
+5. **Commit** — only after the analyst approves:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/spec.py" commit "<project-dir>"
+   ```
+
+   Commit re-runs the full reconciliation + guard (spec is non-skippable, so it only ever
+   sets `approved`). If it prints `[REFUSED]`, fix what the checklist names and re-run. On
+   success it records `spec` = `approved`, sets `current_version` to the target `v_N`, and
+   reports any downstream step it marked `stale`. Relay the summary and tell the analyst to
+   open a fresh conversation and run the next step (`tableau-build`, or `tableau-route` to
+   confirm).
+
+## Notes
+
+- **Non-skippable.** The build needs an explicit spec; `commit` only ever sets `approved`.
+- **Versioned deliverable.** `IMPLEMENTATION-SPEC.md` lives under `mock-version/<v_N>/`
+  beside its `mock.html` (CONTRACT.md §4.3). Spec writes into the mock's `current_version`
+  and **overwrites in place** on a re-run; it never bumps `current_version`. A new spec
+  version is created by re-running `tableau-mock` (which bumps and stales spec). The target
+  path is reported by `precheck`.
+
+> The full `STATE.md` schema and the ordering / staleness / versioning rules live in
+> `CONTRACT.md` at the repo root. This skill restates only its own slice; `spec.py` /
+> `reconcile.py` are the executable mirror of the contract it enforces.

--- a/skills/tableau-spec/references/IMPLEMENTATION-SPEC-TEMPLATE.md
+++ b/skills/tableau-spec/references/IMPLEMENTATION-SPEC-TEMPLATE.md
@@ -1,0 +1,55 @@
+# Implementation Spec: <dashboard name>
+
+> Maps the approved `mock.html` to concrete Tableau constructs so `tableau-build` never has
+> to guess. **The Element Mapping table below is required and machine-checked**: every mock
+> element (every `data-plan-id`) must have exactly one row, and any escalation to an advanced
+> feature must carry a justification. Replace every `<...>` and keep the table structure intact.
+
+**Mock version**: <v_N>
+**Data sources**: <csv file(s) from DATA-MODEL.md>
+
+## Element Mapping
+
+One row per mock element. `id` matches a `data-plan-id` from `mock.html` **exactly**.
+`tableau construct` names the construct; default to the **simplest sufficient** primitive.
+Leave `justification` blank (`-`) for a simple primitive; for any advanced feature (Dynamic
+Zone Visibility, LOD, table calculation, parameter action) write **why the simpler
+alternative was rejected**.
+
+| id                | tableau construct                                   | justification                                              |
+|-------------------|-----------------------------------------------------|------------------------------------------------------------|
+| kpi-revenue       | Text mark, `SUM([revenue])`, `$#,##0`               | -                                                          |
+| chart-trend       | Line mark: MONTH([order_date]) x SUM([revenue])     | -                                                          |
+| chart-region      | Bar mark: [region] x SUM([revenue])                 | -                                                          |
+| flt-region        | Filter card on [region] (multi-select dropdown)     | -                                                          |
+| int-region-filter | Filter action (Use as Filter) chart-region -> rest  | -                                                          |
+| pnl-details       | Dynamic Zone Visibility on the details container     | show/hide button can't collapse a whole zone here: <why>   |
+
+## Calculated Fields
+
+| field name | formula | used by (element id) |
+|------------|---------|----------------------|
+| <Name>     | `<formula>` | <id(s)>          |
+
+## Data Sources & Joins
+
+| source (csv)     | role                | join / relationship                          |
+|------------------|---------------------|----------------------------------------------|
+| <sales.csv>      | primary             | -                                            |
+| <segments.csv>   | lookup              | `sales.customer = segments.customer` (left)  |
+
+## Actions
+
+The dashboard actions that back the mock's interactions (source/target are element ids).
+
+| action name | type       | source        | target(s)              | run on |
+|-------------|------------|---------------|------------------------|--------|
+| <Name>      | Filter     | chart-region  | chart-trend, kpi-revenue | select |
+
+## Parameters
+
+| name | data type | allowed values | drives |
+|------|-----------|----------------|--------|
+| <Name> | <type>  | <list/range>   | <what it changes> |
+
+_Write "None" under any section that does not apply._

--- a/skills/tableau-spec/scripts/reconcile.py
+++ b/skills/tableau-spec/scripts/reconcile.py
@@ -1,0 +1,294 @@
+"""The coverage-reconciliation + simplest-primitive guard core of tableau-spec (CONTRACT.md step 7).
+
+This is the testable heart of ``tableau-spec``, kept pure (stdlib-only, no STATE.md, no
+filesystem) so the contract test can drive it directly. ``spec.py`` owns the STATE.md /
+versioning / entry-gate plumbing and imports :func:`reconcile` from here. It owns two jobs:
+
+1. **Coverage reconciliation** - the mirror of the mock's coverage checklist. Every mock
+   element (every ``data-plan-id`` in ``mock.html``) MUST be mapped to a Tableau construct
+   in ``IMPLEMENTATION-SPEC.md``'s Element Mapping table. A mock id with no mapping row is
+   an **unmapped** element that blocks approval - this is what makes "every mock element
+   maps to a construct, nothing unmapped" a guarantee rather than a hope.
+2. **Simplest-primitive guard** - each element should default to the simplest sufficient
+   Tableau primitive. Any escalation to an advanced feature (Dynamic Zone Visibility, LOD
+   expression, table calculation, parameter action) is detected by keyword in the mapping's
+   construct cell and MUST carry a non-empty justification (why the advanced feature over
+   the simpler alternative). An advanced feature with no justification is **flagged**, so
+   the workbook is not silently over-engineered.
+
+The concrete "what is the simplest primitive for X" knowledge lives in the validated snippet
+library and the SKILL.md's decision guidance; this module enforces only the mechanical rule
+"advanced feature present => a justification must be written".
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+#: The id-string the plan uses for a "no filters" / "no interactions" sentinel row; if it
+#: ever leaks into the mock as a data-plan-id it is not a real element, so we skip it.
+NONE_ID = "none"
+
+# --- Advanced-feature detection (the simplest-primitive guard) ----------------
+# ponytail: keyword heuristics, not a Tableau parser. Each pattern names one advanced
+# construct whose use must be justified against the simpler alternative (CONTRACT.md §6 /
+# issue #13). Matched case-insensitively against a mapping's construct cell. Add a row here
+# only when a new recurring over-engineering pattern appears.
+ADVANCED_FEATURE_PATTERNS: dict[str, str] = {
+    "Dynamic Zone Visibility": r"dynamic\s+zone\s+visibility|\bDZV\b",
+    "LOD expression": r"\bLOD\b|level\s+of\s+detail|\{\s*(fixed|include|exclude)\b",
+    "table calculation": (
+        r"table\s+calc|WINDOW_\w+|RUNNING_\w+|LOOKUP\s*\(|\bINDEX\s*\(\s*\)"
+        r"|\bRANK\b|\bTOTAL\s*\("
+    ),
+    "parameter action": r"parameter\s+action",
+}
+
+_ADVANCED_COMPILED = {
+    name: re.compile(pattern, re.IGNORECASE)
+    for name, pattern in ADVANCED_FEATURE_PATTERNS.items()
+}
+
+#: Cell values that mean "no justification given" (a blank / placeholder / dash cell).
+_ABSENT_JUSTIFICATION = frozenset({"", "-", "--", "n/a", "na", "none", "todo", "tbd"})
+
+
+def advanced_features_in(construct: str) -> list[str]:
+    """Return the advanced Tableau features a construct description mentions.
+
+    Args:
+        construct: The Tableau-construct text from an Element Mapping row.
+
+    Returns:
+        The names of matched advanced features (empty when the construct is a simple
+        primitive that needs no justification).
+    """
+    return [name for name, rx in _ADVANCED_COMPILED.items() if rx.search(construct)]
+
+
+def justification_present(justification: str) -> bool:
+    """Return True if a justification cell holds a real reason (not blank/placeholder).
+
+    Args:
+        justification: The justification cell text from an Element Mapping row.
+
+    Returns:
+        True when the cell is a non-placeholder, non-``<...>`` string.
+    """
+    stripped = justification.strip()
+    if stripped.startswith("<"):  # an unfilled "<why...>" template placeholder
+        return False
+    return stripped.lower() not in _ABSENT_JUSTIFICATION
+
+
+# --- Mock parsing: the elements that MUST be mapped --------------------------
+
+_DATA_PLAN_ID = re.compile(r"""data-plan-id\s*=\s*["']([^"']+)["']""")
+
+
+def mock_element_ids(html: str) -> list[str]:
+    """Return every ``data-plan-id`` value in the mock HTML, in first-seen order.
+
+    These are the mock elements the spec must reconcile - every one needs a mapping row.
+    The ``none`` sentinel (should it ever appear) and duplicates are dropped.
+
+    Args:
+        html: The contents of a ``mock.html`` file.
+
+    Returns:
+        The ordered, de-duplicated list of mock element ids.
+    """
+    seen: dict[str, None] = {}
+    for match in _DATA_PLAN_ID.finditer(html):
+        plan_id = match.group(1).strip()
+        if plan_id and plan_id.lower() != NONE_ID:
+            seen.setdefault(plan_id, None)
+    return list(seen)
+
+
+# --- Spec parsing: the Element Mapping table ---------------------------------
+
+_SEPARATOR_CELL = re.compile(r"^:?-+:?$")
+
+
+def _markdown_tables(text: str) -> list[list[list[str]]]:
+    """Split a markdown document into its pipe tables (rows of trimmed cells)."""
+    tables: list[list[list[str]]] = []
+    current: list[list[str]] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("|"):
+            current.append([cell.strip() for cell in line.strip("|").split("|")])
+            continue
+        if current:
+            tables.append(current)
+            current = []
+    if current:
+        tables.append(current)
+    return tables
+
+
+def _is_separator_row(cells: list[str]) -> bool:
+    """Return True if a table row is the ``|---|---|`` header/body separator."""
+    non_empty = [cell for cell in cells if cell]
+    return bool(non_empty) and all(_SEPARATOR_CELL.match(cell) for cell in non_empty)
+
+
+@dataclass(frozen=True)
+class Mapping:
+    """One row of the spec's Element Mapping table.
+
+    Attributes:
+        id: The mock element id this row maps (matches a ``data-plan-id``).
+        construct: The Tableau construct the element becomes.
+        justification: The reason for any advanced-feature escalation (blank when the
+            construct is a simple primitive).
+    """
+
+    id: str
+    construct: str
+    justification: str
+
+
+def parse_spec_mappings(spec_text: str) -> list[Mapping]:
+    """Extract the Element Mapping rows from an ``IMPLEMENTATION-SPEC.md``.
+
+    The mapping table is the one whose header's first column is ``id`` and that has a
+    column whose header contains ``construct``. The ``justification`` column is located by
+    header name (any column containing ``justif``); if absent, justifications read as blank.
+
+    Args:
+        spec_text: The contents of an ``IMPLEMENTATION-SPEC.md`` file.
+
+    Returns:
+        The parsed mapping rows (empty when no Element Mapping table is present).
+    """
+    for table in _markdown_tables(spec_text):
+        rows = [row for row in table if not _is_separator_row(row)]
+        if len(rows) < 2:
+            continue
+        header = [cell.lower() for cell in rows[0]]
+        if not header or header[0] != "id":
+            continue
+        construct_col = next(
+            (i for i, cell in enumerate(header) if "construct" in cell), None
+        )
+        if construct_col is None:
+            continue
+        justif_col = next((i for i, cell in enumerate(header) if "justif" in cell), None)
+
+        mappings: list[Mapping] = []
+        for row in rows[1:]:
+            element_id = row[0].strip() if row else ""
+            if not element_id or element_id.lower() == NONE_ID:
+                continue
+            construct = row[construct_col].strip() if construct_col < len(row) else ""
+            justification = (
+                row[justif_col].strip()
+                if justif_col is not None and justif_col < len(row)
+                else ""
+            )
+            mappings.append(Mapping(element_id, construct, justification))
+        return mappings
+    return []
+
+
+# --- Reconciliation result ---------------------------------------------------
+
+@dataclass(frozen=True)
+class MappingItem:
+    """One row of the reconciliation checklist (one per mock element).
+
+    Attributes:
+        id: The mock element id.
+        mapped: Whether a mapping row for it exists in the spec.
+        construct: The mapped Tableau construct (empty when unmapped).
+        advanced_features: Advanced features the construct uses (empty when simplest).
+        justified: True when the mapping needs no justification (simple primitive) or
+            carries one; False only for an unjustified advanced-feature escalation.
+    """
+
+    id: str
+    mapped: bool
+    construct: str
+    advanced_features: list[str]
+    justified: bool
+
+
+@dataclass(frozen=True)
+class SpecValidation:
+    """Result of reconciling an ``IMPLEMENTATION-SPEC.md`` against its ``mock.html``.
+
+    Attributes:
+        ok: True iff every mock element is mapped and every advanced-feature escalation is
+            justified.
+        items: The reconciliation checklist (one item per mock element).
+        extra_ids: Ids mapped in the spec that do not exist in the mock (non-fatal note).
+        notes: Non-fatal observations.
+    """
+
+    ok: bool
+    items: list[MappingItem]
+    extra_ids: list[str]
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def unmapped(self) -> list[str]:
+        """list[str]: Mock elements with no mapping row (blocks approval)."""
+        return [item.id for item in self.items if not item.mapped]
+
+    @property
+    def unjustified(self) -> list[MappingItem]:
+        """list[MappingItem]: Advanced-feature escalations with no justification."""
+        return [
+            item for item in self.items
+            if item.mapped and item.advanced_features and not item.justified
+        ]
+
+
+def reconcile(mock_html: str, spec_text: str) -> SpecValidation:
+    """Reconcile a spec against its mock: coverage + simplest-primitive guard.
+
+    Coverage: every ``data-plan-id`` in the mock must have an Element Mapping row.
+    Guard: any mapping whose construct uses an advanced feature (DZV / LOD / table calc /
+    parameter action) must carry a non-empty justification. The spec is valid iff there
+    are no unmapped mock elements and no unjustified escalations.
+
+    Args:
+        mock_html: The contents of the approved ``mock.html``.
+        spec_text: The contents of the ``IMPLEMENTATION-SPEC.md`` under validation.
+
+    Returns:
+        A :class:`SpecValidation`.
+    """
+    mock_ids = mock_element_ids(mock_html)
+    mappings = {m.id: m for m in parse_spec_mappings(spec_text)}
+
+    items: list[MappingItem] = []
+    for element_id in mock_ids:
+        mapping = mappings.get(element_id)
+        if mapping is None:
+            items.append(MappingItem(element_id, False, "", [], False))
+            continue
+        features = advanced_features_in(mapping.construct)
+        justified = not features or justification_present(mapping.justification)
+        items.append(
+            MappingItem(element_id, True, mapping.construct, features, justified)
+        )
+
+    mock_id_set = set(mock_ids)
+    extra_ids = sorted(mapped_id for mapped_id in mappings if mapped_id not in mock_id_set)
+
+    notes: list[str] = []
+    if not mock_ids:
+        notes.append("mock.html declares no data-plan-id elements - nothing to reconcile")
+    if extra_ids:
+        notes.append(
+            "spec maps id(s) not present in the mock (typo or stale mapping?): "
+            + ", ".join(extra_ids)
+        )
+
+    ok = all(item.mapped and item.justified for item in items)
+    return SpecValidation(ok, items, extra_ids, notes)

--- a/skills/tableau-spec/scripts/spec.py
+++ b/skills/tableau-spec/scripts/spec.py
@@ -1,0 +1,564 @@
+"""Gate and commit the ``spec`` step of the tableau-dashboard-plugin.
+
+This is the orchestration core of the ``tableau-spec`` skill (CONTRACT.md step 7): the
+non-skippable step that turns the approved ``mock.html`` into an ``IMPLEMENTATION-SPEC.md``
+mapping every mock element to a Tableau construct, so ``tableau-build`` never has to guess.
+The spec *prose* is authored by the model; the coverage-reconciliation and simplest-
+primitive guard live in :mod:`reconcile`. This module owns the parts that touch
+``STATE.md`` and the filesystem:
+
+1. **Entry gate** - spec refuses to run until both required reads are present and their
+   producers resolved (CONTRACT.md §4.1): ``DASHBOARD-PLAN.md`` (from ``plan``) - the
+   blueprint whose ids the mock/spec share - and ``mock.html`` at ``current_version`` (from
+   ``mock``) - the elements the spec must map.
+2. **Versioning** - the spec is a *deliverable* written under ``mock-version/v_N/``
+   alongside the mock it was specced from (CONTRACT.md §4.3). Per §4.3, **only the leading
+   deliverable (``mock``) bumps ``current_version``**; ``spec`` writes into the mock's
+   current version and overwrites in place on a re-run. A new spec *version* is created by
+   re-running the mock (which bumps and stales spec), so spec never touches ``current_version``.
+3. **STATE.md transition** - committing flips ``spec`` to ``approved`` and propagates
+   staleness to ``build`` (§4.2), so the workbook can never silently disagree with a
+   re-specced mock.
+
+The module is pure and stdlib-only (it does **not** import the router) so the contract
+test can call its functions directly, exactly like ``mock.py`` / ``tableau-data``'s
+``state.py``. The CLI exposes ``precheck`` (before authoring - reports the version dir + the
+elements to map), ``validate`` (the reconciliation checklist + guard on a draft), and
+``commit`` (after approval). Program output goes to stdout; diagnostics through ``logging``.
+
+Keep ``STEP_ORDER`` in lock-step with CONTRACT.md §1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from reconcile import SpecValidation, mock_element_ids, reconcile
+
+logger = logging.getLogger(__name__)
+
+# --- Canonical constants (mirror of CONTRACT.md §1 / §3 / §4.3) --------------
+
+STATE_FILENAME = "STATE.md"
+PLAN_FILENAME = "DASHBOARD-PLAN.md"
+MOCK_FILENAME = "mock.html"
+SPEC_FILENAME = "IMPLEMENTATION-SPEC.md"
+VERSION_DIR = "mock-version"
+
+#: Required reads that gate this step, and their producer steps (CONTRACT.md §4.1).
+PLAN_STEP = "plan"
+MOCK_STEP = "mock"
+
+#: This step.
+SPEC_STEP = "spec"
+
+#: The 8 step names in canonical order (mirror of CONTRACT.md §1). Used to decide which
+#: steps are "downstream of spec" for staleness propagation (§4.2).
+STEP_ORDER: tuple[str, ...] = (
+    "init", "intake", "data", "brand", "plan", "mock", "spec", "build",
+)
+
+#: Statuses that satisfy the ordering gate - the producer step is "resolved" (§4.1).
+RESOLVED_STATUSES = frozenset({"approved", "skipped"})
+
+
+# --- STATE.md reading (shared shape with mock.py / route.py) -----------------
+
+def parse_statuses(text: str) -> dict[str, str]:
+    """Parse the per-step statuses out of a STATE.md manifest.
+
+    Parsing is tolerant (matching the router's parser): only genuine
+    ``| order | step | skill | status |`` rows whose step name is known contribute;
+    header, separator, and stray rows are ignored.
+
+    Args:
+        text: The full contents of a ``STATE.md`` file.
+
+    Returns:
+        A ``{step_name: status}`` mapping (both lower-cased).
+    """
+    statuses: dict[str, str] = {}
+    in_steps = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        if line.lower().startswith("## steps"):
+            in_steps = True
+            continue
+        if line.startswith("## "):  # any other section ends the Steps table
+            in_steps = False
+
+        if in_steps and line.startswith("|"):
+            cells = [cell.strip() for cell in line.strip("|").split("|")]
+            if len(cells) < 4:
+                continue
+            step_name, status = cells[1].lower(), cells[3].lower()
+            if step_name in STEP_ORDER:
+                statuses[step_name] = status
+    return statuses
+
+
+# Matches the ``- current_version: v_3`` metadata line (value read-only; spec never
+# rewrites it - only the leading deliverable ``mock`` bumps it, CONTRACT.md §4.3).
+_CURRENT_VERSION_LINE = re.compile(
+    r"^\s*-\s*current_version\s*:\s*(\S+)", re.MULTILINE
+)
+
+
+def read_current_version(text: str) -> str:
+    """Read the ``current_version`` metadata value from STATE.md.
+
+    This is the version directory where the approved ``mock.html`` lives and where spec
+    writes its ``IMPLEMENTATION-SPEC.md`` alongside it.
+
+    Args:
+        text: The full contents of a ``STATE.md`` file.
+
+    Returns:
+        The recorded version (e.g. ``"v_2"``), or ``"v_1"`` if no line is present.
+    """
+    match = _CURRENT_VERSION_LINE.search(text)
+    return match.group(1) if match else "v_1"
+
+
+# --- STATE.md rewriting (shared shape with mock.py / state.py) ---------------
+
+def _format_step_row(cells: list[str]) -> str:
+    """Render a Steps-table row with the canonical column widths (matches init/mock)."""
+    order, step, skill, status = cells[0], cells[1], cells[2], cells[3]
+    return f"| {order:<5} | {step:<6} | {skill:<14} | {status:<8} |"
+
+
+def apply_status_updates(text: str, updates: dict[str, str]) -> str:
+    """Rewrite the status cell of one or more Steps-table rows.
+
+    Only rows inside the ``## Steps`` table whose step name is a key in ``updates`` are
+    touched; every other line is preserved byte-for-byte. The trailing newline is kept.
+
+    Args:
+        text: The full ``STATE.md`` contents.
+        updates: ``{step_name: new_status}`` for the rows to rewrite (lower-cased).
+
+    Returns:
+        The updated ``STATE.md`` contents.
+    """
+    out_lines: list[str] = []
+    in_steps = False
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+
+        if stripped.lower().startswith("## steps"):
+            in_steps = True
+            out_lines.append(raw_line)
+            continue
+        if stripped.startswith("## "):  # any other section ends the Steps table
+            in_steps = False
+
+        if in_steps and stripped.startswith("|"):
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            if len(cells) >= 4 and cells[1].lower() in updates:
+                cells[3] = updates[cells[1].lower()]
+                out_lines.append(_format_step_row(cells))
+                continue
+
+        out_lines.append(raw_line)
+
+    result = "\n".join(out_lines)
+    if text.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def _downstream_stale_updates(statuses: dict[str, str]) -> dict[str, str]:
+    """Compute which downstream steps must flip to ``stale`` (CONTRACT.md §4.2).
+
+    Every step ordered after ``spec`` that is currently ``approved`` becomes ``stale``
+    (i.e. ``build``); steps already ``pending`` / ``skipped`` / ``stale`` are left as-is.
+
+    Args:
+        statuses: The current ``{step_name: status}`` mapping.
+
+    Returns:
+        ``{step_name: "stale"}`` for each downstream step that was ``approved``.
+    """
+    spec_index = STEP_ORDER.index(SPEC_STEP)
+    return {
+        step: "stale"
+        for step in STEP_ORDER[spec_index + 1:]
+        if statuses.get(step) == "approved"
+    }
+
+
+# --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
+
+def entry_gate_blocker(project_root: Path) -> Optional[str]:
+    """Return why spec may not run yet, or ``None`` if it may.
+
+    Spec refuses to run unless ``STATE.md`` exists and, for each required read
+    (CONTRACT.md §4.1): ``plan`` is resolved and ``DASHBOARD-PLAN.md`` exists, and
+    ``mock`` is resolved and ``mock.html`` exists at ``current_version``.
+
+    Args:
+        project_root: The analyst's project directory.
+
+    Returns:
+        A human-readable blocker message, or ``None`` when the gate is open.
+    """
+    state_path = project_root / STATE_FILENAME
+    if not state_path.exists():
+        return (
+            "No STATE.md found. Run 'tableau-init' first to scaffold the project "
+            "and initialize STATE.md before running 'tableau-spec'."
+        )
+
+    text = state_path.read_text(encoding="utf-8-sig")
+    statuses = parse_statuses(text)
+
+    plan_status = statuses.get(PLAN_STEP, "pending")
+    if plan_status not in RESOLVED_STATUSES:
+        return (
+            f"Step 'plan' is '{plan_status}', not resolved. Run 'tableau-plan' first; "
+            f"'tableau-spec' shares the plan's element ids."
+        )
+    if not (project_root / PLAN_FILENAME).exists():
+        return (
+            f"'{PLAN_FILENAME}' is missing on disk even though step 'plan' is "
+            f"'{plan_status}'. Re-run 'tableau-plan' to regenerate it."
+        )
+
+    mock_status = statuses.get(MOCK_STEP, "pending")
+    if mock_status not in RESOLVED_STATUSES:
+        return (
+            f"Step 'mock' is '{mock_status}', not resolved. Run 'tableau-mock' first; "
+            f"'tableau-spec' maps every element the mock rendered to a Tableau construct."
+        )
+    version = read_current_version(text)
+    mock_path = project_root / VERSION_DIR / version / MOCK_FILENAME
+    if not mock_path.exists():
+        return (
+            f"'{VERSION_DIR}/{version}/{MOCK_FILENAME}' is missing on disk even though "
+            f"step 'mock' is '{mock_status}'. Re-run 'tableau-mock' to regenerate it."
+        )
+    return None
+
+
+# --- precheck ----------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PrecheckResult:
+    """The state spec needs before authoring an IMPLEMENTATION-SPEC.md.
+
+    Attributes:
+        can_run: True when the entry gate is open (plan + mock resolved, artifacts present).
+        blocker: Why spec cannot run, when ``can_run`` is False; else ``None``.
+        version: The ``current_version`` dir holding the mock, and where the spec is written.
+        mock_path: ``mock-version/<version>/mock.html`` (the elements to map).
+        target_path: ``mock-version/<version>/IMPLEMENTATION-SPEC.md`` (where to author).
+        spec_exists: Whether the IMPLEMENTATION-SPEC.md already exists (refine vs author fresh).
+        element_ids: The mock element ids that must each be mapped to a construct.
+    """
+
+    can_run: bool
+    blocker: Optional[str]
+    version: str
+    mock_path: str
+    target_path: str
+    spec_exists: bool
+    element_ids: list[str]
+
+
+def precheck(project_dir: Path | str) -> PrecheckResult:
+    """Report whether spec may run, where to write it, and what it must map.
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`PrecheckResult`. When the entry gate is closed, ``can_run`` is False
+        and ``blocker`` explains why; the other fields are placeholders.
+    """
+    project_root = Path(project_dir)
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return PrecheckResult(False, blocker, "v_1", "", "", False, [])
+
+    text = (project_root / STATE_FILENAME).read_text(encoding="utf-8-sig")
+    version = read_current_version(text)
+
+    mock_rel = f"{VERSION_DIR}/{version}/{MOCK_FILENAME}"
+    target_rel = f"{VERSION_DIR}/{version}/{SPEC_FILENAME}"
+    element_ids = mock_element_ids(
+        (project_root / mock_rel).read_text(encoding="utf-8-sig")
+    )
+    return PrecheckResult(
+        can_run=True,
+        blocker=None,
+        version=version,
+        mock_path=mock_rel,
+        target_path=target_rel,
+        spec_exists=(project_root / target_rel).exists(),
+        element_ids=element_ids,
+    )
+
+
+# --- commit ------------------------------------------------------------------
+
+@dataclass
+class CommitResult:
+    """Outcome of committing the spec step's result to STATE.md.
+
+    Attributes:
+        ok: True when STATE.md was updated; False when the commit was refused.
+        message: Human-readable explanation (the refusal reason when not ``ok``).
+        version: The version directory the (attempted) spec lives in.
+        staled_steps: Downstream steps flipped to ``stale`` by this commit.
+        validation: The reconciliation/guard result that gated the commit, when one ran.
+    """
+
+    ok: bool
+    message: str
+    version: str = "v_1"
+    staled_steps: list[str] = field(default_factory=list)
+    validation: Optional[SpecValidation] = None
+
+
+def commit(project_dir: Path | str) -> CommitResult:
+    """Reconcile the IMPLEMENTATION-SPEC.md and approve the spec step.
+
+    The spec is non-skippable, so commit only ever sets ``approved``. The
+    ``mock-version/<current_version>/IMPLEMENTATION-SPEC.md`` must exist and pass
+    :func:`reconcile.reconcile` (every mock element mapped + every advanced-feature
+    escalation justified) or the commit is refused. On success ``spec`` is approved and
+    every downstream ``approved`` step (``build``) is flipped to ``stale`` (§4.2). Spec
+    writes into the mock's ``current_version`` and never bumps it - only the leading
+    deliverable (``mock``) does (§4.3), so a re-run overwrites the spec in place.
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`CommitResult`. ``ok`` is False (STATE.md untouched) when the entry gate
+        is closed or the spec is missing / leaves an element unmapped / has an unjustified
+        advanced-feature escalation.
+    """
+    project_root = Path(project_dir)
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return CommitResult(False, blocker)
+
+    text = (project_root / STATE_FILENAME).read_text(encoding="utf-8-sig")
+    statuses = parse_statuses(text)
+    version = read_current_version(text)
+
+    mock_path = project_root / VERSION_DIR / version / MOCK_FILENAME
+    spec_path = project_root / VERSION_DIR / version / SPEC_FILENAME
+
+    if not spec_path.exists():
+        return CommitResult(
+            False,
+            f"Cannot approve spec: '{VERSION_DIR}/{version}/{SPEC_FILENAME}' does not "
+            f"exist. Author it first (map every mock element to a Tableau construct).",
+            version=version,
+        )
+
+    validation = reconcile(
+        mock_path.read_text(encoding="utf-8-sig"),
+        spec_path.read_text(encoding="utf-8-sig"),
+    )
+    if not validation.ok:
+        reasons: list[str] = []
+        if validation.unmapped:
+            reasons.append("unmapped mock element(s): " + ", ".join(validation.unmapped))
+        if validation.unjustified:
+            reasons.append(
+                "unjustified advanced feature(s): "
+                + ", ".join(
+                    f"{item.id} ({'/'.join(item.advanced_features)})"
+                    for item in validation.unjustified
+                )
+            )
+        return CommitResult(
+            False,
+            f"'{SPEC_FILENAME}' does not fully reconcile with the mock - "
+            f"{'; '.join(reasons)}. Fix and re-run commit.",
+            version=version,
+            validation=validation,
+        )
+
+    stale_updates = _downstream_stale_updates(statuses)
+    updated = apply_status_updates(text, {SPEC_STEP: "approved", **stale_updates})
+    (project_root / STATE_FILENAME).write_text(updated, encoding="utf-8")
+
+    staled_steps = sorted(stale_updates, key=STEP_ORDER.index)
+    logger.info(
+        f"Set spec -> approved at {version}; marked stale: {staled_steps or 'none'}."
+    )
+    return CommitResult(
+        ok=True,
+        message=f"spec -> approved ({version})",
+        version=version,
+        staled_steps=staled_steps,
+        validation=validation,
+    )
+
+
+# --- CLI ---------------------------------------------------------------------
+
+def format_precheck(result: PrecheckResult) -> str:
+    """Render a :class:`PrecheckResult` as a human-readable, plain-ASCII block."""
+    # Plain ASCII only: this prints to a Windows cp1252 console, which would raise
+    # UnicodeEncodeError on emoji / box-drawing glyphs.
+    if not result.can_run:
+        return f"[BLOCKED] tableau-spec cannot run.\n{result.blocker}"
+
+    lines = [
+        "[SPEC] precheck OK - tableau-spec can run.",
+        f"  map from       : {result.mock_path}",
+        f"  must map       : {len(result.element_ids)} mock element(s) -> "
+        f"a Tableau construct each, nothing unmapped.",
+        f"  elements       : {', '.join(result.element_ids) or '(none)'}",
+        f"  write spec to  : {result.target_path}",
+    ]
+    if result.spec_exists:
+        lines.append(
+            "    -> an IMPLEMENTATION-SPEC.md already exists at this version; refine it in place."
+        )
+    lines.append(
+        "  default each element to the SIMPLEST sufficient Tableau primitive; justify any "
+        "escalation to DZV / LOD / table calc / parameter action against the simpler option."
+    )
+    return "\n".join(lines)
+
+
+def format_validation(validation: SpecValidation) -> str:
+    """Render a :class:`SpecValidation` as the reconciliation checklist + guard report."""
+    # Plain ASCII only (see format_precheck): [x]/[ ] checkboxes, no Unicode ticks.
+    lines = ["Coverage reconciliation (mock element -> Tableau construct):"]
+    for item in validation.items:
+        if not item.mapped:
+            lines.append(f"  [ ] {item.id}: UNMAPPED   <- no mapping row in the spec")
+            continue
+        if item.advanced_features and not item.justified:
+            lines.append(
+                f"  [ ] {item.id}: {item.construct}   <- uses "
+                f"{'/'.join(item.advanced_features)} with NO justification"
+            )
+            continue
+        note = (
+            f" (advanced: {'/'.join(item.advanced_features)}, justified)"
+            if item.advanced_features else ""
+        )
+        lines.append(f"  [x] {item.id}: {item.construct}{note}")
+
+    for note in validation.notes:
+        lines.append(f"  note: {note}")
+
+    lines.append(
+        "[OK] every mock element maps to a construct; escalations are justified."
+        if validation.ok
+        else "[INVALID] spec does not fully reconcile with the mock - fix the items above and re-run."
+    )
+    return "\n".join(lines)
+
+
+def format_commit(result: CommitResult) -> str:
+    """Render a :class:`CommitResult` as a human-readable, plain-ASCII block."""
+    # Plain ASCII only (see format_precheck).
+    if not result.ok:
+        text = f"[REFUSED] {result.message}"
+        if result.validation is not None:
+            text += "\n" + format_validation(result.validation)
+        return text
+
+    lines = [f"[SPEC] {result.message}."]
+    if result.staled_steps:
+        lines.append(
+            f"  downstream marked stale: {', '.join(result.staled_steps)} "
+            f"(re-run these in order)."
+        )
+    lines.append(f"  deliverable: {VERSION_DIR}/{result.version}/{SPEC_FILENAME}")
+    lines.append(
+        "  next: open a fresh conversation and run 'tableau-build' (or 'tableau-route')."
+    )
+    return "\n".join(lines)
+
+
+def _resolve_paths(project_dir: Path) -> tuple[Path, Path]:
+    """Resolve (mock.html, IMPLEMENTATION-SPEC.md) paths for the validate subcommand.
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        ``(mock_path, spec_path)`` the next commit would reconcile (both at current_version).
+    """
+    state_path = project_dir / STATE_FILENAME
+    version = (
+        read_current_version(state_path.read_text(encoding="utf-8-sig"))
+        if state_path.exists() else "v_1"
+    )
+    base = project_dir / VERSION_DIR / version
+    return base / MOCK_FILENAME, base / SPEC_FILENAME
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point: run ``precheck``, ``validate``, or ``commit`` and print it.
+
+    Args:
+        argv: Argument list (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Process exit code: ``0`` on success, ``2`` when spec is blocked/refused/invalid
+        or on a usage error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Gate, validate, and commit the tableau-spec step.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for name, help_text in (
+        ("precheck", "Report whether spec may run, where to write it, and what to map."),
+        ("validate", "Coverage reconciliation + simplest-primitive guard on the draft spec."),
+        ("commit", "Approve the spec in STATE.md and propagate staleness."),
+    ):
+        sub = subparsers.add_parser(name, help=help_text)
+        sub.add_argument(
+            "project_dir", nargs="?", default=".", help="Project directory (default: cwd)."
+        )
+
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    project_dir = Path(args.project_dir)
+
+    if args.command == "precheck":
+        precheck_result = precheck(project_dir)
+        print(format_precheck(precheck_result))
+        return 0 if precheck_result.can_run else 2
+
+    if args.command == "validate":
+        mock_path, spec_path = _resolve_paths(project_dir)
+        if not mock_path.exists() or not spec_path.exists():
+            missing = MOCK_FILENAME if not mock_path.exists() else SPEC_FILENAME
+            print(f"[INVALID] '{missing}' not found (expected spec at '{spec_path}').")
+            return 2
+        validation = reconcile(
+            mock_path.read_text(encoding="utf-8-sig"),
+            spec_path.read_text(encoding="utf-8-sig"),
+        )
+        print(format_validation(validation))
+        return 0 if validation.ok else 2
+
+    commit_result = commit(project_dir)
+    print(format_commit(commit_result))
+    return 0 if commit_result.ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ _SKILL_SCRIPT_DIRS = (
     _REPO_ROOT / "skills" / "tableau-brand" / "scripts",
     _REPO_ROOT / "skills" / "tableau-plan" / "scripts",
     _REPO_ROOT / "skills" / "tableau-mock" / "scripts",
+    _REPO_ROOT / "skills" / "tableau-spec" / "scripts",
 )
 
 for _script_dir in _SKILL_SCRIPT_DIRS:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,0 +1,368 @@
+"""Contract test for tableau-spec (CONTRACT.md step 7, §4.1, §4.2, §4.3).
+
+``tableau-spec`` turns the approved ``mock.html`` into an ``IMPLEMENTATION-SPEC.md`` that
+maps every mock element to a Tableau construct. The spec prose is model-authored, so this
+test pins the parts the scripts must guarantee mechanically, split across the two modules:
+
+* :mod:`reconcile` (pure core) - parsing the mock's ``data-plan-id`` elements and the
+  spec's Element Mapping table, the coverage reconciliation (nothing unmapped), and the
+  simplest-primitive guard (an advanced feature needs a justification);
+* :mod:`spec` (orchestration) - the entry gate (§4.1), deliverable versioning (spec writes
+  into the mock's ``current_version`` and never bumps it, §4.3), and the STATE.md
+  ``approved`` + downstream-``stale`` transition (§4.2), cross-checked through the *router*
+  so the STATE.md spec writes routes on.
+"""
+
+from pathlib import Path
+
+import init  # builds a realistic STATE.md the same way a real project would
+import reconcile  # the pure reconciliation/guard core (on sys.path via conftest.py)
+import route  # the router parses/routes the STATE.md spec writes
+import spec  # the orchestration under test
+
+TARGET_VERSION = "2024.2-2025.x"
+
+# A minimal plan (spec reads it for context; the mock's data-plan-ids drive reconciliation).
+PLAN = "# Dashboard Plan: Sales\n\n## Screen Size\n- dimensions: 1366 x 768 px\n"
+
+# The mock renders four elements, each tagged with a data-plan-id.
+MOCK_IDS = ("kpi-revenue", "chart-trend", "flt-region", "int-region-filter")
+
+
+def _mock_html(ids=MOCK_IDS) -> str:
+    """Render a mock.html tagging each id with data-plan-id (the reconciliation source)."""
+    tagged = "\n".join(f'<div data-plan-id="{plan_id}"></div>' for plan_id in ids)
+    return f"<!doctype html><html><body>\n{tagged}\n</body></html>"
+
+
+def _spec_md(rows=None) -> str:
+    """Render an IMPLEMENTATION-SPEC.md with an Element Mapping table.
+
+    Args:
+        rows: Iterable of ``(id, construct, justification)`` tuples. Defaults to a full,
+            all-simple mapping of every ``MOCK_IDS`` element.
+
+    Returns:
+        A spec markdown string.
+    """
+    if rows is None:
+        rows = [
+            ("kpi-revenue", "Text mark, SUM([revenue])", "-"),
+            ("chart-trend", "Line mark: MONTH([order_date]) x SUM([revenue])", "-"),
+            ("flt-region", "Filter card on [region]", "-"),
+            ("int-region-filter", "Filter action (Use as Filter)", "-"),
+        ]
+    body = "\n".join(f"| {i} | {c} | {j} |" for i, c, j in rows)
+    return (
+        "# Implementation Spec: Sales\n\n## Element Mapping\n"
+        "| id | tableau construct | justification |\n"
+        "|----|-------------------|---------------|\n"
+        f"{body}\n"
+    )
+
+
+def _state_with(project_dir: Path, **status_overrides: str) -> None:
+    """Write a canonical STATE.md, optionally overriding some step statuses."""
+    text = init.render_state_md(TARGET_VERSION)
+    if status_overrides:
+        text = spec.apply_status_updates(text, dict(status_overrides))
+    (project_dir / "STATE.md").write_text(text, encoding="utf-8")
+
+
+def _write_mock(project_dir: Path, version: str, html: str) -> None:
+    """Write ``html`` to ``mock-version/<version>/mock.html``."""
+    version_dir = project_dir / spec.VERSION_DIR / version
+    version_dir.mkdir(parents=True, exist_ok=True)
+    (version_dir / spec.MOCK_FILENAME).write_text(html, encoding="utf-8")
+
+
+def _write_spec(project_dir: Path, version: str, text: str) -> None:
+    """Write ``text`` to ``mock-version/<version>/IMPLEMENTATION-SPEC.md``."""
+    version_dir = project_dir / spec.VERSION_DIR / version
+    version_dir.mkdir(parents=True, exist_ok=True)
+    (version_dir / spec.SPEC_FILENAME).write_text(text, encoding="utf-8")
+
+
+def _ready_project(project_dir: Path, **status_overrides: str) -> None:
+    """Open spec's entry gate: plan+mock resolved, DASHBOARD-PLAN.md and mock.html on disk."""
+    _state_with(project_dir, plan="approved", mock="approved", **status_overrides)
+    (project_dir / "DASHBOARD-PLAN.md").write_text(PLAN, encoding="utf-8")
+    _write_mock(project_dir, "v_1", _mock_html())
+
+
+# --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
+
+def test_precheck_blocks_when_no_state(tmp_path):
+    """No STATE.md => spec cannot run; the blocker points at tableau-init."""
+    result = spec.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "tableau-init" in result.blocker
+
+
+def test_precheck_blocks_when_plan_not_resolved(tmp_path):
+    """plan must be resolved before spec runs (§4.1)."""
+    _state_with(tmp_path, plan="pending", mock="approved")
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(PLAN, encoding="utf-8")
+    _write_mock(tmp_path, "v_1", _mock_html())
+
+    result = spec.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "plan" in result.blocker and "pending" in result.blocker
+
+
+def test_precheck_blocks_when_mock_not_resolved(tmp_path):
+    """mock must be resolved too - spec maps the elements the mock rendered (§4.1)."""
+    _state_with(tmp_path, plan="approved", mock="pending")
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(PLAN, encoding="utf-8")
+    _write_mock(tmp_path, "v_1", _mock_html())
+
+    result = spec.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "mock" in result.blocker and "pending" in result.blocker
+
+
+def test_precheck_blocks_when_mock_file_missing(tmp_path):
+    """Even with mock approved, a missing mock.html at current_version blocks spec (§4.1)."""
+    _state_with(tmp_path, plan="approved", mock="approved")
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(PLAN, encoding="utf-8")  # no mock.html
+
+    result = spec.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "mock.html" in result.blocker
+
+
+def test_precheck_reports_elements_and_target(tmp_path):
+    """precheck surfaces the mock element ids to map and where to write the spec."""
+    _ready_project(tmp_path)
+
+    result = spec.precheck(tmp_path)
+
+    assert result.can_run is True
+    assert result.element_ids == list(MOCK_IDS)
+    assert result.version == "v_1"
+    assert result.mock_path == "mock-version/v_1/mock.html"
+    assert result.target_path == "mock-version/v_1/IMPLEMENTATION-SPEC.md"
+
+
+# --- Reconciliation parsing (reconcile.py) -----------------------------------
+
+def test_mock_element_ids_reads_data_plan_ids():
+    """Every data-plan-id in the mock, de-duplicated in first-seen order, must be mapped."""
+    assert reconcile.mock_element_ids(_mock_html()) == list(MOCK_IDS)
+
+
+def test_parse_spec_mappings_reads_the_element_mapping_table():
+    """The Element Mapping table (header id + construct) is parsed into rows."""
+    mappings = reconcile.parse_spec_mappings(_spec_md())
+
+    assert [m.id for m in mappings] == list(MOCK_IDS)
+    assert mappings[0].construct == "Text mark, SUM([revenue])"
+
+
+def test_advanced_features_detected_by_keyword():
+    """The guard recognises DZV / LOD / table calc / parameter action in a construct."""
+    assert reconcile.advanced_features_in("Dynamic Zone Visibility toggle") == [
+        "Dynamic Zone Visibility"
+    ]
+    assert reconcile.advanced_features_in("{FIXED [region]: SUM([sales])}") == [
+        "LOD expression"
+    ]
+    assert reconcile.advanced_features_in("WINDOW_SUM(SUM([x]))") == ["table calculation"]
+    assert reconcile.advanced_features_in("a parameter action swaps the measure") == [
+        "parameter action"
+    ]
+    assert reconcile.advanced_features_in("Text mark, SUM([revenue])") == []
+
+
+def test_justification_present_rejects_placeholders():
+    """A blank / dash / template-placeholder justification cell reads as absent."""
+    assert reconcile.justification_present("show/hide can't collapse a zone") is True
+    assert reconcile.justification_present("-") is False
+    assert reconcile.justification_present("") is False
+    assert reconcile.justification_present("<why...>") is False
+
+
+# --- reconcile: coverage + guard ---------------------------------------------
+
+def test_reconcile_full_spec_passes():
+    """A spec mapping every mock element with simple primitives reconciles cleanly."""
+    validation = reconcile.reconcile(_mock_html(), _spec_md())
+
+    assert validation.ok is True
+    assert validation.unmapped == []
+    assert validation.unjustified == []
+
+
+def test_reconcile_flags_unmapped_element():
+    """A mock element with no mapping row is unmapped and fails reconciliation (AC)."""
+    # Drop the interaction row from the spec.
+    rows = [
+        ("kpi-revenue", "Text mark, SUM([revenue])", "-"),
+        ("chart-trend", "Line mark", "-"),
+        ("flt-region", "Filter card on [region]", "-"),
+    ]
+    validation = reconcile.reconcile(_mock_html(), _spec_md(rows))
+
+    assert validation.ok is False
+    assert validation.unmapped == ["int-region-filter"]
+
+
+def test_reconcile_flags_unjustified_advanced_feature():
+    """An advanced feature with a blank justification is flagged as over-engineering (AC)."""
+    rows = [
+        ("kpi-revenue", "Text mark, SUM([revenue])", "-"),
+        ("chart-trend", "Line mark", "-"),
+        ("flt-region", "Filter card on [region]", "-"),
+        ("int-region-filter", "parameter action swaps region", "-"),  # advanced, no reason
+    ]
+    validation = reconcile.reconcile(_mock_html(), _spec_md(rows))
+
+    assert validation.ok is False
+    assert [item.id for item in validation.unjustified] == ["int-region-filter"]
+    assert validation.unmapped == []
+
+
+def test_reconcile_accepts_justified_advanced_feature():
+    """The same advanced feature passes once a real justification is written."""
+    rows = [
+        ("kpi-revenue", "Text mark, SUM([revenue])", "-"),
+        ("chart-trend", "Line mark", "-"),
+        ("flt-region", "Filter card on [region]", "-"),
+        (
+            "int-region-filter",
+            "parameter action swaps region",
+            "a filter action can't rewrite the measure used across sheets",
+        ),
+    ]
+    validation = reconcile.reconcile(_mock_html(), _spec_md(rows))
+
+    assert validation.ok is True
+
+
+def test_reconcile_notes_extra_mapped_ids():
+    """A spec row for an id not in the mock is a non-fatal note, not a failure."""
+    rows = list(
+        [
+            ("kpi-revenue", "Text mark", "-"),
+            ("chart-trend", "Line mark", "-"),
+            ("flt-region", "Filter card", "-"),
+            ("int-region-filter", "Filter action", "-"),
+            ("ghost-id", "Bar mark", "-"),  # not in the mock
+        ]
+    )
+    validation = reconcile.reconcile(_mock_html(), _spec_md(rows))
+
+    assert validation.ok is True
+    assert validation.extra_ids == ["ghost-id"]
+
+
+# --- Versioning (CONTRACT.md §4.3: spec never bumps current_version) ----------
+
+def test_spec_reads_and_writes_at_current_version():
+    """Spec always targets current_version (the mock's dir); it never bumps (§4.3)."""
+    text = init.render_state_md(TARGET_VERSION)
+    text = spec.apply_status_updates(text, {"mock": "approved"})
+    text = text.replace("current_version: v_1", "current_version: v_3")
+    assert spec.read_current_version(text) == "v_3"
+
+
+# --- Commit: approve, refuse (CONTRACT.md §4.1, §4.3) ------------------------
+
+def test_commit_refuses_when_gate_closed(tmp_path):
+    """The entry gate guards commit, not just precheck; STATE.md stays untouched."""
+    _state_with(tmp_path, plan="pending", mock="approved")
+    (tmp_path / "DASHBOARD-PLAN.md").write_text(PLAN, encoding="utf-8")
+    _write_mock(tmp_path, "v_1", _mock_html())
+
+    result = spec.commit(tmp_path)
+
+    assert result.ok is False
+    assert "plan" in result.message
+    assert route.parse_state(tmp_path / "STATE.md").statuses["spec"] == "pending"
+
+
+def test_commit_refuses_when_spec_absent(tmp_path):
+    """Approving without an IMPLEMENTATION-SPEC.md on disk is refused."""
+    _ready_project(tmp_path)
+
+    result = spec.commit(tmp_path)
+
+    assert result.ok is False
+    assert "IMPLEMENTATION-SPEC.md" in result.message
+    assert route.parse_state(tmp_path / "STATE.md").statuses["spec"] == "pending"
+
+
+def test_commit_refuses_spec_with_unmapped_element(tmp_path):
+    """commit re-runs reconciliation; an unmapped element is refused, STATE.md untouched."""
+    _ready_project(tmp_path)
+    rows = [
+        ("kpi-revenue", "Text mark", "-"),
+        ("chart-trend", "Line mark", "-"),
+        ("flt-region", "Filter card", "-"),
+    ]  # int-region-filter unmapped
+    _write_spec(tmp_path, "v_1", _spec_md(rows))
+
+    result = spec.commit(tmp_path)
+
+    assert result.ok is False
+    assert "unmapped" in result.message
+    assert route.parse_state(tmp_path / "STATE.md").statuses["spec"] == "pending"
+
+
+def test_commit_approves_valid_spec(tmp_path):
+    """A spec mapping every element commits: spec -> approved, current_version set."""
+    _ready_project(tmp_path)
+    _write_spec(tmp_path, "v_1", _spec_md())
+
+    result = spec.commit(tmp_path)
+
+    assert result.ok is True
+    assert result.version == "v_1"
+    assert route.parse_state(tmp_path / "STATE.md").statuses["spec"] == "approved"
+
+
+# --- Staleness propagation + versioning (CONTRACT.md §4.2, §4.3) -------------
+
+def test_rerun_after_approval_overwrites_in_place_and_stales_build(tmp_path):
+    """A post-approval re-run overwrites the spec at current_version (no bump) and stales build."""
+    _ready_project(
+        tmp_path,
+        intake="approved", brand="approved", data="approved",
+        spec="approved", build="approved",
+    )
+    # build's own required reads must exist so the router reaches the stale 'build' rather
+    # than blocking on data (CONTRACT.md §1: build reads DATA-MODEL.md + data/*.csv).
+    (tmp_path / "DATA-MODEL.md").write_text("# Data Model\n", encoding="utf-8")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / "x.csv").write_text("region,revenue\nWest,10\n", encoding="utf-8")
+    # Spec never bumps: it re-writes into the mock's current_version (still v_1).
+    _write_spec(tmp_path, "v_1", _spec_md())
+
+    result = spec.commit(tmp_path)
+
+    assert result.ok is True
+    assert result.version == "v_1"  # no bump - spec overwrites in place (§4.3)
+    assert result.staled_steps == ["build"]
+
+    state = route.parse_state(tmp_path / "STATE.md")
+    assert state.statuses["spec"] == "approved" and state.statuses["build"] == "stale"
+    assert state.current_version == "v_1"  # only tableau-mock bumps current_version
+
+    # Cross-check through the router: the first unresolved step is now stale 'build'.
+    routed = route.compute_next_step(tmp_path)
+    assert routed.next_step == "build" and "stale" in routed.reason.lower()
+
+
+def test_first_run_marks_nothing_stale(tmp_path):
+    """On a first approval there is nothing downstream approved, so nothing goes stale."""
+    _ready_project(tmp_path)
+    _write_spec(tmp_path, "v_1", _spec_md())
+
+    result = spec.commit(tmp_path)
+
+    assert result.ok is True and result.staled_steps == []


### PR DESCRIPTION
## Summary

Step 7 of 8 in the v2 plugin: the **non-skippable** `tableau-spec` skill. It turns the approved `mock.html` into an `IMPLEMENTATION-SPEC.md` that maps **every** mock element (`data-plan-id`) to a concrete Tableau construct, so `tableau-build` builds from an explicit spec instead of guessing.

## What's in it

- **`reconcile.py`** — pure, stdlib-only core: coverage reconciliation (every mock element mapped, nothing unmapped) + simplest-primitive guard (any escalation to DZV / LOD / table calc / parameter action must carry a justification, else it's flagged as over-engineering).
- **`spec.py`** — orchestration: entry gate (§4.1 — refuses until `plan`+`mock` resolved and their artifacts exist), `precheck`/`validate`/`commit` CLI, and the STATE.md `approved` + downstream-`stale` transition (§4.2). Spec writes into the mock's `current_version` and **never bumps it** (§4.3).
- **`SKILL.md`** + **`IMPLEMENTATION-SPEC-TEMPLATE.md`** — the authoring flow, the machine-checked Element Mapping table convention, and the guard guidance.
- **`CONTRACT.md` §4.3** — clarified that only `tableau-mock` bumps `current_version`; `spec` and `build` write into the mock's `v_N` and overwrite in place.

## Verification

- `route.py` `STEPS` cross-checked against `CONTRACT.md §1` — Step 7 reads `plan`+`mock`, Step 8 (`build`) reads `spec`+`data`. In sync.
- Full suite green: **208 passed** (incl. new `tests/test_spec.py` covering the gate, parsing, coverage+guard, versioning, and the approve/refuse/stale transitions via the router).

🤖 Generated with [Claude Code](https://claude.com/claude-code)