### PR TITLE
feat(build): tableau-build skeleton - entry gate + build manifest

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -69,6 +69,9 @@ approval is blocked until both are present and consistent (enforced by `tableau-
      containers and leaves (`{"id": ..., "size": ...}`);
    - every non-root node has a numeric `size` — its **percentage of the parent** along the parent's
      flow axis — and siblings sum to ~100.
+   - a node may carry both `id` **and** `children` — a **mapped container** (e.g. a DZV panel that
+     is itself a mapped element and also holds further zones). Its `id` occupies a zone, but that
+     zone is filled by the container's children, not by a worksheet or `objects` entry of its own.
 
    Every Element Mapping **zone** id appears in the tree **exactly once**; ids in the tree must have
    a mapping row. Interaction ids (`int-*`, per the plan's id convention) are dashboard *actions*,
@@ -143,11 +146,21 @@ The case of a filename encodes its role, so a skill can tell handoff artifacts f
 - **`UPPER-KEBAB.md` ⇒ handoff artifact** produced by a step and consumed by later steps:
   `PRD.md`, `DATA-MODEL.md`, `DESIGN-TOKENS.md`, `DASHBOARD-PLAN.md`, `IMPLEMENTATION-SPEC.md`.
   (`STATE.md` is the manifest and also uses this casing.)
-- **lowercase ⇒ input or config**, owned by the analyst, never produced as a handoff:
+- **lowercase ⇒ input or config, owned by the analyst, never produced as a handoff** — with
+  one narrow exception, the build-internal file described below:
   `.env`, `branding/`, `data/`, `datasources.json`, `DASHBOARD-REQUEST.md`. Their demo counterparts live
   under `scaffold/` (see §3.1).
 
-New artifacts MUST follow this rule. Do not introduce a lowercase handoff or an UPPER-KEBAB input.
+**Build-internal files** are the third, narrow category: lowercase files a skill writes for
+its *own* next stage, never read by another skill. Today there is exactly one —
+`mock-version/v_N/build-manifest.json`, the machine-readable translation of
+`IMPLEMENTATION-SPEC.md` + `DATA-MODEL.md` that `tableau-build`'s workbook generator
+consumes. Because nothing downstream reads it, it is not a handoff and takes the lowercase
+casing; it is versioned with the deliverable it produces (§4.3). A skill may add one only
+for a stage boundary inside itself.
+
+New artifacts MUST follow this rule. Do not introduce a lowercase handoff, an UPPER-KEBAB
+input, or a build-internal file read by more than the skill that wrote it.
 
 ### 3.1 Scaffold examples vs. production inputs
 
@@ -267,7 +280,8 @@ Two kinds of outputs, two storage strategies:
   current copy. Re-running one of these skills updates the root file and triggers staleness (§4.2);
   it does **not** create a new version directory.
 - **Deliverables = standalone versioned copies.** `mock.html`, `IMPLEMENTATION-SPEC.md`, and
-  `dashboard.twbx` are written under `mock-version/v_N/`, all three sharing the **same** `v_N`
+  `dashboard.twbx` (plus build's internal `build-manifest.json`, §3) are written under
+  `mock-version/v_N/`, all three deliverables sharing the **same** `v_N`
   directory. A version is anchored by its **mock**: `mock.html` is the leading deliverable, and
   **only `tableau-mock` bumps `current_version`**. Re-running `tableau-mock` after its step was
   approved bumps to a new `v_N`, writes the fresh `mock.html` there, and stales `spec`/`build`

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: tableau-build
+description: Builds the Tableau workbook for the tableau-dashboard-plugin workflow from the approved IMPLEMENTATION-SPEC.md and DATA-MODEL.md, producing a Replace-Data-Source-ready dashboard.twbx beside the mock it was specced from. Derives a machine-readable build manifest (datasources, worksheets with chart type and shelves/encodings, the spec's layout container tree, actions, parameters, and the project's target Tableau version) and schema-validates it fail-fast, so an unknown chart type, an element id missing from the layout, or a field that is not in the data model is caught with the offending entry named before any XML is generated. Reads the approved IMPLEMENTATION-SPEC.md at the current version, DATA-MODEL.md, and the CSVs under data/. Use when the user wants to build the workbook, generate the twbx, or when tableau-route reports build is next. Step 8 of 8 in the workflow.
+disable-model-invocation: true
+allowed-tools: Read, Write, Edit, AskUserQuestion, Bash(python *), Bash(python3 *)
+---
+
+# tableau-build
+
+Step 8 of 8, the last step, and **non-skippable**. It turns the approved
+`IMPLEMENTATION-SPEC.md` into the deliverable workbook. Between the prose spec and the XML
+sits one artifact: the **build manifest** (`build-manifest.json`) — the machine-readable
+translation of the spec that the deterministic builder consumes. Validating the manifest is
+what makes a bad translation fail *before* any XML exists, with the offending worksheet,
+field, or element id named.
+
+| | |
+|---|---|
+| **Reads** | **Required:** `mock-version/<v_N>/IMPLEMENTATION-SPEC.md` (from `spec`) — the construct mapping and the layout container tree; `DATA-MODEL.md` + `data/*.csv` (from `data`) — the fields the workbook binds to. **Optional:** `DESIGN-TOKENS.md` (styling; absent ⇒ neutral). |
+| **Writes** | `mock-version/<v_N>/build-manifest.json` (build-internal) and `mock-version/<v_N>/dashboard.twbx` — standalone deliverable copies (CONTRACT.md §4.3). |
+| **STATE.md update** | Sets `build` = `approved`. Nothing is downstream, so nothing goes stale. Does **not** touch `current_version` — only `tableau-mock` bumps it (§4.3). |
+| **Entry gate** | Refuses to run until `spec` is resolved **and** `IMPLEMENTATION-SPEC.md` exists at `current_version`, **and** `data` is resolved **and** `DATA-MODEL.md` plus at least one CSV exist (CONTRACT.md §4.1). |
+| **Next step** | None — the pipeline is complete (`tableau-route` confirms). |
+
+The mechanical guarantees — the entry gate, the manifest schema validation, and the STATE.md
+transition — live in `build.py` (CLI) and `manifest.py` (the schema core). Your job is the
+judgment part: translating each spec row into the right manifest entry. Run the script at
+the points below; do not hand-edit `STATE.md`.
+
+## The build manifest
+
+`references/BUILD-MANIFEST-TEMPLATE.md` is the annotated schema and a worked example. In
+short, the manifest carries `target_tableau_version` (copied from `STATE.md`), `datasources`
+(one per `data/` CSV), `worksheets` (chart type + shelves/encodings + the `element_id` each
+fills), `layout` (the spec's container tree, copied as-is), `actions`, and `parameters`;
+plus optional `objects` (zones no view fills — a filter card, title, logo) and
+`calculated_fields`.
+
+`validate` rejects, naming the entry: an unknown `chart_type`, an `element_id` that is not a
+zone in the layout tree, a leaf zone nothing fills, a field that `DATA-MODEL.md` does not
+document for that CSV, a shelf referencing an undeclared field or an unknown aggregation, a
+duplicate worksheet name, an action endpoint that is not a zone (or, for a parameter action,
+not a declared parameter), and a target version that disagrees with `STATE.md`. It also
+**diffs the manifest's layout tree against the spec's** (CONTRACT.md §1.1), so a dropped or
+invented zone is caught rather than silently built.
+
+## How to run
+
+1. **Precheck.** From the project directory, run:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/build.py" precheck "<project-dir>"
+   ```
+
+   (Use `python3` if `python` is unavailable.) If it prints `[BLOCKED]`, relay the reason and
+   **stop** — the analyst must resolve the named upstream step (`tableau-spec` for the spec,
+   `tableau-data` for the model and CSVs) first. Otherwise note its signals: the **spec path**
+   to build from, the **CSVs**, the **target Tableau version**, and the **manifest and
+   workbook paths** in the mock's `current_version` (build writes beside the spec it builds
+   from and never bumps the version).
+
+2. **Read the inputs.** Read `IMPLEMENTATION-SPEC.md` at the reported path — its Element
+   Mapping rows are the worksheets/objects to create and its `## Layout` JSON is the
+   container tree to copy. Read `DATA-MODEL.md` for the exact field names and types.
+
+3. **Author `build-manifest.json`** at the precheck's manifest path, following
+   `references/BUILD-MANIFEST-TEMPLATE.md`. Every mapping row becomes either a worksheet
+   (a view), an `objects` entry (a filter card / text / image zone), or an action (`int-*`
+   ids). When **refining** an existing manifest at this version, `Edit` it in place.
+
+4. **Validate, then present:**
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/build.py" validate "<project-dir>"
+   ```
+
+   If it prints `[INVALID]`, fix the named entries and re-run — do not generate a workbook
+   from a manifest that does not validate. When it prints `[OK]`, present the manifest
+   summary (worksheets, layout zones, actions) for approval.
+
+5. **Commit** — only after the analyst approves:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/build.py" commit "<project-dir>"
+   ```
+
+   Commit re-validates the manifest and records `build` = `approved`. If it prints
+   `[REFUSED]`, fix what it names and re-run. On success, tell the analyst the pipeline is
+   complete and where the deliverable lives.
+
+## Notes
+
+- **Non-skippable.** The workbook is the deliverable; `commit` only ever sets `approved`.
+- **Versioned deliverable.** The manifest and workbook live under `mock-version/<v_N>/`
+  beside the `mock.html` / `IMPLEMENTATION-SPEC.md` they were built from (CONTRACT.md §4.3).
+  Build **overwrites in place** on a re-run and never bumps `current_version`; a new build
+  version is created by re-running `tableau-mock` (which bumps and stales spec and build).
+- **In development.** The deterministic workbook generator (spec → `dashboard.twbx`) is the
+  next ticket; today the skill gates the step and produces the validated manifest it will
+  consume.
+
+> The full `STATE.md` schema and the ordering / staleness / versioning rules live in
+> `CONTRACT.md` at the repo root. This skill restates only its own slice; `build.py` /
+> `manifest.py` are the executable mirror of the contract it enforces.

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -1,0 +1,104 @@
+# build-manifest.json — the builder's only input
+
+Derived by the agent from `IMPLEMENTATION-SPEC.md` (constructs + layout tree) and
+`DATA-MODEL.md` (the fields). It is **build-internal**, not a handoff artifact — hence the
+lowercase name (CONTRACT.md §3) — and it lives beside the workbook in `mock-version/v_N/`.
+
+`build.py validate` schema-checks it fail-fast: every message names the offending entry, so
+a bad spec-to-manifest translation is fixed row-by-row before any XML is generated.
+
+## Sections
+
+| key | required | what it holds |
+|-----|----------|---------------|
+| `target_tableau_version` | yes | Copied verbatim from `STATE.md` — a mismatch is rejected. |
+| `datasources` | yes | One per `data/` CSV ("csv = datasource", CONTRACT.md §3.2). Every field must be documented in `DATA-MODEL.md` for that CSV. |
+| `worksheets` | yes | One per layout zone that is a **view**: unique `name`, a known `chart_type`, the `element_id` it fills, its `datasource`, and shelves/encodings whose fields resolve. |
+| `layout` | yes | The spec's `## Layout` container tree, copied as-is (canvas + nested `vert`/`horz` + id leaves with `%` sizes). |
+| `actions` | yes (`[]` if none) | Dashboard actions; `type` from `filter`/`highlight`/`parameter`/`set`/`url`. `source` is always a zone; a target is a zone for `filter`/`highlight`, a declared parameter for `parameter` (see below). |
+| `parameters` | yes (`[]` if none) | Each needs a `name` and a `data_type`. |
+| `objects` | optional | Layout zones no view fills — a filter card, title text, a logo, a legend. `kind` from `filter`/`parameter`/`text`/`image`/`legend`/`button`/`blank`. |
+| `calculated_fields` | optional | Fields that legitimately are not in the data model; declaring one makes it usable on a shelf of its `datasource`. |
+
+**Copy the `layout` tree from the spec verbatim** — `validate` diffs the two and rejects any
+zone the manifest drops or invents, so the workbook cannot disagree with the approved mock.
+
+**Every leaf zone must be filled** by exactly one worksheet or one `objects` entry — an
+unfilled zone would build an empty container. A *mapped container* (a node with both an `id`
+and `children`, e.g. a DZV panel) is filled by its children and needs no entry of its own.
+Interaction ids (`int-*`) are actions, not zones, and never appear in the tree.
+
+Chart types the builder emits: `bar`, `line`, `area`, `pie`, `scatter`, `map`, `text`,
+`table`, `heatmap`, `histogram`, `treemap`, `bullet`, `gantt`, `boxplot`.
+
+**Shelf and encoding entries** are either a bare field name (`"revenue"`) or an object
+carrying what the builder must apply: `{"field": "revenue", "aggregation": "sum"}` or
+`{"field": "order_date", "date_part": "month"}`. Aggregations: `sum`, `avg`, `min`, `max`,
+`count`, `countd`, `median`, `attr`, `none`. Never write an expression like
+`"SUM([revenue])"` — that is the spec's prose, not a field reference.
+
+**Action targets depend on the type**: `filter` / `highlight` target layout zones, a
+`parameter` action targets a declared parameter by name. The `source` is always a zone.
+
+## Example
+
+```json
+{
+  "target_tableau_version": "2024.2-2025.x",
+  "datasources": [
+    {
+      "name": "sales_orders",
+      "csv": "sales_orders.csv",
+      "fields": [
+        {"name": "order_date", "type": "date"},
+        {"name": "region", "type": "string"},
+        {"name": "revenue", "type": "real"}
+      ]
+    }
+  ],
+  "calculated_fields": [
+    {"name": "Revenue per Order", "formula": "SUM([revenue]) / COUNTD([order_id])",
+     "datasource": "sales_orders"}
+  ],
+  "worksheets": [
+    {
+      "name": "Revenue KPI",
+      "element_id": "kpi-revenue",
+      "chart_type": "text",
+      "datasource": "sales_orders",
+      "shelves": {"columns": [], "rows": []},
+      "encodings": {"text": "revenue"}
+    },
+    {
+      "name": "Revenue Trend",
+      "element_id": "chart-trend",
+      "chart_type": "line",
+      "datasource": "sales_orders",
+      "shelves": {
+        "columns": [{"field": "order_date", "date_part": "month"}],
+        "rows": [{"field": "revenue", "aggregation": "sum"}]
+      },
+      "encodings": {"color": "region"}
+    }
+  ],
+  "objects": [
+    {"element_id": "flt-region", "kind": "filter"}
+  ],
+  "layout": {
+    "canvas": {"width": 1366, "height": 768},
+    "root": {
+      "type": "vert",
+      "children": [
+        {"id": "flt-region", "size": 8},
+        {"id": "kpi-revenue", "size": 22},
+        {"id": "chart-trend", "size": 70}
+      ]
+    }
+  },
+  "actions": [
+    {"name": "Region cross-filter", "type": "filter", "source": "chart-trend",
+     "targets": ["kpi-revenue"], "run_on": "select"}
+  ],
+  "parameters": []
+}
+```

--- a/skills/tableau-build/scripts/build.py
+++ b/skills/tableau-build/scripts/build.py
@@ -1,0 +1,699 @@
+"""Gate and commit the ``build`` step of the tableau-dashboard-plugin.
+
+This is the orchestration core of the ``tableau-build`` skill (CONTRACT.md step 8): the
+final, non-skippable step that turns the approved ``IMPLEMENTATION-SPEC.md`` plus
+``DATA-MODEL.md`` into a Replace-Data-Source-ready Tableau workbook. The manifest *schema*
+lives in :mod:`manifest`; this module owns the parts that touch ``STATE.md`` and the
+filesystem:
+
+1. **Entry gate** - build refuses to run until both required reads are present and their
+   producers resolved (CONTRACT.md §4.1): ``IMPLEMENTATION-SPEC.md`` at ``current_version``
+   (from ``spec``) - the construct-by-construct mapping - and ``DATA-MODEL.md`` +
+   ``data/*.csv`` (from ``data``) - the fields the workbook binds to.
+2. **Versioning** - build is a *deliverable* written under ``mock-version/v_N/`` beside the
+   mock and spec it was built from (CONTRACT.md §4.3). Per §4.3 only the leading deliverable
+   (``mock``) bumps ``current_version``; build writes into the mock's current version and
+   **overwrites in place** on a re-run.
+3. **STATE.md transition** - committing flips ``build`` to ``approved``. Build is the last
+   step, so there is nothing downstream to stale (§4.2 is a no-op here).
+
+The module is pure and stdlib-only (it does **not** import the router) so the contract test
+can call its functions directly, exactly like ``spec.py``. The CLI exposes ``precheck``
+(before authoring - reports the target ``v_N`` and the inputs), ``validate`` (the manifest
+schema check), and ``commit`` (after approval). Program output goes to stdout; diagnostics
+through ``logging``.
+
+Keep ``STEP_ORDER`` in lock-step with CONTRACT.md §1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from manifest import load_manifest, placed_layout_ids, validate_manifest
+
+logger = logging.getLogger(__name__)
+
+# --- Canonical constants (mirror of CONTRACT.md §1 / §3 / §4.3) --------------
+
+STATE_FILENAME = "STATE.md"
+DATA_MODEL_FILENAME = "DATA-MODEL.md"
+SPEC_FILENAME = "IMPLEMENTATION-SPEC.md"
+#: Build-internal, not a handoff artifact - hence lowercase (CONTRACT.md §3).
+MANIFEST_FILENAME = "build-manifest.json"
+WORKBOOK_FILENAME = "dashboard.twbx"
+VERSION_DIR = "mock-version"
+DATA_DIR = "data"
+SCAFFOLD_DATA_DIR = "scaffold/sample-data"
+
+#: Required reads that gate this step, and their producer steps (CONTRACT.md §4.1).
+SPEC_STEP = "spec"
+DATA_STEP = "data"
+
+#: This step.
+BUILD_STEP = "build"
+
+#: The 8 step names in canonical order (mirror of CONTRACT.md §1).
+STEP_ORDER: tuple[str, ...] = (
+    "init", "intake", "data", "brand", "plan", "mock", "spec", "build",
+)
+
+#: Statuses that satisfy the ordering gate - the producer step is "resolved" (§4.1).
+RESOLVED_STATUSES = frozenset({"approved", "skipped"})
+
+
+# --- STATE.md reading (shared shape with spec.py / route.py) -----------------
+
+def parse_statuses(text: str) -> dict[str, str]:
+    """Parse the per-step statuses out of a STATE.md manifest.
+
+    Parsing is tolerant (matching the router's parser): only genuine
+    ``| order | step | skill | status |`` rows whose step name is known contribute;
+    header, separator, and stray rows are ignored.
+
+    Args:
+        text: The full contents of a ``STATE.md`` file.
+
+    Returns:
+        A ``{step_name: status}`` mapping (both lower-cased).
+    """
+    statuses: dict[str, str] = {}
+    in_steps = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        if line.lower().startswith("## steps"):
+            in_steps = True
+            continue
+        if line.startswith("## "):  # any other section ends the Steps table
+            in_steps = False
+
+        if in_steps and line.startswith("|"):
+            cells = [cell.strip() for cell in line.strip("|").split("|")]
+            if len(cells) < 4:
+                continue
+            step_name, status = cells[1].lower(), cells[3].lower()
+            if step_name in STEP_ORDER:
+                statuses[step_name] = status
+    return statuses
+
+
+# Metadata lines build reads (never writes: only ``mock`` bumps current_version, §4.3).
+_CURRENT_VERSION_LINE = re.compile(r"^\s*-\s*current_version\s*:\s*(\S+)", re.MULTILINE)
+_TARGET_VERSION_LINE = re.compile(
+    r"^\s*-\s*target_tableau_version\s*:\s*([^\n#]+)", re.MULTILINE
+)
+
+
+def read_current_version(text: str) -> str:
+    """Read the ``current_version`` metadata value from STATE.md.
+
+    This is the version directory holding the mock and its spec, and where the workbook and
+    its manifest are written.
+
+    Args:
+        text: The full contents of a ``STATE.md`` file.
+
+    Returns:
+        The recorded version (e.g. ``"v_2"``), or ``"v_1"`` if no line is present.
+    """
+    match = _CURRENT_VERSION_LINE.search(text)
+    return match.group(1) if match else "v_1"
+
+
+def read_target_tableau_version(text: str) -> str:
+    """Read the ``target_tableau_version`` metadata value from STATE.md.
+
+    Captured at ``init`` and never re-asked (CONTRACT.md §2); it drives the workbook's
+    ``version`` attribute and any version-specific XML, and the manifest must carry it.
+
+    Args:
+        text: The full contents of a ``STATE.md`` file.
+
+    Returns:
+        The recorded target version, or ``""`` when the line is absent.
+    """
+    match = _TARGET_VERSION_LINE.search(text)
+    return match.group(1).strip() if match else ""
+
+
+# --- STATE.md rewriting (shared shape with spec.py / state.py) ---------------
+
+def _format_step_row(cells: list[str]) -> str:
+    """Render a Steps-table row with the canonical column widths (matches init/spec)."""
+    order, step, skill, status = cells[0], cells[1], cells[2], cells[3]
+    return f"| {order:<5} | {step:<6} | {skill:<14} | {status:<8} |"
+
+
+def apply_status_updates(text: str, updates: dict[str, str]) -> str:
+    """Rewrite the status cell of one or more Steps-table rows.
+
+    Only rows inside the ``## Steps`` table whose step name is a key in ``updates`` are
+    touched; every other line is preserved byte-for-byte. The trailing newline is kept.
+
+    Args:
+        text: The full ``STATE.md`` contents.
+        updates: ``{step_name: new_status}`` for the rows to rewrite (lower-cased).
+
+    Returns:
+        The updated ``STATE.md`` contents.
+    """
+    out_lines: list[str] = []
+    in_steps = False
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+
+        if stripped.lower().startswith("## steps"):
+            in_steps = True
+            out_lines.append(raw_line)
+            continue
+        if stripped.startswith("## "):  # any other section ends the Steps table
+            in_steps = False
+
+        if in_steps and stripped.startswith("|"):
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            if len(cells) >= 4 and cells[1].lower() in updates:
+                cells[3] = updates[cells[1].lower()]
+                out_lines.append(_format_step_row(cells))
+                continue
+
+        out_lines.append(raw_line)
+
+    result = "\n".join(out_lines)
+    if text.endswith("\n"):
+        result += "\n"
+    return result
+
+
+# --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
+
+def _sample_csvs(project_root: Path) -> list[str]:
+    """Return the CSVs backing the build, preferring ``data/`` over the demo scaffold.
+
+    Per CONTRACT.md §3.1 the csv read is satisfied by either the analyst's ``data/`` or the
+    ``scaffold/sample-data/`` demo example, so a demo run is never wrongly blocked.
+
+    Args:
+        project_root: The analyst's project directory.
+
+    Returns:
+        Project-relative CSV paths (empty when neither location holds one).
+    """
+    for directory in (DATA_DIR, SCAFFOLD_DATA_DIR):
+        found = sorted((project_root / directory).glob("*.csv"))
+        if found:
+            return [f"{directory}/{path.name}" for path in found]
+    return []
+
+
+def entry_gate_blocker(project_root: Path) -> Optional[str]:
+    """Return why build may not run yet, or ``None`` if it may.
+
+    Build refuses to run unless ``STATE.md`` exists and, for each required read
+    (CONTRACT.md §4.1): ``spec`` is resolved and ``IMPLEMENTATION-SPEC.md`` exists at
+    ``current_version``, and ``data`` is resolved with ``DATA-MODEL.md`` plus at least one
+    CSV on disk.
+
+    Args:
+        project_root: The analyst's project directory.
+
+    Returns:
+        A human-readable blocker message, or ``None`` when the gate is open.
+    """
+    state_path = project_root / STATE_FILENAME
+    if not state_path.exists():
+        return (
+            "No STATE.md found. Run 'tableau-init' first to scaffold the project "
+            "and initialize STATE.md before running 'tableau-build'."
+        )
+
+    text = state_path.read_text(encoding="utf-8-sig")
+    statuses = parse_statuses(text)
+    version = read_current_version(text)
+
+    spec_status = statuses.get(SPEC_STEP, "pending")
+    if spec_status not in RESOLVED_STATUSES:
+        return (
+            f"Step 'spec' is '{spec_status}', not resolved. Run 'tableau-spec' first; "
+            f"'tableau-build' builds from the spec's construct mapping instead of guessing."
+        )
+    if not (project_root / VERSION_DIR / version / SPEC_FILENAME).exists():
+        return (
+            f"'{VERSION_DIR}/{version}/{SPEC_FILENAME}' is missing on disk even though "
+            f"step 'spec' is '{spec_status}'. Re-run 'tableau-spec' to regenerate it."
+        )
+
+    data_status = statuses.get(DATA_STEP, "pending")
+    if data_status not in RESOLVED_STATUSES:
+        return (
+            f"Step 'data' is '{data_status}', not resolved. Run 'tableau-data' first; "
+            f"'tableau-build' binds every field to the documented data model."
+        )
+    if not (project_root / DATA_MODEL_FILENAME).exists():
+        return (
+            f"'{DATA_MODEL_FILENAME}' is missing on disk even though step 'data' is "
+            f"'{data_status}'. Re-run 'tableau-data' to regenerate it."
+        )
+    if not _sample_csvs(project_root):
+        return (
+            f"No CSV found in '{DATA_DIR}/' or '{SCAFFOLD_DATA_DIR}/' even though step "
+            f"'data' is '{data_status}'. Re-run 'tableau-data' to write the samples."
+        )
+    return None
+
+
+# --- precheck ----------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PrecheckResult:
+    """The state build needs before deriving a manifest.
+
+    Attributes:
+        can_run: True when the entry gate is open (spec + data resolved, artifacts present).
+        blocker: Why build cannot run, when ``can_run`` is False; else ``None``.
+        version: The ``current_version`` dir holding the mock/spec, built into in place.
+        spec_path: ``mock-version/<version>/IMPLEMENTATION-SPEC.md`` (the constructs to build).
+        data_model_path: ``DATA-MODEL.md`` (the field authority).
+        csv_paths: The CSVs backing the workbook (``data/`` or the scaffold demo).
+        manifest_path: ``mock-version/<version>/build-manifest.json`` (what to author).
+        workbook_path: ``mock-version/<version>/dashboard.twbx`` (the deliverable).
+        manifest_exists: Whether a manifest already exists (refine vs. derive fresh).
+        target_tableau_version: STATE.md's target version, which the manifest must carry.
+    """
+
+    can_run: bool
+    blocker: Optional[str]
+    version: str
+    spec_path: str
+    data_model_path: str
+    csv_paths: list[str]
+    manifest_path: str
+    workbook_path: str
+    manifest_exists: bool
+    target_tableau_version: str
+
+
+def precheck(project_dir: Path | str) -> PrecheckResult:
+    """Report whether build may run, what it reads, and where it writes.
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`PrecheckResult`. When the entry gate is closed, ``can_run`` is False and
+        ``blocker`` explains why; the other fields are placeholders.
+    """
+    project_root = Path(project_dir)
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return PrecheckResult(False, blocker, "v_1", "", "", [], "", "", False, "")
+
+    text = (project_root / STATE_FILENAME).read_text(encoding="utf-8-sig")
+    version = read_current_version(text)
+    manifest_rel = f"{VERSION_DIR}/{version}/{MANIFEST_FILENAME}"
+
+    return PrecheckResult(
+        can_run=True,
+        blocker=None,
+        version=version,
+        spec_path=f"{VERSION_DIR}/{version}/{SPEC_FILENAME}",
+        data_model_path=DATA_MODEL_FILENAME,
+        csv_paths=_sample_csvs(project_root),
+        manifest_path=manifest_rel,
+        workbook_path=f"{VERSION_DIR}/{version}/{WORKBOOK_FILENAME}",
+        manifest_exists=(project_root / manifest_rel).exists(),
+        target_tableau_version=read_target_tableau_version(text),
+    )
+
+
+# --- Spec reconciliation (CONTRACT.md §1.1) ----------------------------------
+# The spec's Layout section is the mock's geometry, machine-checked at step 7. The manifest
+# must carry *that* tree, not a re-derived one, so the workbook cannot silently disagree
+# with the approved spec. These three patterns mirror tableau-spec's reconcile.py; the
+# skills are self-contained (CONTRACT.md §7) and cannot import each other.
+_LAYOUT_HEADING = re.compile(r"^##\s+Layout\b.*$", re.MULTILINE)
+_NEXT_SECTION = re.compile(r"^##\s", re.MULTILINE)
+_FENCED_BLOCK = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
+
+
+def spec_layout(spec_text: str) -> Optional[dict]:
+    """Return the layout object from the spec's ``## Layout`` fenced JSON block.
+
+    Args:
+        spec_text: The contents of an ``IMPLEMENTATION-SPEC.md``.
+
+    Returns:
+        The parsed layout (``canvas`` + ``root``), or ``None`` when the spec has no
+        parseable Layout JSON block.
+    """
+    heading = _LAYOUT_HEADING.search(spec_text)
+    if heading is None:
+        return None
+    section = spec_text[heading.end():]
+    next_section = _NEXT_SECTION.search(section)
+    if next_section is not None:
+        section = section[: next_section.start()]
+    block = _FENCED_BLOCK.search(section)
+    if block is None:
+        return None
+    try:
+        layout = json.loads(block.group(1))
+    except json.JSONDecodeError:
+        return None
+    return layout if isinstance(layout, dict) else None
+
+
+def _normalized_node(node: object) -> object:
+    """Reduce a layout node to the geometry that must survive the copy into the manifest.
+
+    Args:
+        node: A layout node (or anything, when the tree is malformed).
+
+    Returns:
+        A hashable ``(id, type, size, children)`` tuple, ``None`` for a non-object node.
+        Sizes are rounded to 2 decimals so re-serialised floats still compare equal.
+    """
+    if not isinstance(node, dict):
+        return None
+    size = node.get("size")
+    numeric_size = (
+        round(float(size), 2)
+        if isinstance(size, (int, float)) and not isinstance(size, bool) else None
+    )
+    children = node.get("children")
+    return (
+        str(node.get("id", "")).strip(),
+        str(node.get("type", "")).strip(),
+        numeric_size,
+        tuple(_normalized_node(child) for child in children)
+        if isinstance(children, list) else None,
+    )
+
+
+def spec_layout_errors(spec_text: str, manifest_document: dict) -> list[str]:
+    """Check the manifest's layout tree against the approved spec's.
+
+    Args:
+        spec_text: The contents of the approved ``IMPLEMENTATION-SPEC.md``.
+        manifest_document: The parsed build manifest.
+
+    Returns:
+        A list of error messages naming the dropped/invented zones, or reporting a geometry
+        that differs; empty when the manifest carries the spec's tree.
+    """
+    from_spec = spec_layout(spec_text)
+    if from_spec is None:
+        return [
+            f"'{SPEC_FILENAME}' has no parseable '## Layout' JSON block - the manifest's "
+            f"layout must come from the spec. Re-run 'tableau-spec' to regenerate it."
+        ]
+
+    spec_ids = placed_layout_ids(from_spec)
+    manifest_layout = manifest_document.get("layout")
+    manifest_ids = placed_layout_ids(manifest_layout)
+
+    errors: list[str] = []
+    dropped = sorted(spec_ids - manifest_ids)
+    if dropped:
+        errors.append(
+            "layout drops zone(s) the spec places: " + ", ".join(dropped)
+            + f" (copy the '## Layout' tree from {SPEC_FILENAME})"
+        )
+    invented = sorted(manifest_ids - spec_ids)
+    if invented:
+        errors.append(
+            "layout places zone(s) the spec does not: " + ", ".join(invented)
+            + f" (copy the '## Layout' tree from {SPEC_FILENAME})"
+        )
+    if errors:
+        return errors
+
+    # Same zones, but the geometry (canvas, sizes, nesting, orientation) must match too -
+    # it is the mock's geometry the spec carried here for exactly this reason (§1.1).
+    if not isinstance(manifest_layout, dict):
+        return ["layout: must be the spec's layout object ('canvas' + 'root')"]
+    if manifest_layout.get("canvas") != from_spec.get("canvas"):
+        errors.append(
+            f"layout canvas {manifest_layout.get('canvas')} differs from the spec's "
+            f"{from_spec.get('canvas')} - copy the '## Layout' tree from {SPEC_FILENAME}"
+        )
+    if _normalized_node(manifest_layout.get("root")) != _normalized_node(
+        from_spec.get("root")
+    ):
+        errors.append(
+            f"layout geometry differs from the spec's approved tree (sizes, nesting, or "
+            f"vert/horz orientation) - copy the '## Layout' tree from {SPEC_FILENAME} "
+            f"verbatim rather than re-deriving it"
+        )
+    return errors
+
+
+# --- validate ----------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Outcome of validating the build manifest on disk.
+
+    Attributes:
+        ok: True when the manifest parses and every schema check passes.
+        errors: The fail-fast messages, each naming the offending entry.
+        version: The version directory the manifest was read from.
+        manifest_path: Project-relative path of the manifest that was validated.
+    """
+
+    ok: bool
+    errors: list[str]
+    version: str
+    manifest_path: str
+
+
+def validate(project_dir: Path | str) -> ValidationResult:
+    """Validate ``build-manifest.json`` at ``current_version``.
+
+    Two checks: the schema (:func:`manifest.validate_manifest`, against ``DATA-MODEL.md``
+    and STATE.md's target version) and the reconciliation against the approved spec
+    (:func:`spec_layout_errors`, so the manifest carries the spec's container tree rather
+    than a re-derived one).
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`ValidationResult`; ``ok`` is False when the entry gate is closed, the
+        manifest is missing/unparseable, or any check fails.
+    """
+    project_root = Path(project_dir)
+    blocker = entry_gate_blocker(project_root)
+    if blocker is not None:
+        return ValidationResult(False, [blocker], "v_1", "")
+
+    text = (project_root / STATE_FILENAME).read_text(encoding="utf-8-sig")
+    version = read_current_version(text)
+    manifest_rel = f"{VERSION_DIR}/{version}/{MANIFEST_FILENAME}"
+
+    document, load_error = load_manifest(project_root / manifest_rel)
+    if document is None:
+        return ValidationResult(False, [load_error or ""], version, manifest_rel)
+
+    errors = validate_manifest(
+        document,
+        (project_root / DATA_MODEL_FILENAME).read_text(encoding="utf-8-sig"),
+        read_target_tableau_version(text),
+    )
+    errors += spec_layout_errors(
+        (project_root / VERSION_DIR / version / SPEC_FILENAME).read_text(
+            encoding="utf-8-sig"
+        ),
+        document,
+    )
+    return ValidationResult(not errors, errors, version, manifest_rel)
+
+
+# --- commit ------------------------------------------------------------------
+
+@dataclass
+class CommitResult:
+    """Outcome of committing the build step's result to STATE.md.
+
+    Attributes:
+        ok: True when STATE.md was updated; False when the commit was refused.
+        message: Human-readable explanation (the refusal reason when not ``ok``).
+        version: The version directory the (attempted) build lives in.
+        errors: Manifest validation errors that refused the commit, when any.
+        project_dir: The project the commit ran against (so the report can check what
+            actually landed on disk).
+    """
+
+    ok: bool
+    message: str
+    version: str = "v_1"
+    errors: list[str] = field(default_factory=list)
+    project_dir: str = "."
+
+
+def commit(project_dir: Path | str) -> CommitResult:
+    """Validate the manifest and approve the build step.
+
+    Build is non-skippable, so commit only ever sets ``approved``, and it is the last step,
+    so nothing downstream goes stale (§4.2). It writes into the mock's ``current_version``
+    and never bumps it (§4.3), so a re-run overwrites the same ``v_N`` in place.
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`CommitResult`. ``ok`` is False (STATE.md untouched) when the entry gate is
+        closed or the manifest is missing / invalid.
+    """
+    # TODO(builder ticket): once the deterministic builder lands, also require
+    # mock-version/<v_N>/dashboard.twbx to exist and pass XSD validation before approving.
+    project_root = Path(project_dir)
+    validation = validate(project_root)
+    if not validation.ok:
+        if not validation.manifest_path:  # entry gate closed
+            return CommitResult(False, validation.errors[0], validation.version)
+        return CommitResult(
+            False,
+            f"Cannot approve build: '{validation.manifest_path}' is missing or does not "
+            f"validate. Fix the entries named below and re-run commit.",
+            version=validation.version,
+            errors=validation.errors,
+        )
+
+    state_path = project_root / STATE_FILENAME
+    text = state_path.read_text(encoding="utf-8-sig")
+    state_path.write_text(
+        apply_status_updates(text, {BUILD_STEP: "approved"}), encoding="utf-8"
+    )
+
+    logger.info(f"Set build -> approved at {validation.version} (current_version untouched).")
+    return CommitResult(
+        ok=True,
+        message=f"build -> approved ({validation.version})",
+        version=validation.version,
+        project_dir=str(project_root),
+    )
+
+
+# --- CLI ---------------------------------------------------------------------
+
+def format_precheck(result: PrecheckResult) -> str:
+    """Render a :class:`PrecheckResult` as a human-readable, plain-ASCII block."""
+    # Plain ASCII only: this prints to a Windows cp1252 console, which would raise
+    # UnicodeEncodeError on emoji / box-drawing glyphs.
+    if not result.can_run:
+        return f"[BLOCKED] tableau-build cannot run.\n{result.blocker}"
+
+    lines = [
+        "[BUILD] precheck OK - tableau-build can run.",
+        f"  build from     : {result.spec_path}",
+        f"  fields from    : {result.data_model_path}",
+        f"  data           : {', '.join(result.csv_paths)}",
+        f"  target version : {result.target_tableau_version}",
+        f"  write manifest : {result.manifest_path}",
+        f"  workbook       : {result.workbook_path}",
+    ]
+    if result.manifest_exists:
+        lines.append(
+            "    -> a build-manifest.json already exists at this version; refine it in place."
+        )
+    lines.append(
+        "  the manifest is the builder's only input: datasources, worksheets "
+        "(chart type + shelves/encodings), the spec's layout tree, actions, parameters."
+    )
+    return "\n".join(lines)
+
+
+def format_validation(result: ValidationResult) -> str:
+    """Render a :class:`ValidationResult` as the fail-fast manifest report."""
+    # Plain ASCII only (see format_precheck).
+    if result.ok:
+        return f"[OK] {result.manifest_path} validates - every entry is buildable."
+    if not result.manifest_path:  # the entry gate is closed, not a bad manifest
+        return f"[BLOCKED] tableau-build cannot run.\n{result.errors[0]}"
+    lines = [f"[INVALID] {result.manifest_path}:"]
+    lines += [f"  - {error}" for error in result.errors]
+    lines.append("Fix the entries named above and re-run.")
+    return "\n".join(lines)
+
+
+def format_commit(result: CommitResult) -> str:
+    """Render a :class:`CommitResult` as a human-readable, plain-ASCII block."""
+    # Plain ASCII only (see format_precheck).
+    if not result.ok:
+        text = f"[REFUSED] {result.message}"
+        for error in result.errors:
+            text += f"\n  - {error}"
+        return text
+
+    lines = [
+        f"[BUILD] {result.message}.",
+        f"  manifest: {VERSION_DIR}/{result.version}/{MANIFEST_FILENAME} (validated)",
+    ]
+    workbook = Path(result.project_dir) / VERSION_DIR / result.version / WORKBOOK_FILENAME
+    if workbook.exists():
+        lines.append(f"  deliverable: {VERSION_DIR}/{result.version}/{WORKBOOK_FILENAME}")
+    else:
+        # The deterministic generator is the next ticket; say so rather than announcing a
+        # workbook that is not on disk.
+        lines.append(
+            f"  note: no {WORKBOOK_FILENAME} yet - the workbook generator is in development."
+        )
+    lines.append("  the pipeline is complete - run 'tableau-route' to confirm.")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point: run ``precheck``, ``validate``, or ``commit`` and print it.
+
+    Args:
+        argv: Argument list (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Process exit code: ``0`` on success, ``2`` when build is blocked/refused/invalid
+        or on a usage error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Gate, validate, and commit the tableau-build step.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for name, help_text in (
+        ("precheck", "Report whether build may run, what it reads, and where it writes."),
+        ("validate", "Schema-check the build manifest against DATA-MODEL.md and the layout."),
+        ("commit", "Approve the build in STATE.md (never bumps current_version)."),
+    ):
+        sub = subparsers.add_parser(name, help=help_text)
+        sub.add_argument(
+            "project_dir", nargs="?", default=".", help="Project directory (default: cwd)."
+        )
+
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    project_dir = Path(args.project_dir)
+
+    if args.command == "precheck":
+        precheck_result = precheck(project_dir)
+        print(format_precheck(precheck_result))
+        return 0 if precheck_result.can_run else 2
+
+    if args.command == "validate":
+        validation = validate(project_dir)
+        print(format_validation(validation))
+        return 0 if validation.ok else 2
+
+    commit_result = commit(project_dir)
+    print(format_commit(commit_result))
+    return 0 if commit_result.ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/tableau-build/scripts/manifest.py
+++ b/skills/tableau-build/scripts/manifest.py
@@ -1,0 +1,740 @@
+"""The build-manifest core of tableau-build (CONTRACT.md step 8).
+
+The **build manifest** is the machine-readable JSON an agent derives from
+``IMPLEMENTATION-SPEC.md`` + ``DATA-MODEL.md``, and the only thing the deterministic
+workbook builder reads. Putting a validated schema between the prose spec and the XML
+generator is what makes a bad spec-to-manifest translation fail **before** any XML exists:
+every error below names the offending entry (worksheet, field, element id) so the agent can
+fix that one row instead of re-deriving the whole manifest.
+
+The module is pure and stdlib-only (no filesystem beyond :func:`load_manifest`, no STATE.md)
+so the contract test can drive :func:`validate_manifest` directly.
+
+What a manifest carries, and what is checked:
+
+* ``target_tableau_version`` - must equal STATE.md's (CONTRACT.md §2).
+* ``datasources`` - one per ``data/`` CSV ("csv = datasource", §3.2); every declared field
+  must be documented in ``DATA-MODEL.md`` for that CSV.
+* ``worksheets`` - chart type from :data:`CHART_TYPES`, a unique name, an ``element_id`` that
+  occupies a zone in the layout tree, and shelf/encoding fields that resolve to a declared
+  field or a declared calculated field.
+* ``layout`` - the spec's container tree (CONTRACT.md §1.1), each *leaf* zone filled by a
+  worksheet or an ``objects`` entry (a mapped container is filled by its children instead).
+* ``actions`` / ``parameters`` - endpoints that exist, types from the shared interactions
+  vocabulary (§6).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+#: Sections a manifest must carry (actions/parameters may be empty lists, never absent -
+#: "None" must be said explicitly so a forgotten section is not mistaken for "no actions").
+REQUIRED_KEYS: tuple[str, ...] = (
+    "target_tableau_version", "datasources", "worksheets", "layout", "actions", "parameters",
+)
+
+#: Mark/chart types the builder knows how to emit. Add a type here only once the builder
+#: has a validated snippet for it - an unknown type must fail loudly, not build blank.
+CHART_TYPES = frozenset({
+    "bar", "line", "area", "pie", "scatter", "map", "text", "table",
+    "heatmap", "histogram", "treemap", "bullet", "gantt", "boxplot",
+})
+
+#: Dashboard action types (the Tableau constructs behind CONTRACT.md §6's vocabulary).
+ACTION_TYPES = frozenset({"filter", "highlight", "parameter", "set", "url"})
+
+#: Non-worksheet dashboard objects, for layout zones no view fills (a filter card, a title,
+#: a logo, a legend). Every *leaf* zone must be filled by a worksheet or one of these; a
+#: mapped container (see ``container_ids`` below) is filled by its children instead.
+OBJECT_KINDS = frozenset({"filter", "parameter", "text", "image", "legend", "button", "blank"})
+
+#: Valid container orientations in the layout tree (mirror of the spec's Layout section).
+CONTAINER_TYPES = frozenset({"vert", "horz"})
+
+#: Layout/mapping ids with this prefix are dashboard actions, not zones (plan convention).
+INTERACTION_PREFIX = "int-"
+
+#: Aggregations a shelf/encoding entry may request ("none" pins a dimension/exact value).
+AGGREGATIONS = frozenset({
+    "sum", "avg", "min", "max", "count", "countd", "median", "attr", "none",
+})
+
+#: Date parts a shelf/encoding entry may request of a date field.
+DATE_PARTS = frozenset({
+    "year", "quarter", "month", "week", "day", "hour", "minute", "date",
+})
+
+# A data-source heading in DATA-MODEL.md: "## Data source: `sales.csv`" -> "sales.csv".
+_DATASOURCE_HEADING = re.compile(
+    r"^#{1,6}\s+data source:\s*`?([^`\s|]+\.csv)`?\s*$", re.IGNORECASE
+)
+
+
+def documented_fields(data_model_text: str) -> dict[str, set[str]]:
+    """Recover ``{csv filename: {field name}}`` from a DATA-MODEL.md.
+
+    Only the field table's first column is needed here (types are the data step's
+    business); the parse is the tolerant mirror of ``tableau-data``'s renderer, so it keeps
+    working after the model enriches the Role/Description columns.
+
+    Args:
+        data_model_text: The contents of a ``DATA-MODEL.md`` file.
+
+    Returns:
+        A mapping of CSV filename to the set of field names documented for it.
+    """
+    documented: dict[str, set[str]] = {}
+    current: Optional[str] = None
+    in_field_table = False
+
+    for raw_line in data_model_text.splitlines():
+        line = raw_line.strip()
+        heading = _DATASOURCE_HEADING.match(line)
+        if heading:
+            current = heading.group(1)
+            documented.setdefault(current, set())
+            in_field_table = False
+            continue
+        if line.startswith("## "):  # a non-data-source section ends the current one
+            current = None
+            in_field_table = False
+            continue
+        if current is None:
+            continue
+        if not line.startswith("|"):
+            in_field_table = False  # a non-table line ends the field table
+            continue
+
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        name = cells[0] if cells else ""
+        # Only rows under a "| Field | Type |" header count: any other table in the section
+        # (a sample-rows preview, say) would otherwise donate its first column as fields.
+        if len(cells) >= 2 and name.lower() == "field" and cells[1].lower() == "type":
+            in_field_table = True
+            continue
+        if not in_field_table or not name or set(name) <= set("-: "):
+            continue  # separator row, or a table that is not the field table
+        documented[current].add(name)
+    return documented
+
+
+def load_manifest(path: Path | str) -> tuple[Optional[dict], Optional[str]]:
+    """Read and JSON-parse a build manifest.
+
+    Args:
+        path: Path to the ``build-manifest.json``.
+
+    Returns:
+        ``(document, None)`` on success, or ``(None, error message)`` when the file is
+        missing, unparseable, or not a JSON object. The message names the file so the
+        agent can fix it without a stack trace.
+    """
+    manifest_path = Path(path)
+    if not manifest_path.exists():
+        return None, f"'{manifest_path.name}' does not exist at '{manifest_path}'."
+    try:
+        document = json.loads(manifest_path.read_text(encoding="utf-8-sig"))
+    except json.JSONDecodeError as exc:
+        return None, f"'{manifest_path.name}' is not valid JSON: {exc}"
+    if not isinstance(document, dict):
+        return None, f"'{manifest_path.name}' must be a JSON object with the build sections."
+    return document, None
+
+
+# --- Layout tree --------------------------------------------------------------
+
+def _collect_layout_ids(
+    node: object, path: str, ids: list[str], container_ids: set[str], errors: list[str]
+) -> None:
+    """Walk one layout node, recording every placed id and any structural error.
+
+    A node is a container (``type`` + non-empty ``children``), a leaf (``id``), or both (a
+    **mapped container**, e.g. a DZV panel that is itself an element and holds further
+    zones - CONTRACT.md §1.1). A mapped container's id is recorded in ``container_ids``
+    because its children fill it; only *leaf* zones need a worksheet or object of their own.
+    Sibling ``size`` percentages were already reconciled against the mock by
+    ``tableau-spec``; here the tree only has to be structurally sound and consistent with
+    the worksheets.
+
+    Args:
+        node: The JSON value at this position in the tree.
+        path: Human-readable position (e.g. ``layout.root.children[1]``) for messages.
+        ids: Accumulator for placed element ids.
+        container_ids: Accumulator for the ids of nodes that hold children.
+        errors: Accumulator for validation errors.
+    """
+    if not isinstance(node, dict):
+        errors.append(f"{path}: every layout node must be a JSON object")
+        return
+
+    element_id, children = node.get("id"), node.get("children")
+    if element_id is None and children is None:
+        errors.append(f"{path}: a node needs an 'id' (leaf), 'children' (container), or both")
+        return
+    if isinstance(element_id, str) and element_id.strip():
+        placed = element_id.strip()
+        ids.append(placed)
+        if children is not None:
+            container_ids.add(placed)
+        if placed.startswith(INTERACTION_PREFIX):
+            errors.append(
+                f"{path}: interaction id '{placed}' occupies no zone - dashboard actions "
+                f"belong in 'actions', never in the layout tree (CONTRACT.md §1.1)"
+            )
+    elif element_id is not None:
+        errors.append(f"{path}: 'id' must be a non-empty string")
+
+    if children is None:
+        return
+    if node.get("type") not in CONTAINER_TYPES:
+        errors.append(
+            f"{path}: container 'type' must be 'vert' or 'horz' (got {node.get('type')!r})"
+        )
+    if not isinstance(children, list) or not children:
+        errors.append(f"{path}: 'children' must be a non-empty list")
+        return
+    for index, child in enumerate(children):
+        _collect_layout_ids(
+            child, f"{path}.children[{index}]", ids, container_ids, errors
+        )
+
+
+def placed_layout_ids(layout: object) -> set[str]:
+    """Return every element id a layout tree places, ignoring structural problems.
+
+    Used to compare a manifest's tree against the approved spec's (``build.py``); the
+    structural verdict comes from :func:`validate_manifest`.
+
+    Args:
+        layout: A layout object (``{"canvas": ..., "root": ...}``) or ``root`` itself.
+
+    Returns:
+        The placed element ids.
+    """
+    if not isinstance(layout, dict):
+        return set()
+    root = layout.get("root", layout)
+    ids: list[str] = []
+    _collect_layout_ids(root, "root", ids, set(), [])
+    return set(ids)
+
+
+def _validate_layout(layout: object, errors: list[str]) -> tuple[list[str], set[str]]:
+    """Validate the layout section and return what it places.
+
+    Args:
+        layout: The manifest's ``layout`` value.
+        errors: Accumulator for validation errors.
+
+    Returns:
+        ``(placed ids, container ids)``. A container id is filled by its children, so it
+        needs no worksheet or object of its own.
+    """
+    if not isinstance(layout, dict):
+        errors.append("layout: must be an object with 'canvas' and 'root' (copy the spec's)")
+        return [], set()
+
+    canvas = layout.get("canvas")
+    if not (
+        isinstance(canvas, dict)
+        and isinstance(canvas.get("width"), (int, float))
+        and isinstance(canvas.get("height"), (int, float))
+    ):
+        errors.append("layout.canvas: needs numeric 'width' and 'height' (the mock's px size)")
+
+    ids: list[str] = []
+    container_ids: set[str] = set()
+    if isinstance(layout.get("root"), dict):
+        _collect_layout_ids(layout["root"], "layout.root", ids, container_ids, errors)
+    else:
+        errors.append("layout.root: must be a container object ('type' + 'children')")
+
+    duplicates = sorted({placed for placed in ids if ids.count(placed) > 1})
+    if duplicates:
+        errors.append("layout places id(s) more than once: " + ", ".join(duplicates))
+    return ids, container_ids
+
+
+# --- Datasources / worksheets -------------------------------------------------
+
+def _bare_field(reference: object) -> str:
+    """Normalise a field reference to a bare name (``[revenue]`` -> ``revenue``)."""
+    return str(reference).strip().strip("[]").strip() if reference is not None else ""
+
+
+def _validate_datasources(
+    datasources: object, data_model_text: str, errors: list[str]
+) -> dict[str, set[str]]:
+    """Validate the datasources against DATA-MODEL.md.
+
+    Args:
+        datasources: The manifest's ``datasources`` value.
+        data_model_text: The contents of ``DATA-MODEL.md``.
+        errors: Accumulator for validation errors.
+
+    Returns:
+        ``{datasource name: {declared field names}}`` for the entries that parsed, so the
+        worksheet pass can resolve field references.
+    """
+    documented = documented_fields(data_model_text)
+    declared: dict[str, set[str]] = {}
+
+    if not isinstance(datasources, list) or not datasources:
+        errors.append("datasources: must be a non-empty list (one entry per data/ CSV)")
+        return declared
+
+    for index, source in enumerate(datasources):
+        label = f"datasources[{index}]"
+        if not isinstance(source, dict):
+            errors.append(f"{label}: must be an object with 'name', 'csv', 'fields'")
+            continue
+        name, csv_name = str(source.get("name", "")).strip(), str(source.get("csv", "")).strip()
+        label = f"datasources[{index}] '{name or '?'}'"
+        if not name:
+            errors.append(f"{label}: needs a 'name' (how worksheets refer to it)")
+            continue  # an unnamed source would register as '' and swallow bad references
+        if name in declared:
+            errors.append(f"{label}: duplicate datasource name '{name}'")
+            continue  # keep the first entry's fields; the duplicate is the bug to fix
+
+        if csv_name not in documented:
+            errors.append(
+                f"{label}: csv '{csv_name}' is not documented in DATA-MODEL.md "
+                f"(documented: {', '.join(sorted(documented)) or 'none'})"
+            )
+
+        fields = source.get("fields")
+        names: set[str] = set()
+        if not isinstance(fields, list) or not fields:
+            errors.append(f"{label}: 'fields' must be a non-empty list of {{name, type}}")
+        else:
+            for field_index, field in enumerate(fields):
+                if not isinstance(field, dict) or not str(field.get("name", "")).strip():
+                    errors.append(f"{label}: fields[{field_index}] needs a 'name'")
+                    continue
+                field_name = str(field["name"]).strip()
+                if not str(field.get("type", "")).strip():
+                    errors.append(f"{label}: field '{field_name}' needs a 'type'")
+                if csv_name in documented and field_name not in documented[csv_name]:
+                    errors.append(
+                        f"{label}: field '{field_name}' is not in DATA-MODEL.md for "
+                        f"'{csv_name}' (a calculated field belongs in 'calculated_fields')"
+                    )
+                names.add(field_name)
+        declared[name] = names
+    return declared
+
+
+def _calculated_field_names(
+    manifest_document: dict, datasource_names: set[str], errors: list[str]
+) -> dict[str, set[str]]:
+    """Validate the optional ``calculated_fields`` and index them by datasource.
+
+    Args:
+        manifest_document: The whole manifest.
+        datasource_names: The declared datasource names.
+        errors: Accumulator for validation errors.
+
+    Returns:
+        ``{datasource name: {calculated field names}}``.
+    """
+    calculated: dict[str, set[str]] = {}
+    entries = manifest_document.get("calculated_fields", [])
+    if not isinstance(entries, list):
+        errors.append("calculated_fields: must be a list of {name, formula, datasource}")
+        return calculated
+
+    for index, entry in enumerate(entries):
+        label = f"calculated_fields[{index}]"
+        if not isinstance(entry, dict):
+            errors.append(f"{label}: must be an object with 'name', 'formula', 'datasource'")
+            continue
+        name = str(entry.get("name", "")).strip()
+        if not name:
+            errors.append(f"{label}: needs a 'name'")
+            continue
+        if not str(entry.get("formula", "")).strip():
+            errors.append(f"{label} '{name}': needs a 'formula'")
+        source = str(entry.get("datasource", "")).strip()
+        if source not in datasource_names:
+            errors.append(f"{label} '{name}': unknown datasource '{source}'")
+            continue
+        calculated.setdefault(source, set()).add(name)
+    return calculated
+
+
+def _worksheet_field_references(worksheet: dict) -> list[tuple[str, object]]:
+    """Return the ``(where, entry)`` pairs a worksheet's shelves/encodings reference.
+
+    Each entry is either a bare field name (``"revenue"``) or an object carrying the
+    aggregation / date part the builder must apply
+    (``{"field": "revenue", "aggregation": "sum"}``).
+
+    Args:
+        worksheet: One ``worksheets`` entry.
+
+    Returns:
+        ``(where, entry)`` pairs, where ``where`` is e.g. ``shelves.rows`` / ``encodings.color``.
+    """
+    references: list[tuple[str, object]] = []
+    shelves = worksheet.get("shelves")
+    if isinstance(shelves, dict):
+        for shelf, entries in shelves.items():
+            for entry in entries if isinstance(entries, list) else [entries]:
+                references.append((f"shelves.{shelf}", entry))
+    encodings = worksheet.get("encodings")
+    if isinstance(encodings, dict):
+        for encoding, entry in encodings.items():
+            references.append((f"encodings.{encoding}", entry))
+    return references
+
+
+def _validate_reference(
+    label: str, where: str, entry: object, available: set[str], source: str,
+    errors: list[str],
+) -> None:
+    """Validate one shelf/encoding entry against a datasource's fields.
+
+    Args:
+        label: The worksheet's error label.
+        where: The shelf/encoding the entry sits on.
+        entry: The raw entry (a field name, or an object with ``field`` +
+            optional ``aggregation`` / ``date_part``).
+        available: Field names the worksheet's datasource offers (declared + calculated).
+        source: The datasource name, for the message.
+        errors: Accumulator for validation errors.
+    """
+    if isinstance(entry, dict):
+        field_name = _bare_field(entry.get("field"))
+        # A JSON null (or any other non-string) means "not specified", same as a missing
+        # key - never coerce it to a string, or `null` reads as the literal text "none".
+        raw_aggregation = entry.get("aggregation", "")
+        aggregation = raw_aggregation.strip().lower() if isinstance(raw_aggregation, str) else ""
+        raw_date_part = entry.get("date_part", "")
+        date_part = raw_date_part.strip().lower() if isinstance(raw_date_part, str) else ""
+    else:
+        field_name, aggregation, date_part = _bare_field(entry), "", ""
+
+    if not field_name:
+        errors.append(f"{label}: {where} entry needs a 'field'")
+        return
+    if "(" in field_name:
+        # e.g. "SUM([revenue])" copied verbatim out of the spec's construct cell.
+        errors.append(
+            f"{label}: {where} references '{field_name}' - name the field alone and put "
+            f"the aggregation in the entry, e.g. "
+            f'{{"field": "revenue", "aggregation": "sum"}}'
+        )
+        return
+    if field_name not in available:
+        errors.append(
+            f"{label}: {where} references '{field_name}', which is not a field of "
+            f"datasource '{source}' nor a declared calculated field"
+        )
+    if aggregation and aggregation not in AGGREGATIONS:
+        errors.append(
+            f"{label}: {where} '{field_name}' has unknown aggregation '{aggregation}' "
+            f"(expected one of: {', '.join(sorted(AGGREGATIONS))})"
+        )
+    if date_part and date_part not in DATE_PARTS:
+        errors.append(
+            f"{label}: {where} '{field_name}' has unknown date_part '{date_part}' "
+            f"(expected one of: {', '.join(sorted(DATE_PARTS))})"
+        )
+
+
+def _validate_worksheets(
+    worksheets: object,
+    declared_fields: dict[str, set[str]],
+    calculated: dict[str, set[str]],
+    layout_ids: set[str],
+    container_ids: set[str],
+    errors: list[str],
+) -> set[str]:
+    """Validate the worksheets against the datasources and the layout tree.
+
+    Args:
+        worksheets: The manifest's ``worksheets`` value.
+        declared_fields: ``{datasource: {field}}`` from :func:`_validate_datasources`.
+        calculated: ``{datasource: {calculated field}}``.
+        layout_ids: The element ids the layout tree places.
+        container_ids: Mapped-container ids (filled by their children, not a view of
+            their own - CONTRACT.md §1.1).
+        errors: Accumulator for validation errors.
+
+    Returns:
+        The element ids the worksheets fill.
+    """
+    filled: set[str] = set()
+    if not isinstance(worksheets, list) or not worksheets:
+        errors.append("worksheets: must be a non-empty list (one per mock zone that is a view)")
+        return filled
+
+    seen_names: set[str] = set()
+    for index, worksheet in enumerate(worksheets):
+        label = f"worksheets[{index}]"
+        if not isinstance(worksheet, dict):
+            errors.append(f"{label}: must be an object")
+            continue
+        name = str(worksheet.get("name", "")).strip()
+        label = f"worksheets[{index}] '{name or '?'}'"
+        if not name:
+            errors.append(f"{label}: needs a 'name' (the Tableau sheet name)")
+        elif name in seen_names:
+            errors.append(f"{label}: duplicate worksheet name '{name}'")
+        seen_names.add(name)
+
+        chart_type = str(worksheet.get("chart_type", "")).strip().lower()
+        if chart_type not in CHART_TYPES:
+            errors.append(
+                f"{label}: unknown chart_type '{chart_type}' "
+                f"(expected one of: {', '.join(sorted(CHART_TYPES))})"
+            )
+
+        element_id = str(worksheet.get("element_id", "")).strip()
+        if not element_id:
+            errors.append(f"{label}: needs an 'element_id' (the spec/layout zone it fills)")
+        elif element_id in container_ids:
+            errors.append(
+                f"{label}: element_id '{element_id}' is a mapped container - it is filled "
+                f"by its children, not by a view (CONTRACT.md §1.1)"
+            )
+        elif element_id not in layout_ids:
+            errors.append(
+                f"{label}: element_id '{element_id}' is not a zone in the layout tree"
+            )
+        else:
+            filled.add(element_id)
+
+        source = str(worksheet.get("datasource", "")).strip()
+        if source not in declared_fields:
+            errors.append(
+                f"{label}: unknown datasource '{source}' "
+                f"(declared: {', '.join(sorted(declared_fields)) or 'none'})"
+            )
+            continue
+
+        available = declared_fields[source] | calculated.get(source, set())
+        for where, entry in _worksheet_field_references(worksheet):
+            _validate_reference(label, where, entry, available, source, errors)
+    return filled
+
+
+def _validate_objects(
+    objects: object, layout_ids: set[str], container_ids: set[str], errors: list[str]
+) -> set[str]:
+    """Validate the non-worksheet dashboard objects and return the zones they fill.
+
+    Args:
+        objects: The manifest's optional ``objects`` value.
+        layout_ids: The element ids the layout tree places.
+        container_ids: Mapped-container ids (filled by their children, not an object of
+            their own - CONTRACT.md §1.1).
+        errors: Accumulator for validation errors.
+
+    Returns:
+        The element ids the objects fill.
+    """
+    filled: set[str] = set()
+    if not isinstance(objects, list):
+        errors.append("objects: must be a list of {element_id, kind}")
+        return filled
+
+    for index, dashboard_object in enumerate(objects):
+        label = f"objects[{index}]"
+        if not isinstance(dashboard_object, dict):
+            errors.append(f"{label}: must be an object with 'element_id' and 'kind'")
+            continue
+        element_id = str(dashboard_object.get("element_id", "")).strip()
+        label = f"objects[{index}] '{element_id or '?'}'"
+        if element_id in container_ids:
+            errors.append(
+                f"{label}: element_id is a mapped container - it is filled by its children, "
+                f"not by an object (CONTRACT.md §1.1)"
+            )
+        elif element_id not in layout_ids:
+            errors.append(f"{label}: element_id is not a zone in the layout tree")
+        else:
+            filled.add(element_id)
+
+        kind = str(dashboard_object.get("kind", "")).strip().lower()
+        if kind not in OBJECT_KINDS:
+            errors.append(
+                f"{label}: unknown kind '{kind}' "
+                f"(expected one of: {', '.join(sorted(OBJECT_KINDS))})"
+            )
+    return filled
+
+
+def _validate_actions(
+    actions: object, known_ids: set[str], parameter_names: set[str], errors: list[str]
+) -> None:
+    """Validate the dashboard actions' types and endpoints.
+
+    The **source** is always a zone (the view whose marks the analyst clicks). What a
+    **target** is depends on the type: ``filter`` / ``highlight`` target other zones, a
+    ``parameter`` action targets a declared parameter, and ``set`` / ``url`` actions target
+    a set / a URL that this schema does not model - those are left to the builder.
+
+    Args:
+        actions: The manifest's ``actions`` value.
+        known_ids: Element ids an action may point at (the layout's zones).
+        parameter_names: Declared parameter names (the targets of a parameter action).
+        errors: Accumulator for validation errors.
+    """
+    if not isinstance(actions, list):
+        errors.append("actions: must be a list (use [] when the dashboard has none)")
+        return
+
+    for index, action in enumerate(actions):
+        label = f"actions[{index}]"
+        if not isinstance(action, dict):
+            errors.append(f"{label}: must be an object with 'name', 'type', 'source', 'targets'")
+            continue
+        name = str(action.get("name", "")).strip()
+        label = f"actions[{index}] '{name or '?'}'"
+        if not name:
+            errors.append(f"{label}: needs a 'name'")
+
+        action_type = str(action.get("type", "")).strip().lower()
+        if action_type not in ACTION_TYPES:
+            errors.append(
+                f"{label}: unknown action type '{action_type}' "
+                f"(expected one of: {', '.join(sorted(ACTION_TYPES))})"
+            )
+
+        source = str(action.get("source", "")).strip()
+        if not source:
+            errors.append(f"{label}: needs a 'source' element id")
+        elif source not in known_ids:
+            errors.append(f"{label}: source '{source}' is not a zone in the layout tree")
+
+        targets = action.get("targets", [])
+        target_names = [
+            str(target).strip()
+            for target in (targets if isinstance(targets, list) else [targets])
+        ]
+        if not target_names:
+            errors.append(f"{label}: needs at least one 'targets' entry")
+        for target in target_names:
+            if not target:
+                errors.append(f"{label}: has an empty 'targets' entry")
+            elif action_type in {"filter", "highlight"} and target not in known_ids:
+                errors.append(
+                    f"{label}: target '{target}' is not a zone in the layout tree"
+                )
+            elif action_type == "parameter" and target not in parameter_names:
+                errors.append(
+                    f"{label}: target '{target}' is not a declared parameter "
+                    f"(declared: {', '.join(sorted(parameter_names)) or 'none'})"
+                )
+
+
+def _validate_parameters(parameters: object, errors: list[str]) -> set[str]:
+    """Validate the parameters' names, types, and uniqueness.
+
+    Args:
+        parameters: The manifest's ``parameters`` value.
+        errors: Accumulator for validation errors.
+
+    Returns:
+        The declared parameter names (what a parameter action may target).
+    """
+    seen: set[str] = set()
+    if not isinstance(parameters, list):
+        errors.append("parameters: must be a list (use [] when the dashboard has none)")
+        return seen
+
+    for index, parameter in enumerate(parameters):
+        label = f"parameters[{index}]"
+        if not isinstance(parameter, dict):
+            errors.append(f"{label}: must be an object with 'name' and 'data_type'")
+            continue
+        name = str(parameter.get("name", "")).strip()
+        label = f"parameters[{index}] '{name or '?'}'"
+        if not name:
+            errors.append(f"{label}: needs a 'name'")
+        elif name in seen:
+            errors.append(f"{label}: duplicate parameter name '{name}'")
+        seen.add(name)
+        if not str(parameter.get("data_type", "")).strip():
+            errors.append(f"{label}: needs a 'data_type' (string/integer/real/boolean/date)")
+    return seen
+
+
+def validate_manifest(
+    manifest_document: dict, data_model_text: str, target_tableau_version: str
+) -> list[str]:
+    """Validate a build manifest against the data model and the project's target version.
+
+    Every message names the offending entry (worksheet, field, element id) so a bad
+    spec-to-manifest translation is fixed row-by-row instead of re-derived.
+
+    Args:
+        manifest_document: The parsed ``build-manifest.json``.
+        data_model_text: The contents of ``DATA-MODEL.md`` (the field authority).
+        target_tableau_version: STATE.md's ``target_tableau_version`` (CONTRACT.md §2).
+
+    Returns:
+        A list of error messages; empty when the manifest is buildable.
+    """
+    errors: list[str] = []
+    missing = [key for key in REQUIRED_KEYS if key not in manifest_document]
+    if missing:
+        errors.append(f"missing required section(s): {', '.join(missing)}")
+
+    declared_version = str(manifest_document.get("target_tableau_version", "")).strip()
+    if not declared_version:
+        errors.append(
+            f"target_tableau_version: missing - copy STATE.md's '{target_tableau_version}' "
+            f"(it drives the workbook's version attribute)"
+        )
+    elif declared_version != target_tableau_version:
+        errors.append(
+            f"target_tableau_version '{declared_version}' does not match STATE.md's "
+            f"'{target_tableau_version}' - copy STATE.md's value"
+        )
+
+    layout_ids, container_ids = _validate_layout(manifest_document.get("layout"), errors)
+    zone_ids = {
+        element_id for element_id in layout_ids
+        if not element_id.startswith(INTERACTION_PREFIX)
+    }
+    # A mapped container (a DZV panel, say) is filled by its children, not by a view of
+    # its own - only leaf zones need a worksheet or an objects entry.
+    leaf_zone_ids = zone_ids - container_ids
+
+    declared_fields = _validate_datasources(
+        manifest_document.get("datasources"), data_model_text, errors
+    )
+    calculated = _calculated_field_names(
+        manifest_document, set(declared_fields), errors
+    )
+    filled = _validate_worksheets(
+        manifest_document.get("worksheets"), declared_fields, calculated, zone_ids,
+        container_ids, errors
+    )
+
+    filled |= _validate_objects(
+        manifest_document.get("objects", []), zone_ids, container_ids, errors
+    )
+
+    # A leaf zone nothing fills would build an empty container - the spec mapped it to
+    # something, so the translation dropped it.
+    unfilled = sorted(leaf_zone_ids - filled)
+    if unfilled:
+        errors.append(
+            "layout zone(s) that nothing fills: " + ", ".join(unfilled)
+            + " (add a worksheet with that element_id, or an 'objects' entry for a "
+            "filter card / text / image zone)"
+        )
+
+    parameter_names = _validate_parameters(manifest_document.get("parameters", []), errors)
+    _validate_actions(
+        manifest_document.get("actions", []), zone_ids, parameter_names, errors
+    )
+    return errors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ _SKILL_SCRIPT_DIRS = (
     _REPO_ROOT / "skills" / "tableau-plan" / "scripts",
     _REPO_ROOT / "skills" / "tableau-mock" / "scripts",
     _REPO_ROOT / "skills" / "tableau-spec" / "scripts",
+    _REPO_ROOT / "skills" / "tableau-build" / "scripts",
 )
 
 for _script_dir in _SKILL_SCRIPT_DIRS:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,778 @@
+"""Contract test for tableau-build (CONTRACT.md step 8, §4.1, §4.3).
+
+``tableau-build`` turns the approved ``IMPLEMENTATION-SPEC.md`` + ``DATA-MODEL.md`` into a
+Tableau workbook. The XML generation is the next ticket; what this test pins is the
+skeleton the builder stands on, split across the two modules:
+
+* :mod:`manifest` (pure core) - the **build manifest**: the machine-readable JSON an agent
+  derives from the spec + data model that the deterministic builder consumes. Validation is
+  fail-fast and names the offending entry, so a bad spec-to-manifest translation is caught
+  before any XML is generated.
+* :mod:`build` (orchestration) - the entry gate (§4.1: ``spec`` and ``data`` resolved with
+  their artifacts on disk) and the STATE.md transition (``build`` -> ``approved``, never
+  touching ``current_version``, overwriting in the current ``v_N``, §4.3).
+"""
+
+import json
+from pathlib import Path
+
+import build  # the orchestration under test
+import init  # builds a realistic STATE.md the same way a real project would
+import manifest  # the pure manifest-schema core (on sys.path via conftest.py)
+import route  # the router parses/routes the STATE.md build writes
+
+TARGET_VERSION = "2024.2-2025.x"
+
+DATA_MODEL = """# Data Model
+
+## Acquisition
+
+- tier: csv (provided in data/)
+
+## Data source: `sales_orders.csv`
+
+| Field | Type | Role | Sample values | Description |
+|-------|------|------|---------------|-------------|
+| order_date | date | dimension | 2024-01-05 | Order date |
+| region | string | dimension | West | Sales region |
+| revenue | real | measure | 1200.5 | Order revenue |
+"""
+
+def _layout(children=None) -> dict:
+    """The spec's container tree, as the manifest carries it."""
+    return {
+        "canvas": {"width": 1366, "height": 768},
+        "root": {
+            "type": "vert",
+            "children": children or [
+                {"id": "kpi-revenue", "size": 20},
+                {"id": "chart-trend", "size": 80},
+            ],
+        },
+    }
+
+
+def _spec_md(layout=None) -> str:
+    """An IMPLEMENTATION-SPEC.md whose '## Layout' tree the manifest must carry (§1.1)."""
+    return (
+        "# Implementation Spec: Sales\n\n"
+        "## Element Mapping\n\n"
+        "| id | tableau construct | justification |\n"
+        "|----|-------------------|---------------|\n"
+        "| kpi-revenue | Text mark, SUM([revenue]) | - |\n"
+        "| chart-trend | Line mark: MONTH([order_date]) x SUM([revenue]) | - |\n\n"
+        "## Layout\n\nA vert stack.\n\n"
+        f"```json\n{json.dumps(layout or _layout(), indent=2)}\n```\n"
+    )
+
+
+SPEC = _spec_md()
+
+
+def _manifest(**overrides) -> dict:
+    """A valid build manifest for the DATA_MODEL / SPEC pair above."""
+    document = {
+        "target_tableau_version": TARGET_VERSION,
+        "datasources": [
+            {
+                "name": "sales_orders",
+                "csv": "sales_orders.csv",
+                "fields": [
+                    {"name": "order_date", "type": "date"},
+                    {"name": "region", "type": "string"},
+                    {"name": "revenue", "type": "real"},
+                ],
+            }
+        ],
+        "worksheets": [
+            {
+                "name": "Revenue KPI",
+                "element_id": "kpi-revenue",
+                "chart_type": "text",
+                "datasource": "sales_orders",
+                "shelves": {"rows": [], "columns": []},
+                "encodings": {"text": "revenue"},
+            },
+            {
+                "name": "Revenue Trend",
+                "element_id": "chart-trend",
+                "chart_type": "line",
+                "datasource": "sales_orders",
+                "shelves": {"columns": ["order_date"], "rows": ["revenue"]},
+                "encodings": {"color": "region"},
+            },
+        ],
+        "layout": _layout(),
+        "actions": [],
+        "parameters": [],
+    }
+    document.update(overrides)
+    return document
+
+
+def _errors(document=None, **overrides) -> list[str]:
+    """Validate a manifest against the DATA_MODEL and return the error messages."""
+    return manifest.validate_manifest(
+        _manifest(**overrides) if document is None else document,
+        DATA_MODEL,
+        TARGET_VERSION,
+    )
+
+
+def _state_with(project_dir: Path, **status_overrides: str) -> None:
+    """Write a canonical STATE.md, optionally overriding some step statuses."""
+    text = init.render_state_md(TARGET_VERSION)
+    if status_overrides:
+        text = build.apply_status_updates(text, dict(status_overrides))
+    (project_dir / "STATE.md").write_text(text, encoding="utf-8")
+
+
+def _write_spec(project_dir: Path, version: str = "v_1", text: str = SPEC) -> None:
+    """Write ``text`` to ``mock-version/<version>/IMPLEMENTATION-SPEC.md``."""
+    version_dir = project_dir / build.VERSION_DIR / version
+    version_dir.mkdir(parents=True, exist_ok=True)
+    (version_dir / build.SPEC_FILENAME).write_text(text, encoding="utf-8")
+
+
+def _write_manifest(project_dir: Path, document: dict, version: str = "v_1") -> None:
+    """Write ``document`` to ``mock-version/<version>/build-manifest.json``."""
+    version_dir = project_dir / build.VERSION_DIR / version
+    version_dir.mkdir(parents=True, exist_ok=True)
+    (version_dir / build.MANIFEST_FILENAME).write_text(
+        json.dumps(document, indent=2), encoding="utf-8"
+    )
+
+
+def _ready_project(project_dir: Path, **status_overrides: str) -> None:
+    """Open build's entry gate: spec+data resolved with all three artifacts on disk."""
+    _state_with(project_dir, **{"spec": "approved", "data": "approved", **status_overrides})
+    (project_dir / "DATA-MODEL.md").write_text(DATA_MODEL, encoding="utf-8")
+    data_dir = project_dir / "data"
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / "sales_orders.csv").write_text(
+        "order_date,region,revenue\n2024-01-05,West,1200.5\n", encoding="utf-8"
+    )
+    _write_spec(project_dir)
+
+
+# --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
+
+def test_precheck_blocks_when_no_state(tmp_path):
+    """No STATE.md => build cannot run; the blocker points at tableau-init."""
+    result = build.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "tableau-init" in result.blocker
+
+
+def test_precheck_blocks_when_spec_not_resolved(tmp_path):
+    """spec must be resolved before build runs, and the blocker names it (§4.1)."""
+    _ready_project(tmp_path, spec="pending")
+
+    result = build.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "spec" in result.blocker and "pending" in result.blocker
+    assert "tableau-spec" in result.blocker
+
+
+def test_precheck_blocks_when_spec_file_missing(tmp_path):
+    """Even with spec approved, a missing IMPLEMENTATION-SPEC.md at current_version blocks."""
+    _ready_project(tmp_path)
+    (tmp_path / build.VERSION_DIR / "v_1" / build.SPEC_FILENAME).unlink()
+
+    result = build.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert build.SPEC_FILENAME in result.blocker
+
+
+def test_precheck_blocks_when_data_not_resolved(tmp_path):
+    """data must be resolved too - the manifest's fields come from DATA-MODEL.md (§4.1)."""
+    _ready_project(tmp_path, data="pending")
+
+    result = build.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "data" in result.blocker and "tableau-data" in result.blocker
+
+
+def test_precheck_blocks_when_data_model_missing(tmp_path):
+    """A missing DATA-MODEL.md blocks even when data is approved (§4.1)."""
+    _ready_project(tmp_path)
+    (tmp_path / "DATA-MODEL.md").unlink()
+
+    result = build.precheck(tmp_path)
+
+    assert result.can_run is False
+    assert "DATA-MODEL.md" in result.blocker
+
+
+def test_precheck_accepts_scaffold_sample_data(tmp_path):
+    """The csv read is satisfied by scaffold/sample-data/ too (CONTRACT.md §3.1)."""
+    _ready_project(tmp_path)
+    (tmp_path / "data" / "sales_orders.csv").unlink()
+    scaffold = tmp_path / "scaffold" / "sample-data"
+    scaffold.mkdir(parents=True)
+    (scaffold / "sales_orders.csv").write_text("region\nWest\n", encoding="utf-8")
+
+    assert build.precheck(tmp_path).can_run is True
+
+
+def test_precheck_reports_target_version_dir(tmp_path):
+    """precheck surfaces the v_N it builds into and the paths it reads/writes."""
+    _state_with(tmp_path, spec="approved", data="approved")
+    (tmp_path / "STATE.md").write_text(
+        (tmp_path / "STATE.md").read_text(encoding="utf-8").replace(
+            "current_version: v_1", "current_version: v_3"
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "DATA-MODEL.md").write_text(DATA_MODEL, encoding="utf-8")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "sales_orders.csv").write_text("region\nWest\n", encoding="utf-8")
+    _write_spec(tmp_path, "v_3")
+
+    result = build.precheck(tmp_path)
+
+    assert result.can_run is True
+    assert result.version == "v_3"
+    assert result.spec_path == "mock-version/v_3/IMPLEMENTATION-SPEC.md"
+    assert result.manifest_path == "mock-version/v_3/build-manifest.json"
+    assert result.workbook_path == "mock-version/v_3/dashboard.twbx"
+    assert result.target_tableau_version == TARGET_VERSION
+    assert result.manifest_exists is False
+
+
+# --- Manifest schema (manifest.py) -------------------------------------------
+
+def test_valid_manifest_has_no_errors():
+    """The happy path: a manifest consistent with the data model and layout validates."""
+    assert _errors() == []
+
+
+def test_missing_top_level_key_is_rejected():
+    """Every required section must be present - the message names the missing key."""
+    document = _manifest()
+    del document["worksheets"]
+
+    errors = _errors(document)
+
+    assert any("worksheets" in error for error in errors)
+
+
+def test_target_version_must_match_state():
+    """The manifest's target version is STATE.md's; a mismatch is a translation bug."""
+    errors = _errors(target_tableau_version="2026.1+")
+
+    assert any("2026.1+" in error and "2024.2-2025.x" in error for error in errors)
+
+
+def test_unknown_chart_type_names_the_worksheet():
+    """An unknown chart type is rejected with the offending worksheet named."""
+    document = _manifest()
+    document["worksheets"][1]["chart_type"] = "donut"
+
+    errors = _errors(document)
+
+    assert any("Revenue Trend" in error and "donut" in error for error in errors)
+
+
+def test_element_id_not_in_layout_tree_is_rejected():
+    """Every worksheet must occupy a zone in the layout tree, named when it does not."""
+    document = _manifest()
+    document["worksheets"][1]["element_id"] = "chart-ghost"
+
+    errors = _errors(document)
+
+    assert any("chart-ghost" in error and "layout" in error.lower() for error in errors)
+
+
+def test_layout_zone_without_a_worksheet_is_rejected():
+    """A zone in the tree that no worksheet fills would build an empty container."""
+    document = _manifest()
+    document["layout"]["root"]["children"].append({"id": "chart-orphan", "size": 0.1})
+
+    errors = _errors(document)
+
+    assert any("chart-orphan" in error for error in errors)
+
+
+def test_object_zone_fills_a_non_worksheet_zone():
+    """Not every zone is a view - a filter card / text zone is declared under 'objects'."""
+    document = _manifest()
+    document["layout"]["root"]["children"].insert(0, {"id": "flt-region", "size": 10})
+    document["objects"] = [{"element_id": "flt-region", "kind": "filter"}]
+
+    assert _errors(document) == []
+
+
+def test_unknown_object_kind_is_rejected():
+    """An object kind the builder cannot emit is named with its zone."""
+    document = _manifest()
+    document["layout"]["root"]["children"].insert(0, {"id": "flt-region", "size": 10})
+    document["objects"] = [{"element_id": "flt-region", "kind": "hologram"}]
+
+    errors = _errors(document)
+
+    assert any("hologram" in error and "flt-region" in error for error in errors)
+
+
+def test_field_not_in_the_data_model_is_rejected():
+    """A datasource field absent from DATA-MODEL.md is named with its source."""
+    document = _manifest()
+    document["datasources"][0]["fields"].append({"name": "margin", "type": "real"})
+
+    errors = _errors(document)
+
+    assert any("margin" in error and "sales_orders.csv" in error for error in errors)
+
+
+def test_shelf_field_not_declared_is_rejected():
+    """A shelf/encoding referencing an undeclared field names the worksheet and field."""
+    document = _manifest()
+    document["worksheets"][1]["shelves"]["rows"] = ["profit"]
+
+    errors = _errors(document)
+
+    assert any("profit" in error and "Revenue Trend" in error for error in errors)
+
+
+def test_calculated_field_may_back_a_shelf():
+    """Calculated fields are legitimately absent from the data model - declare and use."""
+    document = _manifest()
+    document["calculated_fields"] = [
+        {"name": "Profit Ratio", "formula": "SUM([revenue]) / 2", "datasource": "sales_orders"}
+    ]
+    document["worksheets"][1]["shelves"]["rows"] = ["Profit Ratio"]
+
+    assert _errors(document) == []
+
+
+def test_unknown_datasource_reference_is_rejected():
+    """A worksheet pointing at an undeclared datasource is named."""
+    document = _manifest()
+    document["worksheets"][0]["datasource"] = "inventory"
+
+    errors = _errors(document)
+
+    assert any("inventory" in error and "Revenue KPI" in error for error in errors)
+
+
+def test_csv_not_in_the_data_model_is_rejected():
+    """A datasource whose csv the data model does not document is named."""
+    document = _manifest()
+    document["datasources"][0]["csv"] = "orders.csv"
+
+    errors = _errors(document)
+
+    assert any("orders.csv" in error for error in errors)
+
+
+def test_duplicate_worksheet_names_are_rejected():
+    """Worksheet names are the workbook's keys - duplicates are ambiguous."""
+    document = _manifest()
+    document["worksheets"][1]["name"] = "Revenue KPI"
+
+    errors = _errors(document)
+
+    assert any("Revenue KPI" in error and "duplicate" in error.lower() for error in errors)
+
+
+def test_action_endpoints_must_be_known_elements():
+    """An action whose source/target is not a mapped zone is named."""
+    document = _manifest()
+    document["actions"] = [
+        {"name": "Cross-filter", "type": "filter", "source": "chart-nope",
+         "targets": ["chart-trend"]}
+    ]
+
+    errors = _errors(document)
+
+    assert any("chart-nope" in error and "Cross-filter" in error for error in errors)
+
+
+def test_unknown_action_type_is_rejected():
+    """Action types are the vocabulary of CONTRACT.md §6 - anything else is a typo."""
+    document = _manifest()
+    document["actions"] = [
+        {"name": "Weird", "type": "teleport", "source": "chart-trend",
+         "targets": ["kpi-revenue"]}
+    ]
+
+    errors = _errors(document)
+
+    assert any("teleport" in error and "Weird" in error for error in errors)
+
+
+def test_parameter_needs_a_name_and_data_type():
+    """A parameter without a data type cannot be emitted - it is named by index."""
+    document = _manifest()
+    document["parameters"] = [{"name": "Measure"}]
+
+    errors = _errors(document)
+
+    assert any("Measure" in error and "data_type" in error for error in errors)
+
+
+def test_malformed_layout_tree_is_rejected():
+    """The layout tree must be containers and id leaves - a bad node is located."""
+    document = _manifest()
+    document["layout"]["root"]["type"] = "diagonal"
+
+    errors = _errors(document)
+
+    assert any("diagonal" in error for error in errors)
+
+
+def test_mapped_container_is_filled_by_its_children():
+    """A mapped container (a DZV panel holding zones) needs no view of its own (§1.1)."""
+    document = _manifest()
+    document["layout"] = _layout([
+        {"id": "kpi-revenue", "size": 20},
+        {"id": "pnl-detail", "type": "horz", "size": 80,
+         "children": [{"id": "chart-trend", "size": 100}]},
+    ])
+
+    assert _errors(document) == []
+
+
+def test_worksheet_claiming_a_mapped_container_is_rejected():
+    """A container id is filled by its children - a worksheet cannot claim it too (§1.1)."""
+    document = _manifest()
+    document["layout"] = _layout([
+        {"id": "kpi-revenue", "size": 20},
+        {"id": "pnl-detail", "type": "horz", "size": 80,
+         "children": [{"id": "chart-trend", "size": 100}]},
+    ])
+    document["worksheets"].append({
+        "name": "Detail Panel", "element_id": "pnl-detail", "chart_type": "text",
+        "datasource": "sales_orders", "shelves": {"rows": ["revenue"]},
+    })
+
+    errors = _errors(document)
+
+    assert any(
+        "pnl-detail" in error and "filled by its children" in error for error in errors
+    )
+    assert not any("not a zone in the layout tree" in error and "pnl-detail" in error
+                   for error in errors)
+
+
+def test_object_claiming_a_mapped_container_is_rejected():
+    """Same rule for an 'objects' entry - a container needs no object of its own (§1.1)."""
+    document = _manifest()
+    document["layout"] = _layout([
+        {"id": "kpi-revenue", "size": 20},
+        {"id": "pnl-detail", "type": "horz", "size": 80,
+         "children": [{"id": "chart-trend", "size": 100}]},
+    ])
+    document["objects"] = [{"element_id": "pnl-detail", "kind": "legend"}]
+
+    errors = _errors(document)
+
+    assert any(
+        "pnl-detail" in error and "filled by its children" in error for error in errors
+    )
+
+
+def test_null_date_part_is_not_silently_rejected():
+    """A JSON null must not coerce to the string 'none' - which is not a valid date_part,
+    so it would otherwise fail with the confusing "unknown date_part 'none'" (the same
+    ``str(None).lower()`` coercion bug affects 'aggregation', where it goes unnoticed only
+    because 'none' happens to already be a valid aggregation value)."""
+    document = _manifest()
+    document["worksheets"][1]["shelves"]["columns"] = [
+        {"field": "order_date", "date_part": None}
+    ]
+
+    assert _errors(document) == []
+
+
+def test_interaction_id_in_the_layout_tree_is_rejected():
+    """Actions occupy no zone, so an int-* id in the tree is a translation bug (§1.1)."""
+    document = _manifest()
+    document["layout"]["root"]["children"].append({"id": "int-cross-filter", "size": 0.1})
+
+    errors = _errors(document)
+
+    assert any("int-cross-filter" in error for error in errors)
+
+
+def test_parameter_action_targets_a_parameter_not_a_zone():
+    """A parameter action targets a declared parameter - not every action targets a zone."""
+    document = _manifest()
+    document["parameters"] = [
+        {"name": "Measure", "data_type": "string", "allowed_values": ["Revenue"]}
+    ]
+    document["actions"] = [
+        {"name": "Pick measure", "type": "parameter", "source": "chart-trend",
+         "targets": ["Measure"]}
+    ]
+
+    assert _errors(document) == []
+
+
+def test_parameter_action_with_an_undeclared_target_is_rejected():
+    """The parameter it drives must exist, or the action cannot be emitted."""
+    document = _manifest()
+    document["actions"] = [
+        {"name": "Pick measure", "type": "parameter", "source": "chart-trend",
+         "targets": ["Measure"]}
+    ]
+
+    errors = _errors(document)
+
+    assert any("Measure" in error and "parameter" in error for error in errors)
+
+
+def test_missing_target_version_is_rejected():
+    """The builder needs the workbook version attribute - blank is not "matches"."""
+    errors = _errors(target_tableau_version="")
+
+    assert any("target_tableau_version" in error for error in errors)
+
+
+def test_shelf_entry_may_carry_an_aggregation():
+    """Shelves take a bare field or a {field, aggregation, date_part} entry."""
+    document = _manifest()
+    document["worksheets"][1]["shelves"] = {
+        "columns": [{"field": "order_date", "date_part": "month"}],
+        "rows": [{"field": "revenue", "aggregation": "sum"}],
+    }
+
+    assert _errors(document) == []
+
+
+def test_aggregated_expression_on_a_shelf_is_rejected_with_the_fix():
+    """A construct copied verbatim ('SUM([revenue])') is named, with the entry to use."""
+    document = _manifest()
+    document["worksheets"][1]["shelves"]["rows"] = ["SUM([revenue])"]
+
+    errors = _errors(document)
+
+    assert any("SUM([revenue])" in error and "aggregation" in error for error in errors)
+
+
+def test_unknown_aggregation_is_rejected():
+    """An aggregation the builder cannot emit is named with its field."""
+    document = _manifest()
+    document["worksheets"][1]["shelves"]["rows"] = [
+        {"field": "revenue", "aggregation": "geomean"}
+    ]
+
+    errors = _errors(document)
+
+    assert any("geomean" in error and "revenue" in error for error in errors)
+
+
+def test_duplicate_datasource_keeps_the_first_fields():
+    """A duplicate name is reported once, without corrupting field resolution."""
+    document = _manifest()
+    document["datasources"].append({
+        "name": "sales_orders", "csv": "sales_orders.csv",
+        "fields": [{"name": "region", "type": "string"}],
+    })
+
+    errors = _errors(document)
+
+    assert any("duplicate" in error.lower() for error in errors)
+    # The first entry's fields still resolve: no spurious "not a field" on good worksheets.
+    assert not any("not a field" in error for error in errors)
+
+
+def test_unnamed_datasource_does_not_swallow_bad_references():
+    """An unnamed datasource must not register as '' and absorb worksheet references."""
+    document = _manifest()
+    document["datasources"][0]["name"] = ""
+    document["worksheets"][0]["datasource"] = ""
+
+    errors = _errors(document)
+
+    assert any("needs a 'name'" in error for error in errors)
+    assert any("Revenue KPI" in error and "unknown datasource ''" in error for error in errors)
+
+
+def test_documented_fields_reads_a_rendered_data_model():
+    """Pin the coupling to tableau-data's renderer, not just a hand-written fixture."""
+    import datamodel  # tableau-data's stdlib-only core (on sys.path via conftest.py)
+
+    profile = datamodel.CsvProfile(
+        filename="sales_orders.csv",
+        row_count=1,
+        fields=[
+            datamodel.FieldProfile("region", "string", "dimension", ["West"], ""),
+            datamodel.FieldProfile("revenue", "real", "measure", ["10.5"], ""),
+        ],
+    )
+    rendered = datamodel.render_data_model([profile], "csv (provided in data/)")
+
+    assert manifest.documented_fields(rendered) == {
+        "sales_orders.csv": {"region", "revenue"}
+    }
+
+
+def test_a_stray_table_does_not_donate_field_names():
+    """Only the "| Field | Type |" table counts - a sample-rows preview must not."""
+    with_preview = DATA_MODEL + (
+        "\n| order_date | region |\n|---|---|\n| 2024-01-05 | West |\n"
+    )
+
+    assert "2024-01-05" not in manifest.documented_fields(with_preview)["sales_orders.csv"]
+
+
+def test_load_manifest_reports_bad_json(tmp_path):
+    """Unparseable JSON fails fast with the file named, not a stack trace."""
+    path = tmp_path / build.MANIFEST_FILENAME
+    path.write_text("{not json", encoding="utf-8")
+
+    document, error = manifest.load_manifest(path)
+
+    assert document is None and build.MANIFEST_FILENAME in error
+
+
+# --- Reconciliation with the approved spec (CONTRACT.md §1.1) ----------------
+
+def test_validate_accepts_the_specs_layout_tree(tmp_path):
+    """The happy path through the CLI-level validate: manifest carries the spec's tree."""
+    _ready_project(tmp_path)
+    _write_manifest(tmp_path, _manifest())
+
+    result = build.validate(tmp_path)
+
+    assert result.ok is True and result.errors == []
+    assert result.manifest_path == "mock-version/v_1/build-manifest.json"
+
+
+def test_validate_rejects_a_layout_that_drops_a_spec_zone(tmp_path):
+    """A re-derived tree that loses a zone would build a dashboard the analyst never saw."""
+    _ready_project(tmp_path)
+    document = _manifest()
+    document["layout"] = _layout([{"id": "chart-trend", "size": 100}])
+    document["worksheets"] = [document["worksheets"][1]]
+    _write_manifest(tmp_path, document)
+
+    result = build.validate(tmp_path)
+
+    assert result.ok is False
+    assert any("kpi-revenue" in error and "drops" in error for error in result.errors)
+
+
+def test_validate_rejects_a_layout_that_invents_a_zone(tmp_path):
+    """A zone the spec never placed is equally a translation bug."""
+    _ready_project(tmp_path)
+    document = _manifest()
+    document["layout"]["root"]["children"].append({"id": "chart-extra", "size": 10})
+    document["worksheets"].append({
+        "name": "Extra", "element_id": "chart-extra", "chart_type": "bar",
+        "datasource": "sales_orders", "shelves": {"rows": ["revenue"]},
+    })
+    _write_manifest(tmp_path, document)
+
+    result = build.validate(tmp_path)
+
+    assert result.ok is False
+    assert any("chart-extra" in error for error in result.errors)
+
+
+def test_validate_rejects_a_layout_with_matching_zones_but_different_geometry(tmp_path):
+    """Same zone ids as the spec, but a sibling's 'size' differs - the geometry must match too."""
+    _ready_project(tmp_path)
+    document = _manifest()
+    document["layout"] = _layout([
+        {"id": "kpi-revenue", "size": 50},  # spec has 20/80, not 50/50
+        {"id": "chart-trend", "size": 50},
+    ])
+    _write_manifest(tmp_path, document)
+
+    result = build.validate(tmp_path)
+
+    assert result.ok is False
+    assert any("geometry differs" in error for error in result.errors)
+
+
+def test_validate_blocked_gate_reports_the_blocker(tmp_path):
+    """validate on a closed gate reports the upstream step, not a manifest complaint."""
+    result = build.validate(tmp_path)
+
+    assert result.ok is False and "tableau-init" in result.errors[0]
+
+
+# --- STATE.md transition (CONTRACT.md §4.3) ----------------------------------
+
+def test_commit_refuses_without_a_manifest(tmp_path):
+    """No manifest => nothing to build; STATE.md is untouched."""
+    _ready_project(tmp_path)
+
+    result = build.commit(tmp_path)
+
+    assert result.ok is False
+    assert build.MANIFEST_FILENAME in result.message
+    assert route.parse_state(tmp_path / "STATE.md").statuses["build"] == "pending"
+
+
+def test_commit_refuses_an_invalid_manifest(tmp_path):
+    """An invalid manifest blocks approval and reports the offending entry."""
+    _ready_project(tmp_path)
+    document = _manifest()
+    document["worksheets"][1]["chart_type"] = "donut"
+    _write_manifest(tmp_path, document)
+
+    result = build.commit(tmp_path)
+
+    assert result.ok is False
+    assert any("donut" in error for error in result.errors)
+    assert route.parse_state(tmp_path / "STATE.md").statuses["build"] == "pending"
+
+
+def test_commit_approves_and_leaves_current_version_alone(tmp_path):
+    """A valid manifest approves build in place - current_version is never bumped (§4.3)."""
+    _ready_project(tmp_path)
+    _write_manifest(tmp_path, _manifest())
+
+    result = build.commit(tmp_path)
+
+    assert result.ok is True and result.version == "v_1"
+    state = route.parse_state(tmp_path / "STATE.md")
+    assert state.statuses["build"] == "approved"
+    assert state.current_version == "v_1"
+
+
+def test_recommit_overwrites_in_place(tmp_path):
+    """Re-running build after approval overwrites the same v_N; no new version dir (§4.3)."""
+    _ready_project(tmp_path)
+    _write_manifest(tmp_path, _manifest())
+    build.commit(tmp_path)
+
+    result = build.commit(tmp_path)
+
+    assert result.ok is True and result.version == "v_1"
+    assert route.parse_state(tmp_path / "STATE.md").current_version == "v_1"
+    assert sorted(p.name for p in (tmp_path / build.VERSION_DIR).iterdir()) == ["v_1"]
+
+
+def test_commit_from_stale_reapproves_the_same_version(tmp_path):
+    """The realistic re-run: mock bumped and staled build, which rebuilds into that v_N."""
+    _ready_project(tmp_path, build="stale")
+    _write_manifest(tmp_path, _manifest())
+
+    result = build.commit(tmp_path)
+
+    assert result.ok is True and result.version == "v_1"
+    assert route.parse_state(tmp_path / "STATE.md").statuses["build"] == "approved"
+
+
+def test_router_reports_done_after_build_is_approved(tmp_path):
+    """Cross-check through the router: build approved completes the pipeline."""
+    _ready_project(tmp_path, intake="approved", brand="skipped", plan="approved",
+                   mock="approved")
+    (tmp_path / "DASHBOARD-PLAN.md").write_text("# Plan\n", encoding="utf-8")
+    (tmp_path / build.VERSION_DIR / "v_1" / "mock.html").write_text(
+        "<html></html>", encoding="utf-8"
+    )
+    _write_manifest(tmp_path, _manifest())
+
+    assert build.commit(tmp_path).ok is True
+
+    assert route.compute_next_step(tmp_path).is_done is True


### PR DESCRIPTION
## Summary
- Adds the `tableau-build` skill (step 8): entry gate (`spec`+`data` resolved, CONTRACT.md §4.1), the build-manifest schema validator (`manifest.py`), spec-layout reconciliation, and the `STATE.md` commit (`build -> approved`, never bumps `current_version`, §4.3).
- Closes out the three residual findings from two prior review rounds: a worksheet/object could claim a mapped-container's `element_id`; a JSON `null` aggregation/date_part coerced to the confusing string `"none"`; stale "every zone" prose across `manifest.py`, `BUILD-MANIFEST-TEMPLATE.md`, and `CONTRACT.md`.
- Strengthens a test that passed for the wrong reason, and adds a missing test for the layout-geometry check.
- Amends `CONTRACT.md` §1.1/§3 to document the "mapped container" node shape and the build-internal artifact category the code already relies on.

## Test plan
- [x] `python -m pytest -q` — 271 passed
- [x] `/code-review` (Standards + Spec axes) run over the full diff

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)