### PR TITLE
feat(spec): required Layout container-tree JSON in IMPLEMENTATION-SPEC.md

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -53,6 +53,27 @@ A step may also have *optional reads* that enrich its output but never block it:
 > and the `STEPS` definition in `skills/tableau-route/scripts/route.py`. They are the prose and the
 > executable copy of the same graph and must stay identical.
 
+### 1.1 The `IMPLEMENTATION-SPEC.md` handoff (step 7 → step 8)
+
+`IMPLEMENTATION-SPEC.md` carries two machine-checked sections that `tableau-build` consumes; spec
+approval is blocked until both are present and consistent (enforced by `tableau-spec`'s
+`reconcile.py`):
+
+1. **The Element Mapping table** — one row per mock element (`data-plan-id`), mapping each to a
+   Tableau construct, with a justification for any advanced-feature escalation.
+2. **The Layout section** — a short human-readable summary followed by a **fenced JSON container
+   tree** derived from the approved `mock.html`, so layout truth reaches the build instead of being
+   guessed. The JSON carries:
+   - `canvas` — the mock's design dimensions in px (`{"width": ..., "height": ...}`);
+   - `root` — a container node (`type`: `vert` | `horz`, non-empty `children`), nesting further
+     containers and leaves (`{"id": ..., "size": ...}`);
+   - every non-root node has a numeric `size` — its **percentage of the parent** along the parent's
+     flow axis — and siblings sum to ~100.
+
+   Every Element Mapping **zone** id appears in the tree **exactly once**; ids in the tree must have
+   a mapping row. Interaction ids (`int-*`, per the plan's id convention) are dashboard *actions*,
+   not zones — they are never placed in the tree.
+
 ---
 
 ## 2. The `STATE.md` schema

--- a/demo/output/mock-version/v_1/IMPLEMENTATION-SPEC.md
+++ b/demo/output/mock-version/v_1/IMPLEMENTATION-SPEC.md
@@ -1,0 +1,127 @@
+# Implementation Spec: Sales Performance
+
+> Maps the approved `mock.html` (v_1) to concrete Tableau constructs so `tableau-build`
+> never has to guess. The Element Mapping table and the Layout section are the two
+> machine-checked handoffs (CONTRACT.md §1.1).
+>
+> **Note:** this demo mock predates the `data-plan-id` convention, so the ids below are
+> the stable plan-style ids for its elements; in a live v2 project each id matches a
+> `data-plan-id` attribute in `mock.html` exactly.
+
+**Mock version**: v_1
+**Data sources**: sales_orders.csv, monthly_targets.csv, customer_segments.csv
+
+## Element Mapping
+
+| id                      | tableau construct                                                                  | justification |
+|-------------------------|------------------------------------------------------------------------------------|---------------|
+| flt-date                | Filter card on [order_date] (month dropdown), applies to all sheets                 | -             |
+| flt-region              | Filter card on [region] (multi-select dropdown), applies to all sheets              | -             |
+| flt-category            | Filter card on [product_category] (multi-select dropdown), applies to all sheets    | -             |
+| btn-more-filters        | Show/Hide button toggling pnl-hidden-filters                                        | -             |
+| pnl-hidden-filters      | Floating container with show/hide button, holds the extra filter cards              | -             |
+| flt-segment             | Filter card on [segment] (dropdown)                                                 | -             |
+| flt-country             | Filter card on [country] (dropdown)                                                 | -             |
+| kpi-revenue             | Text mark, SUM([revenue]) with [Revenue vs Target %] subtitle, `$#,##0`             | -             |
+| kpi-profit              | Text mark, SUM([profit]) with [Profit Margin %] subtitle, `$#,##0` / `0.0%`         | -             |
+| kpi-orders              | Text mark, COUNTD([order_id]) with [Orders vs Target %] subtitle, `#,##0`           | -             |
+| kpi-aov                 | Text mark, [Avg Order Value], `$#,##0.00`                                           | -             |
+| chart-revenue-trend     | Line mark: MONTH([order_date]) x SUM([revenue]), color by [region]                  | -             |
+| chart-revenue-vs-target | Side-by-side bar: [region] x Measure Values (SUM([revenue]), SUM([revenue_target])) | -             |
+| chart-profit-category   | Horizontal bar: [product_category] x SUM([profit]), color by [product_category]     | -             |
+| tbl-top-customers       | Text table: [customer_name], [segment], [nps_score] x SUM([revenue]), sorted desc   | -             |
+| int-region-click        | Filter action (Use as Filter): chart-revenue-vs-target -> trend, profit, customers  | -             |
+| int-category-click      | Filter action (Use as Filter): chart-profit-category -> trend, customers            | -             |
+
+## Layout
+
+A vertical stack matching the mock: a filter bar on top (three global filter cards, the
+"more filters" button, and the collapsible extra-filters container), a row of four KPI
+cards, then two equal chart rows (trend + target comparison, category profit + top
+customers). Sizes are percentages of the parent along its flow axis, on the mock's
+1366 x 768 canvas.
+
+```json
+{
+  "canvas": {"width": 1366, "height": 768},
+  "root": {
+    "type": "vert",
+    "children": [
+      {
+        "type": "horz",
+        "size": 8,
+        "children": [
+          {"id": "flt-date", "size": 20},
+          {"id": "flt-region", "size": 20},
+          {"id": "flt-category", "size": 20},
+          {"id": "btn-more-filters", "size": 10},
+          {
+            "id": "pnl-hidden-filters",
+            "type": "horz",
+            "size": 30,
+            "children": [
+              {"id": "flt-segment", "size": 50},
+              {"id": "flt-country", "size": 50}
+            ]
+          }
+        ]
+      },
+      {
+        "type": "horz",
+        "size": 16,
+        "children": [
+          {"id": "kpi-revenue", "size": 25},
+          {"id": "kpi-profit", "size": 25},
+          {"id": "kpi-orders", "size": 25},
+          {"id": "kpi-aov", "size": 25}
+        ]
+      },
+      {
+        "type": "horz",
+        "size": 38,
+        "children": [
+          {"id": "chart-revenue-trend", "size": 50},
+          {"id": "chart-revenue-vs-target", "size": 50}
+        ]
+      },
+      {
+        "type": "horz",
+        "size": 38,
+        "children": [
+          {"id": "chart-profit-category", "size": 50},
+          {"id": "tbl-top-customers", "size": 50}
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Calculated Fields
+
+| field name           | formula                                                          | used by (element id)    |
+|----------------------|------------------------------------------------------------------|-------------------------|
+| Revenue vs Target %  | `SUM([revenue]) / SUM([revenue_target])`                          | kpi-revenue             |
+| Profit Margin %      | `SUM([profit]) / SUM([revenue])`                                  | kpi-profit              |
+| Orders vs Target %   | `COUNTD([order_id]) / SUM([orders_target])`                       | kpi-orders              |
+| Avg Order Value      | `SUM([revenue]) / COUNTD([order_id])`                             | kpi-aov                 |
+| Below Target         | `SUM([revenue]) < SUM([revenue_target])`                          | chart-revenue-vs-target |
+
+## Data Sources & Joins
+
+| source (csv)          | role    | join / relationship                                        |
+|-----------------------|---------|-------------------------------------------------------------|
+| sales_orders.csv      | primary | -                                                           |
+| monthly_targets.csv   | lookup  | `sales_orders.region = monthly_targets.region` (left)       |
+| customer_segments.csv | lookup  | `sales_orders.customer_name = customer_segments.customer_name` (left) |
+
+## Actions
+
+| action name    | type   | source                  | target(s)                                                    | run on |
+|----------------|--------|-------------------------|--------------------------------------------------------------|--------|
+| Region Click   | Filter | chart-revenue-vs-target | chart-revenue-trend, chart-profit-category, tbl-top-customers | select |
+| Category Click | Filter | chart-profit-category   | chart-revenue-trend, tbl-top-customers                        | select |
+
+## Parameters
+
+None

--- a/skills/tableau-spec/SKILL.md
+++ b/skills/tableau-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tableau-spec
-description: Translates the approved HTML mock (mock.html) into an IMPLEMENTATION-SPEC.md for the tableau-dashboard-plugin workflow, mapping every mock element to a concrete Tableau construct so the build step never has to guess. Reconciles coverage the mirror of the mock's checklist so nothing is left unmapped, and applies a simplest-primitive guard defaulting each element to the simplest sufficient Tableau primitive and forcing an explicit justification for any escalation to an advanced feature (Dynamic Zone Visibility, LOD, table calculation, parameter action), so the workbook is not over-engineered. Reads the approved mock.html and DASHBOARD-PLAN.md. Use when the user wants to write the implementation spec, map the mock to Tableau, or when tableau-route reports spec is next. Step 7 of 8 in the workflow.
+description: Translates the approved HTML mock (mock.html) into an IMPLEMENTATION-SPEC.md for the tableau-dashboard-plugin workflow, mapping every mock element to a concrete Tableau construct so the build step never has to guess. Reconciles coverage the mirror of the mock's checklist so nothing is left unmapped, and applies a simplest-primitive guard defaulting each element to the simplest sufficient Tableau primitive and forcing an explicit justification for any escalation to an advanced feature (Dynamic Zone Visibility, LOD, table calculation, parameter action), so the workbook is not over-engineered. Emits a required Layout section (a fenced JSON container tree with canvas dimensions, nested vert/horz containers, and percentage sizes) so the build reproduces the mock's geometry instead of guessing it. Reads the approved mock.html and DASHBOARD-PLAN.md. Use when the user wants to write the implementation spec, map the mock to Tableau, or when tableau-route reports spec is next. Step 7 of 8 in the workflow.
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, AskUserQuestion, Bash(python *), Bash(python3 *)
 ---
@@ -29,10 +29,11 @@ carries a justification), the version bump, and the STATE.md transition — live
 judgment part: choosing the right, simplest Tableau construct for each element and
 justifying any escalation. Run the script at the points below; do not hand-edit `STATE.md`.
 
-## The one convention the reconciliation depends on
+## The two conventions the reconciliation depends on
 
-`reconcile.py` decides "mapped" mechanically, so the spec **must** carry a single
-**Element Mapping table** (see `references/IMPLEMENTATION-SPEC-TEMPLATE.md`):
+`reconcile.py` decides "mapped" and "laid out" mechanically, so the spec **must** carry a
+single **Element Mapping table** and a **Layout section** (see
+`references/IMPLEMENTATION-SPEC-TEMPLATE.md`):
 
 - The table's first column header is **`id`** and it has a column whose header contains
   **`construct`** and one whose header contains **`justif`**.
@@ -41,6 +42,12 @@ justifying any escalation. Run the script at the points below; do not hand-edit 
   is what makes "nothing unmapped" a guarantee.
 - The **construct** cell names the Tableau construct; the **justification** cell explains
   any escalation (leave it blank / `-` for a simple primitive).
+- The **`## Layout` section** holds a short summary and a fenced JSON **container tree**
+  derived from the approved mock: the mock's `canvas` dimensions, nested `vert`/`horz`
+  containers, and element-id leaves with percentage `size`s (siblings sum to ~100). Every
+  mapped **zone** id appears **exactly once**; interaction ids (`int-*`) are actions, not
+  zones, and never appear. This is how the mock's geometry reaches `tableau-build` — a
+  missing or inconsistent Layout blocks approval exactly like an unmapped element.
 
 ## The simplest-primitive guard
 
@@ -84,9 +91,12 @@ panel` / `parameter swap` → these legitimately need DZV / parameter — justif
 
 3. **Author `IMPLEMENTATION-SPEC.md`** at the precheck's **target path**. Fill the Element
    Mapping table with one row per mock element, defaulting to the simplest primitive and
-   justifying every escalation. Add the supporting detail the build needs (calculated
-   fields, data source / joins, actions, parameters) following the template. When
-   **refining** an existing spec at this version, `Edit` it in place.
+   justifying every escalation. Write the **`## Layout` section** by reading the mock's
+   actual geometry (its rows, columns, and nesting) into the JSON container tree — sizes
+   as percentages of the parent, canvas from the plan's Screen Size. Add the supporting
+   detail the build needs (calculated fields, data source / joins, actions, parameters)
+   following the template. When **refining** an existing spec at this version, `Edit` it
+   in place.
 
 4. **Self-check, then present.** Validate the draft before showing it:
 
@@ -95,8 +105,10 @@ panel` / `parameter swap` → these legitimately need DZV / parameter — justif
    ```
 
    It prints the **reconciliation checklist** (one line per mock element, each `[x]` mapped
-   or `[ ]` unmapped / unjustified-escalation) and the guard result. If it prints
-   `[INVALID]`, map the missing element(s) / add the missing justification(s) and re-run.
+   or `[ ]` unmapped / unjustified-escalation), the guard result, and the **layout check**
+   (the container tree present and consistent with the mapping). If it prints `[INVALID]`,
+   map the missing element(s) / add the missing justification(s) / fix the named layout
+   problem(s) and re-run.
    When it prints `[OK]`, **show the checklist to the analyst** (it's the proof nothing was
    dropped and nothing is over-engineered) and present the spec for approval.
 

--- a/skills/tableau-spec/references/IMPLEMENTATION-SPEC-TEMPLATE.md
+++ b/skills/tableau-spec/references/IMPLEMENTATION-SPEC-TEMPLATE.md
@@ -1,9 +1,11 @@
 # Implementation Spec: <dashboard name>
 
 > Maps the approved `mock.html` to concrete Tableau constructs so `tableau-build` never has
-> to guess. **The Element Mapping table below is required and machine-checked**: every mock
-> element (every `data-plan-id`) must have exactly one row, and any escalation to an advanced
-> feature must carry a justification. Replace every `<...>` and keep the table structure intact.
+> to guess. **The Element Mapping table and the Layout section below are required and
+> machine-checked**: every mock element (every `data-plan-id`) must have exactly one mapping
+> row, any escalation to an advanced feature must carry a justification, and the Layout's
+> container tree must place every mapped zone exactly once. Replace every `<...>` and keep
+> the table structure and the fenced JSON intact.
 
 **Mock version**: <v_N>
 **Data sources**: <csv file(s) from DATA-MODEL.md>
@@ -24,6 +26,48 @@ alternative was rejected**.
 | flt-region        | Filter card on [region] (multi-select dropdown)     | -                                                          |
 | int-region-filter | Filter action (Use as Filter) chart-region -> rest  | -                                                          |
 | pnl-details       | Dynamic Zone Visibility on the details container     | show/hide button can't collapse a whole zone here: <why>   |
+
+## Layout
+
+The dashboard's container tree, derived from the approved `mock.html` — this is how the
+mock's geometry reaches `tableau-build`, so the workbook's layout matches the mock instead
+of being guessed. Start with a short human-readable summary of the layout, then the
+**required fenced JSON block**:
+
+- `canvas` — the mock's design dimensions in px (from the plan's Screen Size).
+- `root` — a **container**: `type` is `vert` (children stack top-to-bottom) or `horz`
+  (left-to-right), `children` is a non-empty list.
+- Each child is another container or a **leaf** `{"id": ..., "size": ...}` whose `id`
+  matches an Element Mapping row exactly. A container may also carry an `id` when the
+  container itself is a mapped element (e.g. a DZV panel holding further zones).
+- `size` is the child's **percentage of its parent** along the parent's flow axis;
+  siblings must sum to ~100. The root itself needs no size.
+- Every mapped **zone** id appears **exactly once**. Interaction ids (`int-*`) are
+  dashboard actions, not zones — never place them in the tree.
+
+<Example: a filter bar over a KPI row, a chart row, and a collapsible details panel.>
+
+```json
+{
+  "canvas": {"width": 1366, "height": 768},
+  "root": {
+    "type": "vert",
+    "children": [
+      {"id": "flt-region", "size": 8},
+      {"id": "kpi-revenue", "size": 14},
+      {
+        "type": "horz",
+        "size": 58,
+        "children": [
+          {"id": "chart-trend", "size": 60},
+          {"id": "chart-region", "size": 40}
+        ]
+      },
+      {"id": "pnl-details", "size": 20}
+    ]
+  }
+}
+```
 
 ## Calculated Fields
 

--- a/skills/tableau-spec/scripts/reconcile.py
+++ b/skills/tableau-spec/scripts/reconcile.py
@@ -19,11 +19,21 @@ versioning / entry-gate plumbing and imports :func:`reconcile` from here. It own
 The concrete "what is the simplest primitive for X" knowledge lives in the validated snippet
 library and the SKILL.md's decision guidance; this module enforces only the mechanical rule
 "advanced feature present => a justification must be written".
+
+3. **Layout reconciliation** (issue #32) - the spec MUST carry a ``## Layout`` section
+   holding a fenced JSON container tree (canvas dimensions + nested ``vert``/``horz``
+   containers + element-id leaves with percentage sizes). This is how the mock's geometry
+   reaches ``tableau-build``; without it the workbook's layout is guesswork. The tree must
+   place every mapped *zone* id exactly once (interaction ids - ``int-*`` - are dashboard
+   actions, not zones, so they never appear in the tree), must not place unmapped ids, and
+   sibling sizes must sum to ~100%.
 """
 
 from __future__ import annotations
 
+import json
 import re
+from collections import Counter
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -195,6 +205,195 @@ def parse_spec_mappings(spec_text: str) -> list[Mapping]:
     return []
 
 
+# --- Layout container tree (issue #32) ----------------------------------------
+
+#: Valid container orientations in the layout tree.
+CONTAINER_TYPES = frozenset({"vert", "horz"})
+
+#: Mapped ids with this prefix are dashboard *actions* (plan convention: ``int-region-filter``)
+#: - they occupy no zone, so the layout tree neither requires nor allows placing them.
+INTERACTION_PREFIX = "int-"
+
+#: How far sibling sizes may drift from 100% before they "don't sum sanely" (rounding slack).
+SIBLING_SIZE_TOLERANCE = 2.0
+
+# Exactly '## Layout' (the level the contract/template mandate) so the section reliably
+# ends at the next '## ' heading.
+_LAYOUT_HEADING = re.compile(r"^##\s+Layout\b.*$", re.MULTILINE)
+_NEXT_SECTION = re.compile(r"^##\s", re.MULTILINE)
+_FENCED_BLOCK = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
+
+
+def extract_layout_block(spec_text: str) -> Optional[str]:
+    """Return the fenced JSON text under the spec's ``## Layout`` heading, or ``None``.
+
+    Args:
+        spec_text: The contents of an ``IMPLEMENTATION-SPEC.md`` file.
+
+    Returns:
+        The inner text of the first fenced code block between the ``## Layout`` heading
+        and the next ``## `` section, or ``None`` when the heading or block is absent.
+    """
+    heading = _LAYOUT_HEADING.search(spec_text)
+    if heading is None:
+        return None
+    section = spec_text[heading.end():]
+    next_section = _NEXT_SECTION.search(section)
+    if next_section is not None:
+        section = section[: next_section.start()]
+    block = _FENCED_BLOCK.search(section)
+    return block.group(1) if block else None
+
+
+def _is_number(value: object) -> bool:
+    """Return True for a real (non-bool) JSON number."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _walk_layout_node(
+    node: object, path: str, is_root: bool, placed: list[str], errors: list[str]
+) -> None:
+    """Validate one layout node (and recurse), appending placed ids and errors.
+
+    A node is a **container** (``type`` in vert/horz + non-empty ``children``), a **leaf**
+    (``id`` naming a mapped element), or both - a *mapped container* (e.g. a DZV panel
+    that is itself an element and holds further zones). Every non-root node needs a
+    positive numeric ``size`` (percent of its parent), and each container's children must
+    sum to ~100.
+
+    Args:
+        node: The JSON value at this position in the tree.
+        path: Human-readable position (e.g. ``root.children[1]``) for error messages.
+        is_root: True for the top-level container (which needs no ``size``).
+        placed: Accumulator for every placed id encountered.
+        errors: Accumulator for validation errors.
+    """
+    if not isinstance(node, dict):
+        errors.append(f"{path}: every layout node must be a JSON object")
+        return
+
+    has_id, is_container = "id" in node, "children" in node
+    if not has_id and not is_container:
+        errors.append(
+            f"{path}: a node needs an 'id' (leaf), 'children' (container), or both "
+            f"(a mapped container, e.g. a DZV panel)"
+        )
+        return
+
+    if not is_root and not (_is_number(node.get("size")) and node["size"] > 0):
+        errors.append(f"{path}: missing a positive numeric 'size' (percent of parent)")
+
+    if has_id:
+        element_id = node["id"]
+        if isinstance(element_id, str) and element_id.strip():
+            placed.append(element_id.strip())
+        else:
+            errors.append(f"{path}: 'id' must be a non-empty string")
+    if not is_container:
+        return
+
+    if node.get("type") not in CONTAINER_TYPES:
+        errors.append(
+            f"{path}: container 'type' must be 'vert' or 'horz' (got {node.get('type')!r})"
+        )
+    children = node["children"]
+    if not isinstance(children, list) or not children:
+        errors.append(f"{path}: 'children' must be a non-empty list")
+        return
+    for index, child in enumerate(children):
+        _walk_layout_node(child, f"{path}.children[{index}]", False, placed, errors)
+
+    sizes = [child.get("size") for child in children if isinstance(child, dict)]
+    if len(sizes) == len(children) and all(_is_number(size) for size in sizes):
+        total = sum(sizes)
+        if abs(total - 100) > SIBLING_SIZE_TOLERANCE:
+            errors.append(
+                f"{path}: sibling sizes sum to {total:g}, expected ~100 "
+                f"(each child's share of its parent)"
+            )
+
+
+def validate_layout(spec_text: str, mapped_ids: list[str]) -> list[str]:
+    """Validate the spec's Layout container tree against its Element Mapping ids.
+
+    The Layout section is **required** (it is how the mock's geometry reaches the build):
+    a missing section/block, unparseable JSON, a malformed tree, a mapped zone id absent or
+    placed more than once, an id in the tree with no mapping row, or siblings whose sizes
+    don't sum to ~100% each produce an actionable error.
+
+    Args:
+        spec_text: The contents of an ``IMPLEMENTATION-SPEC.md`` file.
+        mapped_ids: The ids of the spec's Element Mapping rows. Ids prefixed ``int-``
+            (interactions/actions) are exempt from placement - they occupy no zone.
+
+    Returns:
+        A list of error messages; empty when the layout is present and consistent.
+    """
+    block = extract_layout_block(spec_text)
+    if block is None:
+        return [
+            "Layout section missing: add a '## Layout' section with a fenced JSON "
+            "container tree (canvas + nested vert/horz containers + element-id leaves "
+            "with % sizes) - see IMPLEMENTATION-SPEC-TEMPLATE.md"
+        ]
+    try:
+        layout = json.loads(block)
+    except json.JSONDecodeError as exc:
+        return [f"Layout JSON does not parse: {exc}"]
+    if not isinstance(layout, dict):
+        return ["Layout JSON must be an object with 'canvas' and 'root' keys"]
+
+    errors: list[str] = []
+    canvas = layout.get("canvas")
+    if not (
+        isinstance(canvas, dict)
+        and _is_number(canvas.get("width")) and canvas["width"] > 0
+        and _is_number(canvas.get("height")) and canvas["height"] > 0
+    ):
+        errors.append(
+            "Layout 'canvas' must carry positive numeric 'width' and 'height' "
+            "(the mock's design dimensions in px)"
+        )
+
+    root = layout.get("root")
+    placed: list[str] = []
+    if isinstance(root, dict):
+        _walk_layout_node(root, "root", True, placed, errors)
+    else:
+        errors.append("Layout 'root' must be a container object ('type' + 'children')")
+
+    placement_counts = Counter(placed)
+    duplicates = sorted(pid for pid, count in placement_counts.items() if count > 1)
+    if duplicates:
+        errors.append(
+            "element id(s) placed more than once in the layout tree: "
+            + ", ".join(duplicates)
+        )
+
+    mapped_set = set(mapped_ids)
+    unknown = sorted(pid for pid in placement_counts if pid not in mapped_set)
+    if unknown:
+        errors.append(
+            "layout tree places id(s) with no Element Mapping row: " + ", ".join(unknown)
+        )
+
+    zone_ids = [pid for pid in mapped_ids if not pid.startswith(INTERACTION_PREFIX)]
+    unplaced = [pid for pid in zone_ids if pid not in placement_counts]
+    if unplaced:
+        errors.append(
+            "mapped element id(s) missing from the layout tree: " + ", ".join(unplaced)
+        )
+    misplaced_actions = sorted(
+        pid for pid in placement_counts if pid.startswith(INTERACTION_PREFIX)
+    )
+    if misplaced_actions:
+        errors.append(
+            "interaction id(s) placed in the layout tree (actions occupy no zone): "
+            + ", ".join(misplaced_actions)
+        )
+    return errors
+
+
 # --- Reconciliation result ---------------------------------------------------
 
 @dataclass(frozen=True)
@@ -222,17 +421,20 @@ class SpecValidation:
     """Result of reconciling an ``IMPLEMENTATION-SPEC.md`` against its ``mock.html``.
 
     Attributes:
-        ok: True iff every mock element is mapped and every advanced-feature escalation is
-            justified.
+        ok: True iff every mock element is mapped, every advanced-feature escalation is
+            justified, and the Layout container tree is present and consistent.
         items: The reconciliation checklist (one item per mock element).
         extra_ids: Ids mapped in the spec that do not exist in the mock (non-fatal note).
         notes: Non-fatal observations.
+        layout_errors: Layout-section problems (each blocks approval; empty when the
+            container tree is present and consistent with the Element Mapping).
     """
 
     ok: bool
     items: list[MappingItem]
     extra_ids: list[str]
     notes: list[str] = field(default_factory=list)
+    layout_errors: list[str] = field(default_factory=list)
 
     @property
     def unmapped(self) -> list[str]:
@@ -253,8 +455,10 @@ def reconcile(mock_html: str, spec_text: str) -> SpecValidation:
 
     Coverage: every ``data-plan-id`` in the mock must have an Element Mapping row.
     Guard: any mapping whose construct uses an advanced feature (DZV / LOD / table calc /
-    parameter action) must carry a non-empty justification. The spec is valid iff there
-    are no unmapped mock elements and no unjustified escalations.
+    parameter action) must carry a non-empty justification. Layout: the spec must carry a
+    ``## Layout`` container tree consistent with the mapping (:func:`validate_layout`).
+    The spec is valid iff there are no unmapped mock elements, no unjustified escalations,
+    and no layout errors.
 
     Args:
         mock_html: The contents of the approved ``mock.html``.
@@ -290,5 +494,6 @@ def reconcile(mock_html: str, spec_text: str) -> SpecValidation:
             + ", ".join(extra_ids)
         )
 
-    ok = all(item.mapped and item.justified for item in items)
-    return SpecValidation(ok, items, extra_ids, notes)
+    layout_errors = validate_layout(spec_text, list(mappings.keys()))
+    ok = all(item.mapped and item.justified for item in items) and not layout_errors
+    return SpecValidation(ok, items, extra_ids, notes, layout_errors)

--- a/skills/tableau-spec/scripts/spec.py
+++ b/skills/tableau-spec/scripts/spec.py
@@ -335,8 +335,9 @@ def commit(project_dir: Path | str) -> CommitResult:
 
     The spec is non-skippable, so commit only ever sets ``approved``. The
     ``mock-version/<current_version>/IMPLEMENTATION-SPEC.md`` must exist and pass
-    :func:`reconcile.reconcile` (every mock element mapped + every advanced-feature
-    escalation justified) or the commit is refused. On success ``spec`` is approved and
+    :func:`reconcile.reconcile` (every mock element mapped, every advanced-feature
+    escalation justified, and a consistent Layout container tree) or the commit is
+    refused. On success ``spec`` is approved and
     every downstream ``approved`` step (``build``) is flipped to ``stale`` (§4.2). Spec
     writes into the mock's ``current_version`` and never bumps it - only the leading
     deliverable (``mock``) does (§4.3), so a re-run overwrites the spec in place.
@@ -385,6 +386,8 @@ def commit(project_dir: Path | str) -> CommitResult:
                     for item in validation.unjustified
                 )
             )
+        if validation.layout_errors:
+            reasons.append("layout problem(s): " + "; ".join(validation.layout_errors))
         return CommitResult(
             False,
             f"'{SPEC_FILENAME}' does not fully reconcile with the mock - "
@@ -435,6 +438,10 @@ def format_precheck(result: PrecheckResult) -> str:
         "  default each element to the SIMPLEST sufficient Tableau primitive; justify any "
         "escalation to DZV / LOD / table calc / parameter action against the simpler option."
     )
+    lines.append(
+        "  the spec must also carry a '## Layout' fenced-JSON container tree derived from "
+        "the mock's geometry (canvas + nested vert/horz + % sizes; see the template)."
+    )
     return "\n".join(lines)
 
 
@@ -458,11 +465,18 @@ def format_validation(validation: SpecValidation) -> str:
         )
         lines.append(f"  [x] {item.id}: {item.construct}{note}")
 
+    lines.append("Layout container tree:")
+    if validation.layout_errors:
+        lines.extend(f"  [ ] {error}" for error in validation.layout_errors)
+    else:
+        lines.append("  [x] present and consistent with the Element Mapping")
+
     for note in validation.notes:
         lines.append(f"  note: {note}")
 
     lines.append(
-        "[OK] every mock element maps to a construct; escalations are justified."
+        "[OK] every mock element maps to a construct; escalations are justified; "
+        "the layout tree is consistent."
         if validation.ok
         else "[INVALID] spec does not fully reconcile with the mock - fix the items above and re-run."
     )

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -35,12 +35,28 @@ def _mock_html(ids=MOCK_IDS) -> str:
     return f"<!doctype html><html><body>\n{tagged}\n</body></html>"
 
 
-def _spec_md(rows=None) -> str:
-    """Render an IMPLEMENTATION-SPEC.md with an Element Mapping table.
+def _layout_json(ids) -> str:
+    """Render a minimal valid Layout JSON: a vert root placing each zone id once.
+
+    Interaction ids (``int-*``) are actions, not zones, so they are never placed.
+    """
+    zone_ids = [i for i in ids if not i.startswith("int-")]
+    share = round(100 / len(zone_ids), 2) if zone_ids else 100
+    children = ", ".join(f'{{"id": "{i}", "size": {share}}}' for i in zone_ids)
+    return (
+        '{"canvas": {"width": 1366, "height": 768}, '
+        f'"root": {{"type": "vert", "children": [{children}]}}}}'
+    )
+
+
+def _spec_md(rows=None, layout=None) -> str:
+    """Render an IMPLEMENTATION-SPEC.md with an Element Mapping table and Layout section.
 
     Args:
         rows: Iterable of ``(id, construct, justification)`` tuples. Defaults to a full,
             all-simple mapping of every ``MOCK_IDS`` element.
+        layout: The Layout section's fenced JSON text. Defaults to a valid tree placing
+            each mapped zone id once; pass ``""`` to omit the Layout section entirely.
 
     Returns:
         A spec markdown string.
@@ -52,12 +68,18 @@ def _spec_md(rows=None) -> str:
             ("flt-region", "Filter card on [region]", "-"),
             ("int-region-filter", "Filter action (Use as Filter)", "-"),
         ]
+    if layout is None:
+        layout = _layout_json([i for i, _, _ in rows])
     body = "\n".join(f"| {i} | {c} | {j} |" for i, c, j in rows)
+    layout_section = (
+        f"\n## Layout\n\nA vert stack of the mapped zones.\n\n```json\n{layout}\n```\n"
+        if layout else ""
+    )
     return (
         "# Implementation Spec: Sales\n\n## Element Mapping\n"
         "| id | tableau construct | justification |\n"
         "|----|-------------------|---------------|\n"
-        f"{body}\n"
+        f"{body}\n{layout_section}"
     )
 
 
@@ -258,6 +280,156 @@ def test_reconcile_notes_extra_mapped_ids():
 
     assert validation.ok is True
     assert validation.extra_ids == ["ghost-id"]
+
+
+# --- Layout container tree (issue #32) ----------------------------------------
+
+def test_reconcile_flags_missing_layout_section():
+    """A spec with no ## Layout section fails with an actionable message (AC)."""
+    validation = reconcile.reconcile(_mock_html(), _spec_md(layout=""))
+
+    assert validation.ok is False
+    assert any("Layout section missing" in error for error in validation.layout_errors)
+
+
+def test_reconcile_flags_unparseable_layout_json():
+    """A Layout block that is not valid JSON fails with a parse error."""
+    validation = reconcile.reconcile(_mock_html(), _spec_md(layout="{not json"))
+
+    assert validation.ok is False
+    assert any("does not parse" in error for error in validation.layout_errors)
+
+
+def test_reconcile_flags_mapped_id_absent_from_tree():
+    """A mapped zone id with no leaf in the tree blocks approval (AC)."""
+    layout = (
+        '{"canvas": {"width": 1366, "height": 768}, "root": {"type": "vert", "children": '
+        '[{"id": "kpi-revenue", "size": 50}, {"id": "chart-trend", "size": 50}]}}'
+    )  # flt-region unplaced
+    validation = reconcile.reconcile(_mock_html(), _spec_md(layout=layout))
+
+    assert validation.ok is False
+    assert any(
+        "missing from the layout tree" in error and "flt-region" in error
+        for error in validation.layout_errors
+    )
+
+
+def test_reconcile_flags_id_placed_more_than_once():
+    """A zone id placed twice in the tree blocks approval (AC)."""
+    layout = (
+        '{"canvas": {"width": 1366, "height": 768}, "root": {"type": "vert", "children": '
+        '[{"id": "kpi-revenue", "size": 25}, {"id": "kpi-revenue", "size": 25}, '
+        '{"id": "chart-trend", "size": 25}, {"id": "flt-region", "size": 25}]}}'
+    )
+    validation = reconcile.reconcile(_mock_html(), _spec_md(layout=layout))
+
+    assert validation.ok is False
+    assert any(
+        "more than once" in error and "kpi-revenue" in error
+        for error in validation.layout_errors
+    )
+
+
+def test_reconcile_flags_tree_id_with_no_mapping_row():
+    """An id in the tree that has no Element Mapping row blocks approval (AC)."""
+    layout = (
+        '{"canvas": {"width": 1366, "height": 768}, "root": {"type": "vert", "children": '
+        '[{"id": "kpi-revenue", "size": 25}, {"id": "chart-trend", "size": 25}, '
+        '{"id": "flt-region", "size": 25}, {"id": "ghost-zone", "size": 25}]}}'
+    )
+    validation = reconcile.reconcile(_mock_html(), _spec_md(layout=layout))
+
+    assert validation.ok is False
+    assert any(
+        "no Element Mapping row" in error and "ghost-zone" in error
+        for error in validation.layout_errors
+    )
+
+
+def test_reconcile_flags_insane_sibling_sizes():
+    """Sibling sizes far from 100% block approval (AC)."""
+    layout = (
+        '{"canvas": {"width": 1366, "height": 768}, "root": {"type": "vert", "children": '
+        '[{"id": "kpi-revenue", "size": 10}, {"id": "chart-trend", "size": 10}, '
+        '{"id": "flt-region", "size": 10}]}}'
+    )
+    validation = reconcile.reconcile(_mock_html(), _spec_md(layout=layout))
+
+    assert validation.ok is False
+    assert any("sum to 30" in error for error in validation.layout_errors)
+
+
+def test_reconcile_flags_missing_canvas():
+    """The canvas dimensions are required (the mock's design size drives the build)."""
+    layout = (
+        '{"root": {"type": "vert", "children": [{"id": "kpi-revenue", "size": 34}, '
+        '{"id": "chart-trend", "size": 33}, {"id": "flt-region", "size": 33}]}}'
+    )
+    validation = reconcile.reconcile(_mock_html(), _spec_md(layout=layout))
+
+    assert validation.ok is False
+    assert any("'canvas'" in error for error in validation.layout_errors)
+
+
+def test_reconcile_accepts_nested_containers():
+    """A well-formed nested vert/horz tree with sane sizes validates [OK] (AC)."""
+    layout = (
+        '{"canvas": {"width": 1366, "height": 768}, "root": {"type": "vert", "children": '
+        '[{"id": "flt-region", "size": 10}, '
+        '{"type": "horz", "size": 90, "children": '
+        '[{"id": "kpi-revenue", "size": 40}, {"id": "chart-trend", "size": 60}]}]}}'
+    )
+    validation = reconcile.reconcile(_mock_html(), _spec_md(layout=layout))
+
+    assert validation.ok is True
+    assert validation.layout_errors == []
+
+
+def test_reconcile_accepts_mapped_container():
+    """A container may itself carry a mapped id (e.g. a DZV panel holding zones)."""
+    ids = ("pnl-details", "kpi-revenue", "chart-trend")
+    rows = [
+        ("pnl-details", "Dynamic Zone Visibility on the details container", "no simpler toggle"),
+        ("kpi-revenue", "Text mark, SUM([revenue])", "-"),
+        ("chart-trend", "Line mark", "-"),
+    ]
+    layout = (
+        '{"canvas": {"width": 1366, "height": 768}, "root": {"type": "vert", "children": '
+        '[{"id": "chart-trend", "size": 60}, '
+        '{"id": "pnl-details", "type": "horz", "size": 40, "children": '
+        '[{"id": "kpi-revenue", "size": 100}]}]}}'
+    )
+    validation = reconcile.reconcile(_mock_html(ids), _spec_md(rows, layout=layout))
+
+    assert validation.ok is True
+    assert validation.layout_errors == []
+
+
+def test_reconcile_interaction_ids_stay_out_of_the_tree():
+    """int-* ids are actions, not zones: not required in the tree, and rejected if placed."""
+    placed_action = (
+        '{"canvas": {"width": 1366, "height": 768}, "root": {"type": "vert", "children": '
+        '[{"id": "kpi-revenue", "size": 25}, {"id": "chart-trend", "size": 25}, '
+        '{"id": "flt-region", "size": 25}, {"id": "int-region-filter", "size": 25}]}}'
+    )
+    validation = reconcile.reconcile(_mock_html(), _spec_md(layout=placed_action))
+
+    assert validation.ok is False
+    assert any("occupy no zone" in error for error in validation.layout_errors)
+    # The default helper layout omits int-region-filter and is valid (see other tests).
+
+
+def test_commit_refuses_spec_without_layout(tmp_path):
+    """commit is gated on the Layout section too, STATE.md untouched (AC)."""
+    _ready_project(tmp_path)
+    _write_spec(tmp_path, "v_1", _spec_md(layout=""))
+
+    result = spec.commit(tmp_path)
+
+    assert result.ok is False
+    assert "layout" in result.message.lower()
+    assert route.parse_state(tmp_path / "STATE.md").statuses["spec"] == "pending"
 
 
 # --- Versioning (CONTRACT.md §4.3: spec never bumps current_version) ----------


### PR DESCRIPTION
## Summary

**Adds a required, machine-checked `## Layout` section to `IMPLEMENTATION-SPEC.md`** — a fenced JSON container tree (canvas dimensions, nested `vert`/`horz` containers, element-id leaves with percentage sizes) derived from the approved `mock.html`, so layout truth reaches `tableau-build` instead of being guessed. Spec approval is now blocked until the layout is present and consistent, the same hard gate the Element Mapping table already has.

Closes #32 (PR 1 of the two-PR plan; PR 2 is `feat/tableau-build`).

## What's in it

- **`skills/tableau-spec/scripts/reconcile.py`** — the new layout core:
  - `extract_layout_block` finds the fenced JSON under the `## Layout` heading (exactly level-2, so the section reliably ends at the next `## `).
  - `validate_layout` + `_walk_layout_node` check: positive numeric **canvas** width/height, container `type` ∈ {`vert`, `horz`} with non-empty `children`, a positive `size` (% of parent) on every non-root node, **siblings summing to ~100** (±2 rounding slack), every mapped **zone** id placed **exactly once**, no tree id without a mapping row, and no `int-*` id placed (**interactions are actions, not zones** — per the plan skill's id convention). A container may also carry an `id` (a mapped DZV panel holding further zones).
  - Layout errors join `SpecValidation` and block `ok` exactly like an unmapped element.
- **`skills/tableau-spec/scripts/spec.py`** — `validate` prints a layout checklist section, `commit` refusals name the layout problem(s), `precheck` reminds the author of the Layout requirement.
- **`skills/tableau-spec/references/IMPLEMENTATION-SPEC-TEMPLATE.md`** — documents the Layout section (schema rules + worked JSON example, which itself validates cleanly).
- **`skills/tableau-spec/SKILL.md`** — restates the convention ("the two conventions the reconciliation depends on") and the authoring step; trigger description updated.
- **`CONTRACT.md`** — new **§1.1** documents the `IMPLEMENTATION-SPEC.md` handoff (Element Mapping + Layout block) consumed by step 8, without renumbering existing sections.
- **`demo/output/mock-version/v_1/IMPLEMENTATION-SPEC.md`** — new demo spec with an Element Mapping and a Layout tree matching the demo mock's geometry (filter bar → KPI row → 2×2 chart grid, with the hidden-filters panel as a mapped container). Ids are plan-style; the legacy demo mock predates `data-plan-id` tagging, noted in the file.

## Tests & validation

- **10 new stdlib-only contract tests** in `tests/test_spec.py`: missing section, unparseable JSON, mapped id absent from the tree, id placed twice, tree id with no mapping row, insane sibling sums, missing canvas, nested containers, mapped containers, the `int-*` exemption, and the commit gate. **Full suite: 219 pass.**
- Both the template's example JSON and the demo spec validate to zero layout errors through `validate_layout`.
- Two-axis code review (standards + spec) ran; its two actionable findings (heading-level parsing wrinkle, overlong docstring line) were fixed before commit.

## Notes

- The `int-` prefix exemption is a bare string-prefix convention (mirrors the plan skill's id scheme); a future zone id starting `int-` would be silently excused.
- Floating containers (e.g. a show/hide panel) are represented as tiled tree nodes; how the build renders floating vs tiled is PR 2 (`feat/tableau-build`) territory.
- The demo mock is legacy (no `data-plan-id`s), so the demo spec's "matches its mock" is visually asserted, not machine-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)