### PR TITLE
feat(build): deterministic core assembler - datasources, windows, .twbx, legacy validators

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -152,11 +152,13 @@ The case of a filename encodes its role, so a skill can tell handoff artifacts f
   under `scaffold/` (see §3.1).
 
 **Build-internal files** are the third, narrow category: lowercase files a skill writes for
-its *own* next stage, never read by another skill. Today there is exactly one —
+its *own* next stage, never read by another skill. Today there are two, both `tableau-build`'s:
 `mock-version/v_N/build-manifest.json`, the machine-readable translation of
-`IMPLEMENTATION-SPEC.md` + `DATA-MODEL.md` that `tableau-build`'s workbook generator
-consumes. Because nothing downstream reads it, it is not a handoff and takes the lowercase
-casing; it is versioned with the deliverable it produces (§4.3). A skill may add one only
+`IMPLEMENTATION-SPEC.md` + `DATA-MODEL.md` that the workbook generator consumes; and
+`mock-version/v_N/dashboard.twb`, the unpackaged workbook the two validators read before it is
+zipped into the deliverable `.twbx` (it stays on disk after a failed build so the XML can be
+inspected). Because nothing downstream reads them, they are not handoffs and take the lowercase
+casing; they are versioned with the deliverable they produce (§4.3). A skill may add one only
 for a stage boundary inside itself.
 
 New artifacts MUST follow this rule. Do not introduce a lowercase handoff, an UPPER-KEBAB
@@ -280,7 +282,7 @@ Two kinds of outputs, two storage strategies:
   current copy. Re-running one of these skills updates the root file and triggers staleness (§4.2);
   it does **not** create a new version directory.
 - **Deliverables = standalone versioned copies.** `mock.html`, `IMPLEMENTATION-SPEC.md`, and
-  `dashboard.twbx` (plus build's internal `build-manifest.json`, §3) are written under
+  `dashboard.twbx` (plus build's internal `build-manifest.json` and `dashboard.twb`, §3) are written under
   `mock-version/v_N/`, all three deliverables sharing the **same** `v_N`
   directory. A version is anchored by its **mock**: `mock.html` is the leading deliverable, and
   **only `tableau-mock` bumps `current_version`**. Re-running `tableau-mock` after its step was

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Each step is owned by exactly one skill, reads a known set of artifacts, and wri
 | 5 | `tableau-plan`   | Blueprint: screen size, slots, KPIs, charts, filters, interactions (stable ids) | `DATA-MODEL.md` (+ `PRD.md`, `DESIGN-TOKENS.md`) → `DASHBOARD-PLAN.md` | no |
 | 6 | `tableau-mock`   | Interactive HTML demo from real sample data | `DASHBOARD-PLAN.md`, `data/*.csv` → `mock-version/v_N/mock.html` | no |
 | 7 | `tableau-spec`   | Map every mock element to a concrete Tableau construct | `mock.html`, `DASHBOARD-PLAN.md` → `mock-version/v_N/IMPLEMENTATION-SPEC.md` | no |
-| 8 | `tableau-build` *(in development)* | Generate the version-aware, XSD-validated workbook | `IMPLEMENTATION-SPEC.md`, `DATA-MODEL.md`, `data/*.csv` → `mock-version/v_N/dashboard.twbx` | no |
+| 8 | `tableau-build` *(views in development)* | Generate the version-aware, XSD-validated workbook | `IMPLEMENTATION-SPEC.md`, `DATA-MODEL.md`, `data/*.csv` → `mock-version/v_N/dashboard.twbx` | no |
 
 > **`tableau-route`** is the compass, not a step: it reads `STATE.md` and reports the single next skill to run. It only recommends — it never runs another skill for you.
 
-> **Status — step 8 is not shipped yet.** Steps 1–7 (`init` → `spec`) are available today; `tableau-build` is in active development and releasing shortly. Tableau has announced a **native skill** for generating a workbook from a spec — when it ships we intend to integrate it as the build step rather than maintain a parallel generator, so the exact shape of step 8 may change.
+> **Status — step 8 is landing in pieces.** Steps 1–7 (`init` → `spec`) are complete. `tableau-build` today derives and validates the build manifest and assembles a workbook that Tableau opens: datasources (live, with the CSVs packaged into the `.twbx`), a dashboard sized from the approved mock, windows, and version targeting, checked by both validators on every build. The worksheet bodies (shelves, encodings, marks) and the dashboard's zone tree are the remaining piece, so the views are still empty. Tableau has announced a **native skill** for generating a workbook from a spec — when it ships we intend to integrate it as the build step rather than maintain a parallel generator, so the exact shape of step 8 may change.
 
 Skippable steps (`intake`, `brand`) let you go straight from a scaffolded project to planning with sensible fallbacks (the raw request text; neutral styling).
 
@@ -145,7 +145,7 @@ If you used the old single skill: the workflow now lives in this plugin. Install
 - **No box shadows** — not natively supported in Tableau.
 - **Container hierarchy** must follow Tableau's zone model (layout-basic → layout-flow → sheets).
 - **Fallback-driven choices are disclosed** — when a skill uses a Tableau default for missing input, it says so.
-- **`tableau-build` is in development** — the workbook-generation step is not shipped yet (see the status note above); when available, always review the generated workbook in Tableau Desktop before publishing.
+- **`tableau-build` still emits empty views** — the workbook it produces opens cleanly and carries the data, but the shelves/encodings are the remaining piece (see the status note above); always review the generated workbook in Tableau Desktop before publishing.
 
 ## Contributing
 

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -22,10 +22,13 @@ field, or element id named.
 | **Entry gate** | Refuses to run until `spec` is resolved **and** `IMPLEMENTATION-SPEC.md` exists at `current_version`, **and** `data` is resolved **and** `DATA-MODEL.md` plus at least one CSV exist (CONTRACT.md §4.1). |
 | **Next step** | None — the pipeline is complete (`tableau-route` confirms). |
 
-The mechanical guarantees — the entry gate, the manifest schema validation, and the STATE.md
-transition — live in `build.py` (CLI) and `manifest.py` (the schema core). Your job is the
-judgment part: translating each spec row into the right manifest entry. Run the script at
-the points below; do not hand-edit `STATE.md`.
+The mechanical guarantees live in Python: the entry gate, the manifest schema validation and
+the STATE.md transition in `build.py` / `manifest.py`, and the XML itself in `twb.py` — the
+element order, the generated ids, the four places every column must appear, the live-only
+connection and the version targeting are **code, not a checklist**, so a validated manifest
+builds a workbook that is correct by construction. Your job is the judgment part: translating
+each spec row into the right manifest entry. Run the script at the points below; do not
+hand-edit `STATE.md` or the generated XML.
 
 ## The build manifest
 
@@ -78,15 +81,30 @@ invented zone is caught rather than silently built.
    from a manifest that does not validate. When it prints `[OK]`, present the manifest
    summary (worksheets, layout zones, actions) for approval.
 
-5. **Commit** — only after the analyst approves:
+5. **Build the workbook:**
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/build.py" build "<project-dir>"
+   ```
+
+   This assembles `dashboard.twb`, runs both validators over it, and packages
+   `dashboard.twbx` with the CSVs. `[BUILT]` means both validators are green — a `[WARN]`
+   line about a missing `explain-data` element is the expected version shift when the target
+   is `2024.2-2025.x` (the 2026.1 schema requires an element that older Tableau must not
+   carry), not a problem. `[INVALID]` leaves the `.twb` on disk unpackaged: read the named
+   errors, fix the manifest, and re-run. Never hand-patch the generated XML — the assembler
+   is the fix's home.
+
+6. **Commit** — only after the analyst approves:
 
    ```bash
    python "${CLAUDE_SKILL_DIR}/scripts/build.py" commit "<project-dir>"
    ```
 
-   Commit re-validates the manifest and records `build` = `approved`. If it prints
-   `[REFUSED]`, fix what it names and re-run. On success, tell the analyst the pipeline is
-   complete and where the deliverable lives.
+   Commit re-validates the manifest, refuses unless `dashboard.twbx` is on disk (run step 5
+   first), and records `build` = `approved`. If it prints `[REFUSED]`, fix what it names and
+   re-run. On success, tell the analyst the pipeline is complete and where the deliverable
+   lives.
 
 ## Notes
 
@@ -95,10 +113,13 @@ invented zone is caught rather than silently built.
   beside the `mock.html` / `IMPLEMENTATION-SPEC.md` they were built from (CONTRACT.md §4.3).
   Build **overwrites in place** on a re-run and never bumps `current_version`; a new build
   version is created by re-running `tableau-mock` (which bumps and stales spec and build).
-- **In development.** The deterministic workbook generator (spec → `dashboard.twbx`) is the
-  next ticket; today the skill gates the step and produces the validated manifest it will
-  consume.
+- **Live connection, always.** The workbook never carries an extract: the `.twbx` embeds the
+  CSVs, and the analyst points it at the real database with Data → Replace Data Source.
+- **Worksheet bodies are still coming.** Today's assembler emits the datasources, placeholder
+  worksheets, a dashboard sized from the mock's canvas, and the windows. Shelves, encodings,
+  marks and the dashboard's zone tree are the next ticket, so the built workbook opens
+  clean but the views are empty.
 
 > The full `STATE.md` schema and the ordering / staleness / versioning rules live in
-> `CONTRACT.md` at the repo root. This skill restates only its own slice; `build.py` /
-> `manifest.py` are the executable mirror of the contract it enforces.
+> `CONTRACT.md` at the repo root. This skill restates only its own slice; `build.py`,
+> `manifest.py` and `twb.py` are the executable mirror of the contract it enforces.

--- a/skills/tableau-build/references/xsd/twb_2026.1.0.xsd
+++ b/skills/tableau-build/references/xsd/twb_2026.1.0.xsd
@@ -1,0 +1,7586 @@
+<!--
+ Tableau Workbook Schema (TWB)
+ Version: 2026.1.0
+ Published: 2026-02-27T19:11:46Z
+ Build: 20261.26.0211.1127
+ This schema validates Tableau workbook (.twb) files for version 2026.1.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:user="http://www.tableausoftware.com/xml/user" elementFormDefault="qualified" version="2026.1.0">
+  <xs:annotation>
+    <xs:documentation>
+      Tableau Workbook Schema for version 2026.1
+      Publication Info:
+      - Generated: 2026-02-27T19:11:46Z
+      - Source Build: 20261.26.0211.1127
+      - Schema Version: 1.0
+    </xs:documentation>
+  </xs:annotation>
+<xs:import namespace="http://www.tableausoftware.com/xml/user" schemaLocation="user.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:attributeGroup name="LinkSpec-AG">
+    <xs:attribute name="caption" type="xs:string" use="required"/>
+    <xs:attribute name="expression" type="xs:string" use="required"/>
+    <xs:attribute name="multi-select" type="xs:boolean"/>
+    <xs:attribute name="delimiter" type="xs:string"/>
+    <xs:attribute name="escape" type="xs:string"/>
+    <xs:attribute name="include-null" type="xs:boolean"/>
+    <xs:attribute name="url-escape" type="xs:boolean"/>
+  </xs:attributeGroup>
+  <xs:group name="ActionSpec-G">
+    <xs:sequence>
+      <xs:element name="action">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attributeGroup ref="LinkSpec-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ActivationMethod-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="explicit"/>
+      <xs:enumeration value="on-select"/>
+      <xs:enumeration value="on-hover"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SourceType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="all"/>
+      <xs:enumeration value="datasource"/>
+      <xs:enumeration value="sheet"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="UrlActionType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="default-zone-or-browser"/>
+      <xs:enumeration value="browser"/>
+      <xs:enumeration value="specific-zone"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="ActionList-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="actions" type="ActionList-ActionList-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Actions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="actions">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="LegacyActions-G"/>
+            <xs:group minOccurs="0" ref="DataSourcesAndDependencies-G"/>
+            <xs:group ref="NavActions-G"/>
+            <xs:group ref="GroupActions-G"/>
+            <xs:group ref="ParameterActions-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ActionsOrActionList-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="actions">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="LegacyActions-G"/>
+            <xs:group minOccurs="0" ref="DataSourcesAndDependencies-G"/>
+            <xs:group ref="NavActions-G"/>
+            <xs:group ref="GroupActions-G"/>
+            <xs:group ref="ParameterActions-G"/>
+          </xs:sequence>
+          <xs:attribute name="brushing-enabled" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="LegacyActions-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="LegacyAction-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="LegacyAction-G">
+    <xs:sequence>
+      <xs:element name="action">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ActionList-ActionActivation-G"/>
+            <xs:group ref="ActionList-ActionSource-G"/>
+            <xs:group minOccurs="0" ref="ActionList-Link-G"/>
+            <xs:group minOccurs="0" ref="ActionList-Command-G"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="ActionList-ActionAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="NavActions-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="NavAction-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GroupActions-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="GroupAction-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ParameterActions-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="ParameterAction-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="NavAction-G">
+    <xs:sequence>
+      <xs:element name="nav-action">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ActionList-ActionActivation-G"/>
+            <xs:group ref="ActionList-ActionSource-G"/>
+            <xs:element minOccurs="0" name="params">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="ActionList-ActionParams-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attributeGroup ref="ActionList-ActionAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GroupAction-G">
+    <xs:sequence>
+      <xs:element name="edit-group-action">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ActionList-ActionActivation-G"/>
+            <xs:group ref="ActionList-ActionSource-G"/>
+            <xs:element minOccurs="0" name="single-select">
+              <xs:complexType>
+                <xs:attribute name="value" type="xs:boolean"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="add-or-remove-marks">
+              <xs:complexType>
+                <xs:attribute name="value" type="ActionList-Modification-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="params">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="ActionList-ActionParams-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attributeGroup ref="ActionList-ActionAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ParameterAction-G">
+    <xs:sequence>
+      <xs:element name="edit-parameter-action">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ActionList-ActionActivation-G"/>
+            <xs:group ref="ActionList-ActionSource-G"/>
+            <xs:element minOccurs="0" name="agg-type">
+              <xs:complexType>
+                <xs:attribute name="type" type="ActionList-Agg-ST"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="clear-option">
+              <xs:complexType>
+                <xs:attribute name="type" type="ActionList-ClearSelectionType-ST"/>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="params">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="ActionList-ActionParams-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attributeGroup ref="ActionList-ActionAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="ActionList-ActionList-CT">
+    <xs:sequence>
+      <xs:group ref="LegacyActions-G"/>
+      <xs:group ref="DataSourcesAndDependencies-G"/>
+      <xs:group ref="NavActions-G"/>
+      <xs:group ref="GroupActions-G"/>
+      <xs:group ref="ParameterActions-G"/>
+    </xs:sequence>
+    <xs:attribute name="brushing-enabled" type="xs:boolean"/>
+  </xs:complexType>
+  <xs:group name="ActionList-ActionActivation-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="activation">
+        <xs:complexType>
+          <xs:attribute name="type" type="ActivationMethod-ST"/>
+          <xs:attribute name="auto-clear" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ActionList-ActionSource-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="source">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="exclude-sheet">
+              <xs:complexType>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="type" type="SourceType-ST" use="required"/>
+          <xs:attribute name="datasource" type="xs:string"/>
+          <xs:attribute name="worksheet" type="xs:string"/>
+          <xs:attribute name="dashboard" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ActionList-Link-G">
+    <xs:sequence>
+      <xs:element name="link">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="url-action-type" type="UrlActionType-ST"/>
+            <xs:element minOccurs="0" name="url-action-target" type="xs:string"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="LinkSpec-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ActionList-Command-G">
+    <xs:sequence>
+      <xs:element name="command">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="param">
+              <xs:complexType>
+                <xs:attribute name="name" type="xs:string"/>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="command" type="ActionList-CommandName-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ActionList-ActionParams-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="param">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="ActionList-ActionAttributes-AG">
+    <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+    <xs:attribute name="enabled" type="xs:boolean"/>
+    <xs:attribute name="caption" type="xs:string"/>
+  </xs:attributeGroup>
+  <xs:simpleType name="ActionList-CommandName-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^:]+:[^:]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ActionList-Agg-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="attr"/>
+      <xs:enumeration value="sum"/>
+      <xs:enumeration value="average"/>
+      <xs:enumeration value="min"/>
+      <xs:enumeration value="max"/>
+      <xs:enumeration value="median"/>
+      <xs:enumeration value="collect"/>
+      <xs:enumeration value="union"/>
+      <xs:enumeration value="count"/>
+      <xs:enumeration value="count-d"/>
+      <xs:enumeration value="std-dev"/>
+      <xs:enumeration value="std-dev-p"/>
+      <xs:enumeration value="var"/>
+      <xs:enumeration value="var-p"/>
+      <xs:enumeration value="concatenate"/>
+      <xs:enumeration value="quart1"/>
+      <xs:enumeration value="quart3"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ActionList-Modification-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="assign"/>
+      <xs:enumeration value="add"/>
+      <xs:enumeration value="remove"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ActionList-ClearSelectionType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="do-nothing"/>
+      <xs:enumeration value="assign-fixed-value"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Extension-String-ST">
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="1000"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Localized-Resource-String-CT">
+    <xs:simpleContent>
+      <xs:extension base="Extension-String-ST">
+        <xs:attribute name="locale" type="Extension-String-ST" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Resource-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="100" name="text" type="Localized-Resource-String-CT"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="Extension-String-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Resources-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="resource" type="Resource-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Limited-Length-URL-ST">
+    <xs:restriction base="xs:anyURI">
+      <xs:maxLength value="2083"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Author-URL-ST">
+    <xs:restriction base="Limited-Length-URL-ST">
+      <xs:pattern value="[Hh][Tt][Tt][Pp][Ss]://.+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Extension-URL-ST">
+    <xs:restriction base="Limited-Length-URL-ST">
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Source-Location-CT">
+    <xs:choice>
+      <xs:element name="url" type="Extension-URL-ST"/>
+    </xs:choice>
+  </xs:complexType>
+  <xs:simpleType name="Version-ST">
+    <xs:restriction base="Extension-String-ST">
+      <xs:pattern value="[0-9]+\.[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Author-CT">
+    <xs:attribute name="email" type="Extension-String-ST" use="required"/>
+    <xs:attribute name="name" type="Extension-String-ST" use="required"/>
+    <xs:attribute name="organization" type="Extension-String-ST"/>
+    <xs:attribute name="website" type="Author-URL-ST" use="required"/>
+  </xs:complexType>
+  <xs:simpleType name="Size-Type-ST">
+    <xs:restriction base="Extension-String-ST">
+      <xs:enumeration value="default"/>
+      <xs:enumeration value="max"/>
+      <xs:enumeration value="min"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Positive-Int-ST">
+    <xs:restriction base="xs:int">
+      <xs:minExclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Size-CT">
+    <xs:attribute name="height" type="Positive-Int-ST" use="required"/>
+    <xs:attribute name="width" type="Positive-Int-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Layout-CT">
+    <xs:all>
+      <xs:element minOccurs="0" name="max-size" type="Size-CT"/>
+      <xs:element minOccurs="0" name="min-size" type="Size-CT"/>
+      <xs:element minOccurs="0" name="default-size" type="Size-CT"/>
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="Localized-Text-CT">
+    <xs:simpleContent>
+      <xs:extension base="Extension-String-ST">
+        <xs:attribute name="resource-id" type="Extension-String-ST"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="Extension-Id-ST">
+    <xs:restriction base="Extension-String-ST">
+      <xs:pattern value="[A-Za-z]{2,6}(\.[A-Za-z0-9\-]{1,63})+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Extension-Icon-ST">
+    <xs:restriction base="xs:base64Binary">
+      <xs:maxLength value="19608"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Extension-Permission-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="full data"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Extension-Permissions-CT">
+    <xs:sequence>
+      <xs:element name="permission" type="Extension-Permission-ST"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Extension-Context-Menu-Configure-ST">
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Extension-Context-Menu-CT">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="configure-context-menu-item" type="Extension-Context-Menu-Configure-ST"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Encoding-Seq-CT">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="encoding" type="Encoding-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Encoding-CT">
+    <xs:attribute name="name" type="Extension-String-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Tableau-Extension-CT">
+    <xs:sequence>
+      <xs:element name="default-locale" type="Extension-String-ST"/>
+      <xs:element name="name" type="Localized-Text-CT"/>
+      <xs:element name="description" type="Localized-Text-CT"/>
+      <xs:element name="author" type="Author-CT"/>
+      <xs:element name="min-api-version" type="Version-ST"/>
+      <xs:element name="source-location" type="Source-Location-CT"/>
+      <xs:element name="icon" type="Extension-Icon-ST"/>
+      <xs:element minOccurs="0" name="permissions" type="Extension-Permissions-CT"/>
+      <xs:element minOccurs="0" name="context-menu" type="Extension-Context-Menu-CT"/>
+      <xs:element minOccurs="0" name="disable-sorting-ui" type="xs:boolean"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="Extension-Id-ST" use="required"/>
+    <xs:attribute name="extension-version" type="Extension-String-ST"/>
+  </xs:complexType>
+  <xs:complexType name="Dashboard-Extension-CT">
+    <xs:complexContent>
+      <xs:extension base="Tableau-Extension-CT">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="layout" type="Layout-CT"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="Data-Type-ST">
+    <xs:restriction base="Extension-String-ST">
+      <xs:enumeration value="numeric"/>
+      <xs:enumeration value="temporal"/>
+      <xs:enumeration value="string"/>
+      <xs:enumeration value="boolean"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Data-Type-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="4" name="data-type" type="Data-Type-ST"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Role-Type-ST">
+    <xs:restriction base="Extension-String-ST">
+      <xs:enumeration value="discrete-dimension"/>
+      <xs:enumeration value="discrete-measure"/>
+      <xs:enumeration value="continuous-dimension"/>
+      <xs:enumeration value="continuous-measure"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Role-Type-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="4" name="role-type" type="Role-Type-ST"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="MaxField-CT">
+    <xs:attribute name="max-count" type="Positive-Int-ST" use="required"/>
+  </xs:complexType>
+  <xs:simpleType name="Image-Type-ST">
+    <xs:restriction base="Extension-String-ST">
+      <xs:enumeration value="color"/>
+      <xs:enumeration value="size"/>
+      <xs:enumeration value="text"/>
+      <xs:enumeration value="sort"/>
+      <xs:enumeration value="shape"/>
+      <xs:enumeration value="wedge"/>
+      <xs:enumeration value="level-of-detail"/>
+      <xs:enumeration value="tooltip"/>
+      <xs:enumeration value="level"/>
+      <xs:enumeration value="level-radial"/>
+      <xs:enumeration value="edge"/>
+      <xs:enumeration value="letter-a"/>
+      <xs:enumeration value="letter-b"/>
+      <xs:enumeration value="letter-c"/>
+      <xs:enumeration value="letter-d"/>
+      <xs:enumeration value="letter-e"/>
+      <xs:enumeration value="letter-f"/>
+      <xs:enumeration value="letter-g"/>
+      <xs:enumeration value="letter-h"/>
+      <xs:enumeration value="letter-i"/>
+      <xs:enumeration value="letter-j"/>
+      <xs:enumeration value="letter-k"/>
+      <xs:enumeration value="letter-l"/>
+      <xs:enumeration value="letter-m"/>
+      <xs:enumeration value="letter-n"/>
+      <xs:enumeration value="letter-o"/>
+      <xs:enumeration value="letter-p"/>
+      <xs:enumeration value="letter-q"/>
+      <xs:enumeration value="letter-r"/>
+      <xs:enumeration value="letter-s"/>
+      <xs:enumeration value="letter-t"/>
+      <xs:enumeration value="letter-u"/>
+      <xs:enumeration value="letter-v"/>
+      <xs:enumeration value="letter-w"/>
+      <xs:enumeration value="letter-x"/>
+      <xs:enumeration value="letter-y"/>
+      <xs:enumeration value="letter-z"/>
+      <xs:enumeration value="digit-0"/>
+      <xs:enumeration value="digit-1"/>
+      <xs:enumeration value="digit-2"/>
+      <xs:enumeration value="digit-3"/>
+      <xs:enumeration value="digit-4"/>
+      <xs:enumeration value="digit-5"/>
+      <xs:enumeration value="digit-6"/>
+      <xs:enumeration value="digit-7"/>
+      <xs:enumeration value="digit-8"/>
+      <xs:enumeration value="digit-9"/>
+      <xs:enumeration value="hash"/>
+      <xs:enumeration value="dollar"/>
+      <xs:enumeration value="percentage"/>
+      <xs:enumeration value="ampersand"/>
+      <xs:enumeration value="exclamation"/>
+      <xs:enumeration value="smaller-than"/>
+      <xs:enumeration value="equal"/>
+      <xs:enumeration value="larger-than"/>
+      <xs:enumeration value="question"/>
+      <xs:enumeration value="at-symbol"/>
+      <xs:enumeration value="function"/>
+      <xs:enumeration value="dot"/>
+      <xs:enumeration value="favorite"/>
+      <xs:enumeration value="filter"/>
+      <xs:enumeration value="flow"/>
+      <xs:enumeration value="forecast"/>
+      <xs:enumeration value="globe"/>
+      <xs:enumeration value="grid"/>
+      <xs:enumeration value="highlight"/>
+      <xs:enumeration value="image"/>
+      <xs:enumeration value="join"/>
+      <xs:enumeration value="link"/>
+      <xs:enumeration value="metric"/>
+      <xs:enumeration value="delta-down"/>
+      <xs:enumeration value="delta-up"/>
+      <xs:enumeration value="three-dots"/>
+      <xs:enumeration value="arrow-down"/>
+      <xs:enumeration value="arrow-up"/>
+      <xs:enumeration value="arrow-left"/>
+      <xs:enumeration value="arrow-right"/>
+      <xs:enumeration value="thumbnail-even"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Encoding-Icon-CT">
+    <xs:simpleContent>
+      <xs:extension base="Extension-Icon-ST">
+        <xs:attribute name="token" type="Image-Type-ST"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Encoding-Custom-CT">
+    <xs:sequence>
+      <xs:element name="display-name" type="Localized-Text-CT"/>
+      <xs:element minOccurs="0" name="data-spec" type="Data-Type-CT"/>
+      <xs:element minOccurs="0" name="role-spec" type="Role-Type-CT"/>
+      <xs:element minOccurs="0" name="fields" type="MaxField-CT"/>
+      <xs:element minOccurs="0" name="encoding-icon" type="Encoding-Icon-CT"/>
+      <xs:element minOccurs="0" name="tooltip" type="Localized-Text-CT"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="Extension-String-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Worksheet-Extension-CT">
+    <xs:complexContent>
+      <xs:extension base="Tableau-Extension-CT">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="4" name="encoding" type="Encoding-Custom-CT"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ExtensionManifest-CT">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DocumentManifest-G"/>
+      <xs:choice>
+        <xs:element name="dashboard-extension" type="Dashboard-Extension-CT"/>
+        <xs:element name="worksheet-extension" type="Worksheet-Extension-CT"/>
+      </xs:choice>
+      <xs:element minOccurs="0" name="resources" type="Resources-CT"/>
+    </xs:sequence>
+    <xs:attribute name="manifest-version" type="Version-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Settings-Value-CT">
+    <xs:attribute name="key" type="xs:string" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Instance-Settings-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" type="Settings-Value-CT" name="setting"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Dashboard-Settings-CT">
+  </xs:complexType>
+  <xs:complexType name="Worksheet-Settings-CT">
+  </xs:complexType>
+  <xs:complexType name="Type-Settings-CT">
+    <xs:choice>
+      <xs:element name="dashboard" type="Dashboard-Settings-CT"/>
+      <xs:element name="worksheet" type="Worksheet-Settings-CT"/>
+    </xs:choice>
+  </xs:complexType>
+  <xs:complexType name="Extension-CT">
+    <xs:sequence>
+      <xs:element name="instance-settings" type="Instance-Settings-CT">
+        <xs:unique name="DemandUniqueKeys">
+          <xs:selector xpath="setting"/>
+          <xs:field xpath="@key"/>
+        </xs:unique>
+      </xs:element>
+      <xs:element name="type-settings" type="Type-Settings-CT"/>
+    </xs:sequence>
+    <xs:attribute name="add-in-id" type="xs:string" use="required"/>
+    <xs:attribute name="instance-id" type="xs:string" use="required"/>
+    <xs:attribute name="extension-version" type="xs:string" use="required"/>
+    <xs:attribute name="extension-url" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:simpleType name="AggType-ST">
+    <xs:restriction base="xs:string">
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="FormattedText-G">
+    <xs:sequence>
+      <xs:element name="formatted-text">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="run">
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="fontname" type="xs:string"/>
+                    <xs:attribute name="fontsize" type="xs:unsignedInt"/>
+                    <xs:attribute name="fontalignment" type="xs:int"/>
+                    <xs:attribute name="bold" type="xs:boolean"/>
+                    <xs:attribute name="italic" type="xs:boolean"/>
+                    <xs:attribute name="underline" type="xs:boolean"/>
+                    <xs:attribute name="fontcolor" type="ColorObject-ST"/>
+                    <xs:attribute name="indent" type="xs:int"/>
+                    <xs:attribute name="lmargin" type="xs:int"/>
+                    <xs:attribute name="rmargin" type="xs:int"/>
+                    <xs:attribute name="hyperlink" type="xs:string"/>
+                    <xs:attribute name="auto-url" type="xs:boolean"/>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="StoryDelta-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="added"/>
+      <xs:enumeration value="edited"/>
+      <xs:enumeration value="removed"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="FieldNames-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="field" type="QualifiedName-ST"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="NodeReference-G">
+    <xs:sequence>
+      <xs:element name="node-reference">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="Reference-NodeReferenceFields-G"/>
+            <xs:element minOccurs="0" name="axis" type="QualifiedName-ST"/>
+          </xs:sequence>
+          <xs:attribute name="duplicate-index" type="xs:unsignedInt"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PageReference-G">
+    <xs:sequence>
+      <xs:element name="page-reference">
+        <xs:complexType>
+          <xs:group minOccurs="0" ref="Reference-PageReferenceFields-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneDescriptor-G">
+    <xs:sequence>
+      <xs:element name="pane-descriptor">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="x-fields">
+              <xs:complexType>
+                <xs:group ref="FieldNames-G"/>
+                <xs:attributeGroup ref="Reference-Indexes-AG"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="y-fields">
+              <xs:complexType>
+                <xs:group ref="FieldNames-G"/>
+                <xs:attributeGroup ref="Reference-Indexes-AG"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attributeGroup ref="Reference-Indexes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="TupleDescriptor-G">
+    <xs:sequence>
+      <xs:element name="tuple-descriptor">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="PaneDescriptor-G"/>
+            <xs:element name="columns">
+              <xs:complexType>
+                <xs:group ref="FieldNames-G"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="TupleReference-G">
+    <xs:sequence>
+      <xs:element name="tuple-reference">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="TupleDescriptor-G"/>
+            <xs:group ref="Tuple-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Reference-NodeReferenceFields-G">
+    <xs:sequence>
+      <xs:element name="fields">
+        <xs:complexType>
+          <xs:group ref="FieldNames-G"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:group ref="MultiBucket-Only-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Reference-PageReferenceFields-G">
+    <xs:sequence>
+      <xs:element name="fields">
+        <xs:complexType>
+          <xs:group ref="FieldNames-G"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:group ref="MultiBucket-Only-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="Reference-Indexes-AG">
+    <xs:attribute name="x-index" type="xs:unsignedInt"/>
+    <xs:attribute name="y-index" type="xs:unsignedInt"/>
+    <xs:attribute name="pane-specification-id" type="xs:integer"/>
+  </xs:attributeGroup>
+  <xs:group name="VisualCoordinate-G">
+    <xs:sequence>
+      <xs:element name="visual-coordinate">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="TupleReference-G"/>
+            <xs:element minOccurs="0" name="x-coord" type="VisualCoordinate-Coord-CT"/>
+            <xs:element minOccurs="0" name="y-coord" type="VisualCoordinate-Coord-CT"/>
+            <xs:group minOccurs="0" ref="PageReference-G"/>
+            <xs:element minOccurs="0" name="projection" type="VisualCoordinate-Projection-CT"/>
+          </xs:sequence>
+          <xs:attribute name="class" type="VisualCoordinate-VisualCoordinateType-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="VisualCoordinate-Coord-CT">
+    <xs:sequence>
+      <xs:group ref="NodeReference-G"/>
+    </xs:sequence>
+    <xs:attribute name="axis-value" type="DataValue-ST"/>
+    <xs:attribute name="cell-offset" type="Float-ST"/>
+  </xs:complexType>
+  <xs:simpleType name="VisualCoordinate-VisualCoordinateType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="axis"/>
+      <xs:enumeration value="mark"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="VisualCoordinate-Projection-CT">
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="u" type="DataValue-ST" use="required"/>
+    <xs:attribute name="v" type="DataValue-ST" use="required"/>
+  </xs:complexType>
+  <xs:simpleType name="Double-ST">
+    <xs:union memberTypes="xs:double XML-RealSpecial-ST"/>
+  </xs:simpleType>
+  <xs:simpleType name="Float-ST">
+    <xs:union memberTypes="xs:float XML-RealSpecial-ST"/>
+  </xs:simpleType>
+  <xs:simpleType name="XML-RealSpecial-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="nan"/>
+      <xs:enumeration value="inf"/>
+      <xs:enumeration value="-inf"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="BoxCoordinate-CT">
+    <xs:attribute name="x" type="Float-ST"/>
+    <xs:attribute name="y" type="Float-ST"/>
+  </xs:complexType>
+  <xs:group name="AnnotationSpecification-G">
+    <xs:sequence>
+      <xs:element name="annotation">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Annotation-FormattedText-G"/>
+            <xs:element minOccurs="0" name="point" type="Annotation-VisualCoordinate-CT"/>
+            <xs:element minOccurs="0" name="body" type="Annotation-XYCoordinate-CT"/>
+            <xs:element minOccurs="0" name="top-left" type="Annotation-VisualCoordinate-CT"/>
+            <xs:element minOccurs="0" name="bottom-right" type="Annotation-VisualCoordinate-CT"/>
+            <xs:element minOccurs="0" name="text" type="BoxCoordinate-CT"/>
+          </xs:sequence>
+          <xs:attribute name="class" type="Annotation-Class-ST" use="required"/>
+          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+          <xs:attribute name="pullback" type="Float-ST"/>
+          <xs:attribute name="mark-position" type="Float-ST"/>
+          <xs:attribute name="text-width" type="xs:int"/>
+          <xs:attribute name="text-width-delta" type="xs:int"/>
+          <xs:attribute name="text-pinx" type="Float-ST"/>
+          <xs:attribute name="text-piny" type="Float-ST"/>
+          <xs:attributeGroup ref="Annotation-DeltaAttrs-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Annotation-FormattedText-G">
+    <xs:sequence>
+      <xs:group ref="FormattedText-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Annotation-VisualCoordinate-CT">
+    <xs:sequence>
+      <xs:group ref="VisualCoordinate-G"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Annotation-XYCoordinate-CT">
+    <xs:attribute name="x" type="xs:int"/>
+    <xs:attribute name="y" type="xs:int"/>
+  </xs:complexType>
+  <xs:simpleType name="Annotation-Class-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="point"/>
+      <xs:enumeration value="area"/>
+      <xs:enumeration value="mark"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:attributeGroup name="Annotation-DeltaAttrs-AG">
+    <xs:attribute name="delta-type" type="StoryDelta-ST"/>
+  </xs:attributeGroup>
+  <xs:group name="SingleValueFieldNode-G">
+    <xs:sequence>
+      <xs:element name="single-value-field-node">
+        <xs:complexType>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="fieldname-input-guid" type="xs:string"/>
+          <xs:attribute name="value-output-guid" type="xs:string"/>
+          <xs:attribute name="fieldname" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DashboardZoneVisibilityNode-G">
+    <xs:sequence>
+      <xs:element name="dashboard-zone-visibility-node">
+        <xs:complexType>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="visibility-input-guid" type="xs:string"/>
+          <xs:attribute name="dashboard-identifier" type="xs:string"/>
+          <xs:attribute name="zone-id" type="xs:nonNegativeInteger"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AxisTitleNode-G">
+    <xs:sequence>
+      <xs:element name="axis-title-node">
+        <xs:complexType>
+          <xs:attribute name="duplicate-index" type="xs:nonNegativeInteger"/>
+          <xs:attribute name="fieldname" type="xs:string"/>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="orientation" type="xs:string"/>
+          <xs:attribute name="sheet-identifier" type="xs:string"/>
+          <xs:attribute name="title-input-guid" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AxisExtentNode-G">
+    <xs:sequence>
+      <xs:element name="axis-extent-node">
+        <xs:complexType>
+          <xs:attribute name="duplicate-index" type="xs:nonNegativeInteger"/>
+          <xs:attribute name="fieldname" type="xs:string"/>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="orientation" type="xs:string"/>
+          <xs:attribute name="sheet-identifier" type="xs:string"/>
+          <xs:attribute name="axis-extent" type="xs:string"/>
+          <xs:attribute name="extent-input-guid" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="QuantitativeColorLegendNode-G">
+    <xs:sequence>
+      <xs:element name="quantitative-color-legend-node">
+        <xs:complexType>
+          <xs:attribute name="fieldname" type="xs:string"/>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="sheet-identifier" type="xs:string"/>
+          <xs:attribute name="range-point" type="xs:string"/>
+          <xs:attribute name="range-input-guid" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ParameterSinkNode-G">
+    <xs:sequence>
+      <xs:element name="parameter-sink-node">
+        <xs:complexType>
+          <xs:attribute name="parameter-name" type="xs:string"/>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="input-guid" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapViewportNode-G">
+    <xs:sequence>
+      <xs:element name="map-viewport-node">
+        <xs:complexType>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="viewport-output-guid" type="xs:string"/>
+          <xs:attribute name="sheet-identifier" type="xs:string"/>
+          <xs:attribute name="dashboard-identifier" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-G">
+    <xs:sequence>
+      <xs:element name="datagraph">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Datagraph-Graph-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-GraphNode-G">
+    <xs:sequence>
+      <xs:element name="graph-node">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Datagraph-Graph-G"/>
+            <xs:group ref="Datagraph-Graph-Nodes-GraphNode-Properties-G"/>
+            <xs:group ref="Datagraph-Graph-Nodes-GraphNode-Inputs-G"/>
+            <xs:group ref="Datagraph-Graph-Nodes-GraphNode-Outputs-G"/>
+          </xs:sequence>
+          <xs:attribute name="guid" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-GraphNode-Properties-G">
+    <xs:sequence>
+      <xs:element name="properties">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="name">
+              <xs:complexType>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="description">
+              <xs:complexType>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-GraphNode-Inputs-G">
+    <xs:sequence>
+      <xs:element name="inputs">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Datagraph-Graph-Nodes-GraphNode-Inputs-Inputs-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-GraphNode-Inputs-Inputs-G">
+    <xs:sequence>
+      <xs:element name="input">
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-GraphNode-Outputs-G">
+    <xs:sequence>
+      <xs:element name="outputs">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Datagraph-Graph-Nodes-GraphNode-Outputs-Output-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-GraphNode-Outputs-Output-G">
+    <xs:sequence>
+      <xs:element name="output">
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-G">
+    <xs:sequence>
+      <xs:element name="graph">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Datagraph-Graph-Properties-G"/>
+            <xs:group ref="Datagraph-Graph-ExecutionSubgraphs-G"/>
+            <xs:group ref="Datagraph-Graph-Nodes-G"/>
+            <xs:group ref="Datagraph-Graph-Edges-G"/>
+            <xs:group ref="Datagraph-Graph-PinValues-G" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Properties-G">
+    <xs:sequence>
+      <xs:element name="properties">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="default-execution-subgraph-guid">
+              <xs:complexType>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Nodes-G">
+    <xs:sequence>
+      <xs:element name="nodes">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Datagraph-Graph-Nodes-GraphNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="SingleValueFieldNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="DashboardZoneVisibilityNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="AxisTitleNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="AxisExtentNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="QuantitativeColorLegendNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="ParameterSinkNode-G"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="MapViewportNode-G"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Edges-G">
+    <xs:sequence>
+      <xs:element name="edges">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Datagraph-Graph-Edges-Edge-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-ExecutionSubgraphs-G">
+    <xs:sequence>
+      <xs:element name="node-execution-subgraphs">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Datagraph-Graph-ExecutionSubgraphs-Pair-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-ExecutionSubgraphs-Pair-G">
+    <xs:sequence>
+      <xs:element name="pair">
+        <xs:complexType>
+          <xs:attribute name="node-guid" type="xs:string"/>
+          <xs:attribute name="execution-subgraph-guid" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-Edges-Edge-G">
+    <xs:sequence>
+      <xs:element name="edge">
+        <xs:complexType>
+          <xs:attribute name="from" type="xs:string"/>
+          <xs:attribute name="to" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Datagraph-Graph-PinValues-G">
+    <xs:sequence>
+      <xs:element name="pin-values">
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="QUUID-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\{[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="SimpleIdentifier-G">
+    <xs:sequence>
+      <xs:element name="simple-id">
+        <xs:complexType>
+          <xs:attribute name="uuid" type="QUUID-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="DataOrientation-Link-CT">
+    <xs:attribute name="text" type="xs:string" use="required"/>
+    <xs:attribute name="url" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="DataOrientation-Item-CT">
+    <xs:sequence>
+      <xs:group ref="SimpleIdentifier-G"/>
+      <xs:element name="desc" type="xs:string" minOccurs="0"/>
+      <xs:element name="video-link" type="DataOrientation-Link-CT" minOccurs="0"/>
+      <xs:element name="additional-resource" type="DataOrientation-Link-CT" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="DataOrientation-G">
+    <xs:sequence>
+      <xs:element name="data-orientation">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="data-orientation-item" type="DataOrientation-Item-CT" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="UniqueDataOrientationItemIdentifier">
+          <xs:selector xpath="data-orientation-item/simple-id"/>
+          <xs:field xpath="@uuid"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="QualifiedName-ST">
+    <xs:restriction base="FullValue-ST"/>
+  </xs:simpleType>
+  <xs:simpleType name="LeafValue-ST">
+    <xs:restriction base="QualifiedName-Component-ST"/>
+  </xs:simpleType>
+  <xs:simpleType name="RootValue-ST">
+    <xs:restriction base="QualifiedName-Component-ST"/>
+  </xs:simpleType>
+  <xs:simpleType name="FullValue-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(\[([^\]]*(\]\])?)*\](\.\[([^\]]*(\]\])?)*\])*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="QualifiedName-Component-ST">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="AnalyticModel-OptionalFields-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="field">
+        <xs:complexType>
+          <xs:attribute name="name" type="FullValue-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="AnalyticModel-Specifications-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="analytic-model-specifications">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="AnalysisFields-G"/>
+            <xs:group ref="FilterFields-G"/>
+            <xs:group ref="LODFields-G"/>
+            <xs:group ref="NumDesiredClusters-G"/>
+            <xs:element minOccurs="0" name="is-dissagregate" type="xs:boolean"/>
+          </xs:sequence>
+          <xs:attribute name="class" type="AnalyticModelSpecificationsClass-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AnalysisFields-G">
+    <xs:sequence>
+      <xs:element name="analysis-fields" type="AnalyticModel-OptionalFields-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="AnalyticModel-NumClusters-ST">
+    <xs:restriction base="xs:int">
+      <xs:minInclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="FilterFields-G">
+    <xs:sequence>
+      <xs:element name="filter-fields" type="AnalyticModel-OptionalFields-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="LODFields-G">
+    <xs:sequence>
+      <xs:element name="lod-fields" type="AnalyticModel-OptionalFields-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="NumDesiredClusters-G">
+    <xs:sequence>
+      <xs:element name="number-of-desired-clusters" type="AnalyticModel-NumClusters-ST"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AnalyticModel-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="analytic-model">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="AnalyticModel-Name-G"/>
+            <xs:group ref="AnalyticModel-Specifications-G"/>
+            <xs:group ref="AnalyticModel-ResultFields-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AnalyticModel-Name-G">
+    <xs:sequence>
+      <xs:element name="name">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="field">
+              <xs:complexType>
+                <xs:attribute name="name" type="QualifiedName-ST"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AnalyticModel-ResultFields-G">
+    <xs:sequence>
+      <xs:element name="result-fields">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="field">
+              <xs:complexType>
+                <xs:attribute name="name" type="FullValue-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DomainType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="any"/>
+      <xs:enumeration value="list"/>
+      <xs:enumeration value="range"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Function-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ancestors"/>
+      <xs:enumeration value="crossjoin"/>
+      <xs:enumeration value="descendants"/>
+      <xs:enumeration value="empty-level"/>
+      <xs:enumeration value="end"/>
+      <xs:enumeration value="except"/>
+      <xs:enumeration value="extract"/>
+      <xs:enumeration value="filter"/>
+      <xs:enumeration value="hierarchy-members"/>
+      <xs:enumeration value="intersection"/>
+      <xs:enumeration value="level-members"/>
+      <xs:enumeration value="member"/>
+      <xs:enumeration value="named-set"/>
+      <xs:enumeration value="order"/>
+      <xs:enumeration value="range"/>
+      <xs:enumeration value="relative-date-range"/>
+      <xs:enumeration value="reference"/>
+      <xs:enumeration value="reorder-dimensionality"/>
+      <xs:enumeration value="tuples"/>
+      <xs:enumeration value="union"/>
+      <xs:enumeration value="visual-totals"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="RelationType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="join"/>
+      <xs:enumeration value="subquery"/>
+      <xs:enumeration value="table"/>
+      <xs:enumeration value="stored-proc"/>
+      <xs:enumeration value="text"/>
+      <xs:enumeration value="union"/>
+      <xs:enumeration value="batch-union"/>
+      <xs:enumeration value="pivot"/>
+      <xs:enumeration value="project"/>
+      <xs:enumeration value="text-transform"/>
+      <xs:enumeration value="collection"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SortDirection-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ASC"/>
+      <xs:enumeration value="DESC"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SortType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="natural"/>
+      <xs:enumeration value="alphabetic"/>
+      <xs:enumeration value="computed"/>
+      <xs:enumeration value="manual"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SubqueryType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="from"/>
+      <xs:enumeration value="group-by"/>
+      <xs:enumeration value="having"/>
+      <xs:enumeration value="order-by"/>
+      <xs:enumeration value="select"/>
+      <xs:enumeration value="where"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ColumnOrdering-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="alphabetic"/>
+      <xs:enumeration value="ordinal"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StatisticalModelClass-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="cluster-k-means"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AnalyticModelSpecificationsClass-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="cluster-specifications"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="ColumnInstance-UtilityMembers-CT">
+    <xs:sequence minOccurs="1">
+      <xs:element name="utility-member" minOccurs="1">
+        <xs:complexType>
+          <xs:attribute name="level" type="QualifiedName-ST"/>
+          <xs:attribute name="member" type="DataValue-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ColumnInstance-MemberProperties-CT">
+    <xs:sequence>
+      <xs:element name="alias" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:attribute name="key" type="xs:string"/>
+          <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:attributeGroup name="ColumnInstance-Attrs-AG">
+    <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+    <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+    <xs:attribute name="type" type="FieldType-ST" use="required"/>
+    <xs:attribute name="pivot" type="PivotStrategy-ST" use="required"/>
+    <xs:attribute name="derivation" type="AggType-ST" use="required"/>
+    <xs:attribute name="forecast-column-type" type="xs:string"/>
+    <xs:attribute name="forecast-column-base" type="xs:string"/>
+    <xs:attribute name="is-adhoc-cluster" type="xs:boolean"/>
+    <xs:attribute name="aggregation-param" type="xs:string"/>
+    <xs:attribute name="visual-totals" type="xs:string"/>
+  </xs:attributeGroup>
+  <xs:group name="ColumnInstance-G">
+    <xs:sequence>
+      <xs:element name="column-instance">
+        <xs:complexType mixed="true">
+          <xs:sequence minOccurs="0">
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="TableCalc-G"/>
+            <xs:element minOccurs="0" name="utility-members" type="ColumnInstance-UtilityMembers-CT"/>
+            <xs:element minOccurs="0" name="aliases" type="ColumnInstance-MemberProperties-CT"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="ColumnInstance-Attrs-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="Collation-AG">
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="charset" type="xs:unsignedShort"/>
+    <xs:attribute name="flag" type="xs:unsignedInt"/>
+  </xs:attributeGroup>
+  <xs:group name="DataValue-G">
+    <xs:sequence>
+      <xs:element name="value" type="DataValue-ST"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Schema-G">
+    <xs:sequence>
+      <xs:element name="schema">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="column" type="QualifiedName-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SchemaWithDataType-G">
+    <xs:sequence>
+      <xs:element name="schema">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Table-G">
+    <xs:sequence>
+      <xs:element name="table">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Schema-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Tuple-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Tuple-G">
+    <xs:sequence>
+      <xs:element name="tuple">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" minOccurs="0" ref="DataValue-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="TupleList-CT">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="Tuple-G"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="TupleSource-G">
+    <xs:sequence>
+      <xs:element name="table">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="schema">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+                    <xs:complexType>
+                      <xs:attribute name="key" type="xs:string"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Tuple-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="QuantitativeDomain-G">
+    <xs:sequence>
+      <xs:element name="quantitative-domain">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="min" type="DataValue-ST"/>
+            <xs:element name="max" type="DataValue-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="CategoricalDomain-G">
+    <xs:sequence>
+      <xs:element name="categorical-domain">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="DataValue-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Domain-G">
+    <xs:sequence>
+      <xs:choice>
+        <xs:group ref="QuantitativeDomain-G"/>
+        <xs:group ref="CategoricalDomain-G"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MultiDomain-G">
+    <xs:sequence>
+      <xs:element name="multidomain">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Tuple-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="RefreshType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="create"/>
+      <xs:enumeration value="increment"/>
+      <xs:enumeration value="add from data source"/>
+      <xs:enumeration value="add from file"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DataConnectionCustomization-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="connection-customization">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Vendor-G"/>
+            <xs:group ref="Driver-G"/>
+            <xs:group ref="Customizations-G"/>
+          </xs:sequence>
+          <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+          <xs:attribute name="class" type="xs:string" use="required"/>
+          <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Vendor-G">
+    <xs:sequence>
+      <xs:element name="vendor">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Driver-G">
+    <xs:sequence>
+      <xs:element name="driver">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Customizations-G">
+    <xs:sequence>
+      <xs:element name="customizations">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="DataConnectionCust-Customizations-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataConnectionCust-Customizations-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="DataConnectionCust-Customization-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataConnectionCust-Customization-G">
+    <xs:sequence>
+      <xs:element name="customization">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="MetadataRecord-Class-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="column"/>
+      <xs:enumeration value="measure"/>
+      <xs:enumeration value="level"/>
+      <xs:enumeration value="dimension"/>
+      <xs:enumeration value="hierarchy"/>
+      <xs:enumeration value="remote-set"/>
+      <xs:enumeration value="granularity"/>
+      <xs:enumeration value="pair-hierarchy"/>
+      <xs:enumeration value="capability"/>
+      <xs:enumeration value="primary-key"/>
+      <xs:enumeration value="foreign-key"/>
+      <xs:enumeration value="sampled-data"/>
+      <xs:enumeration value="unique-constraint"/>
+      <xs:enumeration value="table-statistic"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MetadataRecord-LevelType-EnumBase-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="regular"/>
+      <xs:enumeration value="all"/>
+      <xs:enumeration value="time"/>
+      <xs:enumeration value="time-year"/>
+      <xs:enumeration value="time-semester"/>
+      <xs:enumeration value="time-trimester"/>
+      <xs:enumeration value="time-quarter"/>
+      <xs:enumeration value="time-month"/>
+      <xs:enumeration value="time-period"/>
+      <xs:enumeration value="time-week"/>
+      <xs:enumeration value="time-day"/>
+      <xs:enumeration value="time-hour"/>
+      <xs:enumeration value="time-minute"/>
+      <xs:enumeration value="time-second"/>
+      <xs:enumeration value="time-day-of-week"/>
+      <xs:enumeration value="time-semester-by-year"/>
+      <xs:enumeration value="time-quarter-by-year"/>
+      <xs:enumeration value="time-quarter-by-semester"/>
+      <xs:enumeration value="time-month-by-year"/>
+      <xs:enumeration value="time-month-by-semester"/>
+      <xs:enumeration value="time-month-by-quarter"/>
+      <xs:enumeration value="time-week-by-year"/>
+      <xs:enumeration value="time-week-by-semester"/>
+      <xs:enumeration value="time-week-by-quarter"/>
+      <xs:enumeration value="time-week-by-month"/>
+      <xs:enumeration value="time-day-by-year"/>
+      <xs:enumeration value="time-day-by-semester"/>
+      <xs:enumeration value="time-day-by-quarter"/>
+      <xs:enumeration value="time-day-by-month"/>
+      <xs:enumeration value="time-day-by-week"/>
+      <xs:enumeration value="time-weekend"/>
+      <xs:enumeration value="time-holiday"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MetadataRecord-LevelType-ST">
+    <xs:union memberTypes="xs:int MetadataRecord-LevelType-EnumBase-ST"/>
+  </xs:simpleType>
+  <xs:group name="MetadataRecord-RemoteType-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="remote-type" type="MetadataRecord-LevelType-ST"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MetadataRecord-Statistics-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="statistics">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="statistic" type="Statistic-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Statistic-CT">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="aggregation" type="AggType-ST" use="required"/>
+        <xs:attribute name="datatype" type="DataType-ST" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:group name="MetadataRecord-Attributes-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="attributes">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="attribute" type="Attribute-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Attribute-CT">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="datatype" type="DataType-ST" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="MetadataRecord-ObjectId-ST">
+    <xs:restriction base="QualifiedName-ST"/>
+  </xs:simpleType>
+  <xs:group name="MetadataRecord-G">
+    <xs:sequence>
+      <xs:element name="metadata-record">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element name="remote-name" type="xs:string"/>
+            <xs:group ref="MetadataRecord-RemoteType-G"/>
+            <xs:element minOccurs="0" name="local-name" type="QualifiedName-ST"/>
+            <xs:element minOccurs="0" name="parent-name" type="QualifiedName-ST"/>
+            <xs:element name="remote-alias" type="xs:string"/>
+            <xs:element minOccurs="0" name="ordinal" type="xs:int"/>
+            <xs:element minOccurs="0" name="hidden" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="auto-hidden" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="layered" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="caption" type="xs:string"/>
+            <xs:element minOccurs="0" name="family" type="xs:string"/>
+            <xs:element minOccurs="0" name="local-type" type="DataType-ST"/>
+            <xs:element name="aggregation" type="AggType-ST"/>
+            <xs:element minOccurs="0" name="approx-count" type="xs:int"/>
+            <xs:element minOccurs="0" name="precision" type="xs:int"/>
+            <xs:element minOccurs="0" name="scale" type="xs:int"/>
+            <xs:element minOccurs="0" name="width" type="xs:int"/>
+            <xs:element name="contains-null" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="padded-semantics" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="cast-to-local-type" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="collation">
+              <xs:complexType>
+                <xs:attributeGroup ref="Collation-AG"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="default" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="level-number" type="xs:int"/>
+            <xs:element minOccurs="0" name="layer-number" type="xs:int"/>
+            <xs:element minOccurs="0" name="semantic-role" type="QualifiedName-ST"/>
+            <xs:element minOccurs="0" name="associated-user-geom" type="QualifiedName-ST"/>
+            <xs:element minOccurs="0" name="user-geom-alias" type="QualifiedName-ST"/>
+            <xs:group ref="MetadataRecord-Statistics-G"/>
+            <xs:group ref="MetadataRecord-Attributes-G"/>
+            <xs:element minOccurs="0" name="object-id" type="MetadataRecord-ObjectId-ST"/>
+          </xs:sequence>
+          <xs:attribute name="class" type="MetadataRecord-Class-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="JoinType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="inner"/>
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="right"/>
+      <xs:enumeration value="full"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Relation-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="relation">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element minOccurs="0" name="database-filter">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group minOccurs="0" ref="SQLExpression-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="table-filter">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group minOccurs="0" ref="SQLExpression-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:group minOccurs="0" ref="RelationColumns-G"/>
+            <xs:element minOccurs="0" name="clause">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="SQLExpression-G"/>
+                </xs:sequence>
+                <xs:attribute fixed="join" name="type" type="RelationType-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:group minOccurs="0" ref="SQLSubquery-G"/>
+            <xs:group minOccurs="0" ref="RelationActualParameters-G"/>
+            <xs:element minOccurs="0" name="tag">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="value">
+                    <xs:complexType>
+                      <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="groups">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="group">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="field">
+                          <xs:complexType>
+                            <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                      <xs:attribute name="name" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="bindings">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="binding">
+                    <xs:complexType>
+                      <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+                      <xs:attribute name="expression" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Relation-G"/>
+          </xs:sequence>
+          <xs:attribute name="type" type="RelationType-ST" use="required"/>
+          <xs:attribute name="join" type="JoinType-ST"/>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="table" type="QualifiedName-ST"/>
+          <xs:attributeGroup ref="ConnectionName-AG"/>
+          <xs:attribute name="stored-proc" type="QualifiedName-ST"/>
+          <xs:attribute name="all" type="xs:boolean"/>
+          <xs:attribute name="path" type="xs:string"/>
+          <xs:attribute name="is-recursive" type="xs:boolean"/>
+          <xs:attribute name="include-siblings" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="RelationNames-G">
+    <xs:sequence>
+      <xs:element name="cols">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="map">
+              <xs:complexType>
+                <xs:attribute name="key" type="QualifiedName-ST"/>
+                <xs:attribute name="value" type="QualifiedName-ST"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SQLSubquery-G">
+    <xs:sequence>
+      <xs:element name="subquery">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="6" minOccurs="0" name="clause">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="expression">
+                    <xs:complexType>
+                      <xs:sequence minOccurs="0">
+                        <xs:group maxOccurs="unbounded" minOccurs="0" ref="SQLExpression-G"/>
+                      </xs:sequence>
+                      <xs:attribute name="op" type="Op-ST"/>
+                      <xs:attribute name="name" type="xs:string"/>
+                      <xs:attribute name="expression" type="xs:string"/>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:group minOccurs="0" ref="Relation-G"/>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="sort">
+                    <xs:complexType>
+                      <xs:attribute name="expression" type="xs:string" use="required"/>
+                      <xs:attribute name="direction" type="SortDirection-ST" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+                <xs:attribute name="type" type="SubqueryType-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="into" type="xs:boolean" use="required"/>
+          <xs:attribute name="count" type="Float-ST" use="required"/>
+          <xs:attribute name="units" type="SortUnits-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="RelationColumns-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="columns">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+              <xs:complexType>
+                <xs:anyAttribute namespace="##local" processContents="skip"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="RelationActualParameters-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="actual-parameters">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+              <xs:complexType>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="ordinal" type="xs:unsignedInt" use="required"/>
+                <xs:attribute name="parameter" type="QualifiedName-ST"/>
+                <xs:attribute name="value" type="DataValue-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="ConnectionName-AG">
+    <xs:attribute name="connection" type="xs:string" use="optional"/>
+  </xs:attributeGroup>
+  <xs:group name="SchemaSelections-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="semistruct-schemas">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="SchemaSelection-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SchemaSelection-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="semistruct-schema">
+        <xs:complexType>
+          <xs:group ref="SemiStructSchema-SchemaNodeSelection-G"/>
+          <xs:attribute name="table" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SemiStructSchema-SchemaNodeSelection-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="map">
+        <xs:complexType>
+          <xs:attribute name="key" type="xs:string" use="required"/>
+          <xs:attribute name="value" type="xs:boolean" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Connection-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="connection" type="DataConnection-Connection-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MaterialisedCalcs-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="calculations">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="calculation" type="DataConnection-MaterializedCalc-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Refresh-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="refresh">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="1" minOccurs="0" name="subrange-refresh" type="SubrangeRefresh-CT"/>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="refresh-event" type="DataConnection-RefreshEvent-CT"/>
+          </xs:sequence>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Metadata-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="metadata-records">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="MetadataRecord-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MDXConnection-G">
+    <xs:sequence>
+      <xs:group ref="Connection-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SQLConnection-G">
+    <xs:sequence>
+      <xs:group ref="Connection-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="NonTransactedState-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="nontransacted-state">
+        <xs:complexType>
+          <xs:attribute name="forced-slow" type="DataSource-YesNo-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="DataConnection-Connection-CT">
+    <xs:sequence>
+      <xs:any maxOccurs="unbounded" minOccurs="0" namespace="##local" processContents="skip"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##local" processContents="skip"/>
+  </xs:complexType>
+  <xs:complexType name="DataConnection-RefreshEvent-CT">
+    <xs:attribute name="refresh-type" type="RefreshType-ST" use="required"/>
+    <xs:attribute name="timestamp-start">
+      <xs:simpleType>
+        <xs:union memberTypes="DateFormat_5-ST DateFormat_11-ST"/>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="rows-inserted" type="xs:long" use="required"/>
+    <xs:attribute name="add-from-file-path" type="xs:string" use="required"/>
+    <xs:attribute name="increment-value" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="DataConnection-MaterializedCalc-CT">
+    <xs:attribute name="column" type="QualifiedName-ST"/>
+    <xs:attribute name="formula" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="SubrangeRefresh-CT">
+    <xs:attribute name="period-type-v2" type="PeriodTypeV2-ST" use="required"/>
+    <xs:attribute name="range" type="xs:int" use="required"/>
+  </xs:complexType>
+  <xs:simpleType name="DataSource-YesNo-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="no"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:attributeGroup name="DateOptions-AG">
+    <xs:attribute name="start-of-week">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="seven-day-period"/>
+          <xs:enumeration value="sunday"/>
+          <xs:enumeration value="monday"/>
+          <xs:enumeration value="tuesday"/>
+          <xs:enumeration value="wednesday"/>
+          <xs:enumeration value="thursday"/>
+          <xs:enumeration value="friday"/>
+          <xs:enumeration value="saturday"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="fiscal-year-start">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="january"/>
+          <xs:enumeration value="february"/>
+          <xs:enumeration value="march"/>
+          <xs:enumeration value="april"/>
+          <xs:enumeration value="may"/>
+          <xs:enumeration value="june"/>
+          <xs:enumeration value="july"/>
+          <xs:enumeration value="august"/>
+          <xs:enumeration value="september"/>
+          <xs:enumeration value="october"/>
+          <xs:enumeration value="november"/>
+          <xs:enumeration value="december"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:group name="DateOptions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="date-options">
+        <xs:complexType>
+          <xs:attributeGroup ref="DateOptions-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ObjectModelRelationship-ObjectId-ST">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="EndPointAttributes-G">
+    <xs:sequence>
+      <xs:element name="first-end-point">
+        <xs:complexType>
+          <xs:attribute name="unique-key" type="xs:string"/>
+          <xs:attribute name="guaranteed-value" type="xs:string"/>
+          <xs:attribute name="is-db-set-unique-key" type="xs:boolean"/>
+          <xs:attribute name="is-db-set-guaranteed-value" type="xs:boolean"/>
+          <xs:attribute name="object-id" type="ObjectModelRelationship-ObjectId-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="second-end-point">
+        <xs:complexType>
+          <xs:attribute name="unique-key" type="xs:string"/>
+          <xs:attribute name="guaranteed-value" type="xs:string"/>
+          <xs:attribute name="is-db-set-unique-key" type="xs:boolean"/>
+          <xs:attribute name="is-db-set-guaranteed-value" type="xs:boolean"/>
+          <xs:attribute name="object-id" type="ObjectModelRelationship-ObjectId-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ObjectModelRelationship-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="relationship">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="SQLExpression-G"/>
+            <xs:group ref="EndPointAttributes-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceTree-Parents-G">
+    <xs:sequence>
+      <xs:element name="parents">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="DataSourceTreeNode-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceTree-ObjectModelRelationships-G">
+    <xs:sequence>
+      <xs:element name="relationships">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="ObjectModelRelationship-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceTreeNode-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="pds">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="DataSourceTree-Parents-G"/>
+            <xs:group minOccurs="0" ref="DataSourceTree-ObjectModelRelationships-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="datasource-url" type="xs:string"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="name-in-immediate-child" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceTree-NamePersistenceMaps-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="name-persistence-map">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="relation-alias-map">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="1" maxOccurs="unbounded" name="map">
+                    <xs:complexType>
+                      <xs:attribute name="current-alias" type="xs:string" use="required"/>
+                      <xs:attribute name="alias-in-genesis-datasource" type="xs:string" use="required"/>
+                      <xs:attribute name="genesis-datasource-name" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="object-id-map">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="1" maxOccurs="unbounded" name="map">
+                    <xs:complexType>
+                      <xs:attribute name="current-id" type="xs:string" use="required"/>
+                      <xs:attribute name="id-in-genesis-datasource" type="xs:string" use="required"/>
+                      <xs:attribute name="genesis-datasource-name" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="user-created-column-name-map">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="1" maxOccurs="unbounded" name="map">
+                    <xs:complexType>
+                      <xs:attribute name="current-name" type="xs:string" use="required"/>
+                      <xs:attribute name="name-in-origin-datasource" type="xs:string" use="required"/>
+                      <xs:attribute name="origin-datasource-name" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="parameter-name-map">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="1" maxOccurs="unbounded" name="map">
+                    <xs:complexType>
+                      <xs:attribute name="current-name" type="xs:string" use="required"/>
+                      <xs:attribute name="name-in-origin-datasource" type="xs:string" use="required"/>
+                      <xs:attribute name="origin-datasource-name" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="database-column-name-map">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="1" maxOccurs="unbounded" name="map">
+                    <xs:complexType>
+                      <xs:attribute name="current-name" type="xs:string" use="required"/>
+                      <xs:attribute name="name-in-remote-database" type="xs:string" use="required"/>
+                      <xs:attribute name="relation-current-alias" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceTree-Wrapper-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="data-source-tree">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="DataSourceTreeNode-G"/>
+            <xs:group minOccurs="0" ref="DataSourceTree-NamePersistenceMaps-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="FieldRole-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="dimension"/>
+      <xs:enumeration value="measure"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PivotStrategy-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="key"/>
+      <xs:enumeration value="alias"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AliasType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="alias-key"/>
+      <xs:enumeration value="alias-key-name"/>
+      <xs:enumeration value="alias-key-medname"/>
+      <xs:enumeration value="alias-key-longname"/>
+      <xs:enumeration value="alias-name"/>
+      <xs:enumeration value="alias-name-key"/>
+      <xs:enumeration value="alias-medname"/>
+      <xs:enumeration value="alias-medname-key"/>
+      <xs:enumeration value="alias-longname"/>
+      <xs:enumeration value="alias-longname-key"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FolderRole-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="dimensions"/>
+      <xs:enumeration value="measures"/>
+      <xs:enumeration value="groups"/>
+      <xs:enumeration value="parameters"/>
+      <xs:enumeration value="common"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FolderItemType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="field"/>
+      <xs:enumeration value="drillpath"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FieldOrderType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="datasource-order"/>
+      <xs:enumeration value="alpha-per-table"/>
+      <xs:enumeration value="alphabetical-order"/>
+      <xs:enumeration value="custom-order"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SortOrder-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ascending"/>
+      <xs:enumeration value="descending"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Filter-G">
+    <xs:sequence>
+      <xs:element name="filter">
+        <xs:complexType>
+          <xs:sequence minOccurs="0">
+            <xs:element minOccurs="0" name="min" type="DataValue-ST"/>
+            <xs:element minOccurs="0" name="max" type="DataValue-ST"/>
+            <xs:group minOccurs="0" ref="SetFunction-G"/>
+            <xs:group ref="Filter-FilterPresets-G"/>
+            <xs:group ref="Filter-FilterTargets-G"/>
+          </xs:sequence>
+          <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="context" type="xs:boolean"/>
+          <xs:attribute name="filter-group" type="xs:int"/>
+          <xs:attribute name="affect-totals" type="xs:boolean"/>
+          <xs:attribute name="class" type="Filter-Class-ST" use="required"/>
+          <xs:attribute name="included-values" type="Filter-Include-ST"/>
+          <xs:attribute name="period-type-v2" type="PeriodTypeV2-ST"/>
+          <xs:attribute name="period-anchor" type="DataValue-ST"/>
+          <xs:attribute name="first-period" type="xs:int"/>
+          <xs:attribute name="last-period" type="xs:int"/>
+          <xs:attribute name="include-future" type="xs:boolean"/>
+          <xs:attribute name="include-null" type="xs:boolean"/>
+          <xs:attribute name="logical-table-scoped" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="HideDataFilter-G">
+    <xs:sequence>
+      <xs:element name="filter">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="SetFunction-G"/>
+          </xs:sequence>
+          <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="kind" type="Filter-Kind-ST" use="required"/>
+          <xs:attribute name="class" type="Filter-Class-ST" use="required"/>
+          <xs:attribute name="logical-table-scoped" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="FilterOrHideDataFilter-G">
+    <xs:sequence>
+      <xs:element name="filter">
+        <xs:complexType>
+          <xs:sequence minOccurs="0">
+            <xs:element minOccurs="0" name="min" type="DataValue-ST"/>
+            <xs:element minOccurs="0" name="max" type="DataValue-ST"/>
+            <xs:group minOccurs="0" ref="SetFunction-G"/>
+            <xs:group ref="Filter-FilterPresets-G"/>
+            <xs:group ref="Filter-FilterTargets-G"/>
+          </xs:sequence>
+          <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="context" type="xs:boolean"/>
+          <xs:attribute name="filter-group" type="xs:int"/>
+          <xs:attribute name="affect-totals" type="xs:boolean"/>
+          <xs:attribute name="class" type="Filter-Class-ST" use="required"/>
+          <xs:attribute name="included-values" type="Filter-Include-ST"/>
+          <xs:attribute name="period-type-v2" type="PeriodTypeV2-ST"/>
+          <xs:attribute name="period-anchor" type="DataValue-ST"/>
+          <xs:attribute name="first-period" type="xs:int"/>
+          <xs:attribute name="last-period" type="xs:int"/>
+          <xs:attribute name="include-future" type="xs:boolean"/>
+          <xs:attribute name="include-null" type="xs:boolean"/>
+          <xs:attribute name="kind" type="Filter-Kind-ST"/>
+          <xs:attribute name="logical-table-scoped" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ClearFilter-G">
+    <xs:sequence>
+      <xs:element name="clear-filter">
+        <xs:complexType>
+          <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Filter-Class-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="categorical"/>
+      <xs:enumeration value="quantitative"/>
+      <xs:enumeration value="relative-date"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Filter-Include-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="all"/>
+      <xs:enumeration value="non-null"/>
+      <xs:enumeration value="null"/>
+      <xs:enumeration value="in-range"/>
+      <xs:enumeration value="in-range-or-null"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Filter-Kind-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="hide"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FilterScope-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="pervasive"/>
+      <xs:enumeration value="logical-tables"/>
+      <xs:enumeration value="datasource-scoped"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Filter-FilterTargets-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="target">
+        <xs:complexType>
+          <xs:attribute name="field" type="QualifiedName-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Filter-FilterPresets-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="preset">
+        <xs:complexType>
+          <xs:attribute name="type" type="PresetType-ST" use="required"/>
+          <xs:attribute name="applied" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GeocodingEnhancement-AddressColumns-G">
+    <xs:sequence>
+      <xs:element name="address-columns" minOccurs="1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="address-column" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+                <xs:attribute name="caption" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GeocodingEnhancement-G">
+    <xs:sequence>
+      <xs:element name="geocoding-enhancement">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="GeocodingEnhancement-AddressColumns-G"/>
+          </xs:sequence>
+          <xs:attribute name="instance-id" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MappedImage-Mapping-G">
+    <xs:sequence>
+      <xs:element name="mapping">
+        <xs:complexType>
+          <xs:attribute name="x" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="y" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="left" type="DataValue-ST" use="required"/>
+          <xs:attribute name="right" type="DataValue-ST" use="required"/>
+          <xs:attribute name="top" type="DataValue-ST" use="required"/>
+          <xs:attribute name="bottom" type="DataValue-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MappedImage-Options-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="image-options">
+        <xs:complexType>
+          <xs:attribute name="lock-aspect-ratio" type="xs:boolean"/>
+          <xs:attribute name="show-entire-image" type="xs:boolean"/>
+          <xs:attribute name="desaturate-image" type="xs:boolean"/>
+          <xs:attribute name="desaturate-pct" type="Float-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MappedImage-Predicates-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="SetFunction-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MappedImageSpec-G">
+    <xs:sequence>
+      <xs:element name="mapped-image">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="MappedImage-Mapping-G"/>
+            <xs:group ref="MappedImage-Options-G"/>
+            <xs:group ref="MappedImage-Predicates-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="caption" type="xs:string" use="required"/>
+          <xs:attribute name="expression" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ObjectId-ST">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="ObjectGraphNode-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="object">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="properties">
+              <xs:complexType>
+                <xs:choice minOccurs="0">
+                  <xs:group ref="Relation-G"/>
+                  <xs:group ref="AnalyticsExtensionObjectNode-G"/>
+                </xs:choice>
+                <xs:attribute name="context" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="table-description">
+              <xs:complexType>
+                <xs:group ref="FormattedText-G"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="id" type="ObjectId-ST" use="required"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="origin-pds" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="AnalyticsExtensionObjectNode-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="analytics-extension-object-node">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="script-code" type="xs:string"/>
+            <xs:element name="input">
+              <xs:complexType>
+                <xs:sequence minOccurs="0">
+                  <xs:group ref="Relation-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="output">
+              <xs:complexType>
+                <xs:sequence minOccurs="1">
+                  <xs:group ref="Relation-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ObjectGraph-ObjectNodes-G">
+    <xs:sequence>
+      <xs:element name="objects">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="ObjectGraphNode-G"/>
+          </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="UniqueObjectId">
+          <xs:selector xpath="object"/>
+          <xs:field xpath="@id"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ObjectGraph-ObjectModelRelationships-G">
+    <xs:sequence>
+      <xs:element name="relationships">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="ObjectModelRelationship-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ObjectGraph-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="object-graph">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="ObjectGraph-ObjectNodes-G"/>
+            <xs:group minOccurs="0" ref="ObjectGraph-ObjectModelRelationships-G"/>
+          </xs:sequence>
+          <xs:attribute name="is-legacy" type="xs:boolean"/>
+          <xs:attribute name="semantic-layer" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Descendants-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="SELF"/>
+      <xs:enumeration value="AFTER"/>
+      <xs:enumeration value="SELF-AND-AFTER"/>
+      <xs:enumeration value="BEFORE"/>
+      <xs:enumeration value="SELF-AND_BEFORE"/>
+      <xs:enumeration value="BEFORE-AND-AFTER"/>
+      <xs:enumeration value="SELF_BEFORE-AFTER"/>
+      <xs:enumeration value="LEAVES"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Include-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="all"/>
+      <xs:enumeration value="non-null"/>
+      <xs:enumeration value="null"/>
+      <xs:enumeration value="in-range"/>
+      <xs:enumeration value="in-range-or-null"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PeriodType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="year"/>
+      <xs:enumeration value="quarter"/>
+      <xs:enumeration value="month"/>
+      <xs:enumeration value="week"/>
+      <xs:enumeration value="day"/>
+      <xs:enumeration value="hour"/>
+      <xs:enumeration value="minute"/>
+      <xs:enumeration value="second"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PeriodTypeV2-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="year"/>
+      <xs:enumeration value="iso-year"/>
+      <xs:enumeration value="quarter"/>
+      <xs:enumeration value="iso-quarter"/>
+      <xs:enumeration value="month"/>
+      <xs:enumeration value="week"/>
+      <xs:enumeration value="iso-week"/>
+      <xs:enumeration value="day"/>
+      <xs:enumeration value="hour"/>
+      <xs:enumeration value="minute"/>
+      <xs:enumeration value="second"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PresetType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="last-values"/>
+      <xs:enumeration value="current-values"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="SetFunction-G">
+    <xs:sequence>
+      <xs:element name="groupfilter">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="projection" type="Dimensionality-CT"/>
+            <xs:element minOccurs="0" name="perspective" type="SetFunction-Perspective-CT"/>
+            <xs:element minOccurs="0" name="tuples" type="TupleList-CT"/>
+            <xs:element minOccurs="0" name="dimensionality" type="Dimensionality-CT"/>
+            <xs:element minOccurs="0" name="cols" type="SetFunction-NameBindings-CT"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="SetFunction-G"/>
+            <xs:element minOccurs="0" name="order" type="Dimensionality-CT"/>
+          </xs:sequence>
+          <xs:attribute name="function" type="Function-ST" use="required"/>
+          <xs:attribute name="level" type="QualifiedName-ST"/>
+          <xs:attribute name="flag" type="Descendants-ST"/>
+          <xs:attribute name="slice" type="xs:boolean"/>
+          <xs:attribute name="member" type="SetFunction-Member-ST"/>
+          <xs:attribute name="end" type="SortEnd-ST"/>
+          <xs:attribute name="count" type="Expression-ST"/>
+          <xs:attribute name="units" type="SortUnits-ST"/>
+          <xs:attribute name="expression" type="Expression-ST"/>
+          <xs:attribute name="perspective-type" type="SetFunction-PerspectiveType-ST"/>
+          <xs:attribute name="hierarchy" type="QualifiedName-ST"/>
+          <xs:attribute name="name" type="QualifiedName-ST"/>
+          <xs:attribute name="remote-expression" type="Expression-ST"/>
+          <xs:attribute name="evaluation-context" type="EvaluationContext-ST"/>
+          <xs:attribute name="direction" type="SetFunction-OrderSortDirection-ST"/>
+          <xs:attribute name="from" type="DataValue-ST"/>
+          <xs:attribute name="to" type="DataValue-ST"/>
+          <xs:attribute name="period-type-v2" type="PeriodTypeV2-ST"/>
+          <xs:attribute name="first-period" type="xs:int"/>
+          <xs:attribute name="last-period" type="xs:int"/>
+          <xs:attribute name="include-future" type="xs:boolean"/>
+          <xs:attribute name="period-anchor" type="DataValue-ST"/>
+          <xs:attribute name="field" type="QualifiedName-ST"/>
+          <xs:attribute name="keep-duplicates" type="xs:boolean"/>
+          <xs:attributeGroup ref="user:UserAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="SortEnd-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="top"/>
+      <xs:enumeration value="bottom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SortUnits-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="percent"/>
+      <xs:enumeration value="records"/>
+      <xs:enumeration value="sample-percent"/>
+      <xs:enumeration value="sample-records"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EvaluationContext-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="static"/>
+      <xs:enumeration value="dynamic"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="LevelFlags-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[01]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Dimensionality-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="hierarchy">
+        <xs:complexType>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="level-flags" type="LevelFlags-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Expression-ST">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="SetFunction-Member-ST">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="SetFunction-PerspectiveType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="reality"/>
+      <xs:enumeration value="first"/>
+      <xs:enumeration value="last"/>
+      <xs:enumeration value="custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="SetFunction-BoundsTuple-CT">
+    <xs:sequence>
+      <xs:group ref="Tuple-G"/>
+    </xs:sequence>
+    <xs:attribute name="indep-dim" type="QualifiedName-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="SetFunction-Perspective-CT">
+    <xs:sequence maxOccurs="unbounded" minOccurs="0">
+      <xs:element name="start" type="SetFunction-BoundsTuple-CT"/>
+      <xs:element name="end" type="SetFunction-BoundsTuple-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SetFunction-NameBindings-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="map">
+        <xs:complexType>
+          <xs:attribute name="key" type="QualifiedName-ST"/>
+          <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="SetFunction-OrderSortDirection-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ASC"/>
+      <xs:enumeration value="DESC"/>
+      <xs:enumeration value="BASC"/>
+      <xs:enumeration value="BDESC"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Bucket-G">
+    <xs:sequence>
+      <xs:element name="bucket">
+        <xs:simpleType>
+          <xs:restriction base="DataValue-ST"/>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="BucketList-CT">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="Bucket-G"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="MultiBucket-Only-G">
+    <xs:sequence>
+      <xs:element name="multibucket" type="BucketList-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MultiBucket-Or-Bucket-G">
+    <xs:choice>
+      <xs:group ref="MultiBucket-Only-G"/>
+      <xs:group ref="Bucket-G"/>
+    </xs:choice>
+  </xs:group>
+  <xs:simpleType name="Op-ST">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:group name="SQLExpression-G">
+    <xs:sequence>
+      <xs:element name="expression">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="SQLExpression-G"/>
+          </xs:sequence>
+          <xs:attribute name="op" type="Op-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Sort-G">
+    <xs:choice>
+      <xs:group ref="Sort-ComputedSort-G"/>
+      <xs:group ref="Sort-ManualSort-G"/>
+      <xs:group ref="Sort-Natural-G"/>
+      <xs:group ref="Sort-Alphabetic-G"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="ClearSort-G">
+    <xs:sequence>
+      <xs:element name="clear-sort">
+        <xs:complexType>
+          <xs:attribute name="column" type="Sort-FieldName-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Sort-ComputedSort-G">
+    <xs:sequence>
+      <xs:element name="computed-sort">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="SetFunction-G"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="Sort-CommonAttributes-AG"/>
+          <xs:attribute name="using" type="Sort-FieldName-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Sort-ManualSort-G">
+    <xs:sequence>
+      <xs:element name="manual-sort">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="dictionary" type="BucketList-CT"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="Sort-CommonAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Sort-Natural-G">
+    <xs:sequence>
+      <xs:element name="natural-sort">
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Sort-Alphabetic-G">
+    <xs:sequence>
+      <xs:element name="alphabetic-sort">
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Sort-FieldName-ST">
+    <xs:restriction base="QualifiedName-ST"/>
+  </xs:simpleType>
+  <xs:attributeGroup name="Sort-CommonAttributes-AG">
+    <xs:attribute name="column" type="Sort-FieldName-ST" use="required"/>
+    <xs:attribute name="direction" type="SortDirection-ST" use="required"/>
+  </xs:attributeGroup>
+  <xs:simpleType name="DataScaling-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="standardized"/>
+      <xs:enumeration value="normalized"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Fields-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+        <xs:complexType>
+          <xs:attribute name="name" type="FullValue-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="StatisticalModel-NumClusters-ST">
+    <xs:restriction base="xs:int">
+      <xs:minInclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="UnsupervisedModel-G">
+    <xs:sequence>
+      <xs:element name="model-specification">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="analysis-fields" type="Fields-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StatisticalModel-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="statistical-model">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="UnsupervisedModel-G"/>
+            <xs:element name="model-summary">
+              <xs:complexType>
+                <xs:sequence minOccurs="0">
+                  <xs:group ref="StatisticalModel-Clusters-G"/>
+                  <xs:group ref="StatisticalModel-ANOVA-G"/>
+                </xs:sequence>
+                <xs:attribute name="num-rows" type="xs:int"/>
+                <xs:attribute name="num-cols" type="xs:int"/>
+                <xs:attribute name="num-desired-clusters" type="StatisticalModel-NumClusters-ST" use="required"/>
+                <xs:attribute name="num-clusters" type="xs:int"/>
+                <xs:attribute name="num-outliers" type="xs:int"/>
+                <xs:attribute name="num-not-clustered" type="xs:int"/>
+                <xs:attribute name="between-group-sum-of-squared" type="Double-ST"/>
+                <xs:attribute name="within-group-sum-of-squares" type="Double-ST"/>
+                <xs:attribute name="total-sum-of-squares" type="Double-ST"/>
+                <xs:attribute name="estimate-nulls" type="xs:boolean"/>
+                <xs:attribute name="scaling" type="DataScaling-ST"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="class" type="StatisticalModelClass-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StatisticalModel-Clusters-G">
+    <xs:sequence>
+      <xs:element name="clusters">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="StatisticalModel-Cluster-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StatisticalModel-Cluster-G">
+    <xs:sequence>
+      <xs:element name="cluster">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="derivedcolumn">
+              <xs:complexType>
+                <xs:attribute name="mean" type="Double-ST" use="required"/>
+                <xs:attribute name="std-dev" type="Double-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="size" type="xs:int" use="required"/>
+          <xs:attribute name="outlier-cutoff" type="Double-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StatisticalModel-ANOVA-G">
+    <xs:sequence>
+      <xs:element name="anova">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="derivedcolumn">
+              <xs:complexType>
+                <xs:attribute name="cluster-df" type="xs:int" use="required"/>
+                <xs:attribute name="cluster-ss" type="Double-ST" use="required"/>
+                <xs:attribute name="cluster-ms" type="Double-ST" use="required"/>
+                <xs:attribute name="error-df" type="xs:int" use="required"/>
+                <xs:attribute name="error-ss" type="Double-ST" use="required"/>
+                <xs:attribute name="error-ms" type="Double-ST" use="required"/>
+                <xs:attribute name="f-statistic" type="Double-ST" use="required"/>
+                <xs:attribute name="p-value" type="Double-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="TCType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None"/>
+      <xs:enumeration value="CumTotal"/>
+      <xs:enumeration value="WindowTotal"/>
+      <xs:enumeration value="Difference"/>
+      <xs:enumeration value="PctDiff"/>
+      <xs:enumeration value="PctValue"/>
+      <xs:enumeration value="PctTotal"/>
+      <xs:enumeration value="Rank"/>
+      <xs:enumeration value="PctRank"/>
+      <xs:enumeration value="Custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="OrderingType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None"/>
+      <xs:enumeration value="Table"/>
+      <xs:enumeration value="TableCol"/>
+      <xs:enumeration value="Rows"/>
+      <xs:enumeration value="Columns"/>
+      <xs:enumeration value="Pane"/>
+      <xs:enumeration value="PaneCol"/>
+      <xs:enumeration value="RowInPane"/>
+      <xs:enumeration value="ColumnInPane"/>
+      <xs:enumeration value="CellInPane"/>
+      <xs:enumeration value="Field"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="WindowOptions-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="IncludeCurrent"/>
+      <xs:enumeration value="NullIfIncomplete"/>
+      <xs:enumeration value="IncludeCurrent,NullIfIncomplete"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DifferenceOptions-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(Fixed|Relative)(,(Parameter|Compounded))*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PctTotalOptions-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="IncludePages"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="RankOptions-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(Unique|Competition|ModifiedCompetition|Dense),(Ascending|Descending)"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CustomOptions-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(UsePartitionDomain|Parameter|Fixed|NullIfIncomplete|IncludePages)(,(UsePartitionDomain|Parameter|Fixed|NullIfIncomplete|IncludePages))*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="TableCalc-G">
+    <xs:sequence>
+      <xs:element name="table-calc">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="TableCalcProp-OrderingFields-G"/>
+            <xs:group minOccurs="0" ref="TableCalcProp-Address-G"/>
+          </xs:sequence>
+          <xs:attribute name="field" type="QualifiedName-ST"/>
+          <xs:attribute name="ordering-type" type="OrderingType-ST" use="required"/>
+          <xs:attribute name="ordering-field" type="QualifiedName-ST"/>
+          <xs:attribute name="level-break" type="QualifiedName-ST"/>
+          <xs:attribute name="level-address" type="QualifiedName-ST"/>
+          <xs:attribute name="aggregation" type="AggType-ST"/>
+          <xs:attribute name="type" type="TCType-ST"/>
+          <xs:attribute name="from" type="DataValue-ST"/>
+          <xs:attribute name="to" type="DataValue-ST"/>
+          <xs:attribute name="window-options" type="WindowOptions-ST"/>
+          <xs:attribute name="diff-options" type="DifferenceOptions-ST"/>
+          <xs:attribute name="pcttotal-options" type="PctTotalOptions-ST"/>
+          <xs:attribute name="rank-options" type="RankOptions-ST"/>
+          <xs:attribute name="tc-options" type="CustomOptions-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="TableCalcProp-OrderingFields-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="order">
+        <xs:complexType>
+          <xs:attribute name="field" type="QualifiedName-ST"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element minOccurs="0" name="sort">
+        <xs:complexType>
+          <xs:attribute name="using" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="direction" type="SortDirection-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="TableCalcProp-Address-G">
+    <xs:sequence>
+      <xs:element name="address">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="value" type="DataValue-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="OSShortName-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="win"/>
+      <xs:enumeration value="mac"/>
+      <xs:enumeration value="linux"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Group-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="group">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="SetFunction-G"/>
+            <xs:element minOccurs="0" name="desc">
+              <xs:complexType>
+                <xs:group ref="FormattedText-G"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:group minOccurs="0" ref="DataSource-Aliases-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="name-style"/>
+          <xs:attribute name="delimiter" type="xs:string"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="pivot" type="PivotStrategy-ST"/>
+          <xs:attribute name="descend" type="xs:boolean"/>
+          <xs:attribute name="hidden" type="xs:boolean"/>
+          <xs:attribute name="auto-hidden" type="xs:boolean"/>
+          <xs:attribute name="layered" type="xs:boolean"/>
+          <xs:attributeGroup ref="user:UserAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Groups-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="Group-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Aliases-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="aliases">
+        <xs:complexType>
+          <xs:attribute name="enabled" type="DataSource-YesNo-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Column-G">
+    <xs:sequence>
+      <xs:element name="column">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="DataSource-LocalizedServerCaptions-G"/>
+            <xs:group minOccurs="0" ref="DataSource-Calculation-G"/>
+            <xs:group minOccurs="0" ref="DataSource-UtilityDimension-G"/>
+            <xs:group minOccurs="0" ref="DataSource-Aliases-G"/>
+            <xs:group minOccurs="0" ref="StatisticalModel-G"/>
+            <xs:group minOccurs="0" ref="DataSource-SemanticRole-G"/>
+            <xs:group minOccurs="0" ref="DataSource-UserDescription-G"/>
+            <xs:choice minOccurs="0">
+              <xs:group ref="ParameterList-G"/>
+              <xs:group ref="ParameterRange-G"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="role" type="FieldRole-ST" use="required"/>
+          <xs:attribute name="default-role" type="FieldRole-ST"/>
+          <xs:attribute name="aggregation" type="AggType-ST"/>
+          <xs:attribute name="aggregation-param" type="DataValue-ST"/>
+          <xs:attribute name="visual-totals" type="xs:string"/>
+          <xs:attribute name="type" type="FieldType-ST" use="required"/>
+          <xs:attribute name="default-type" type="FieldType-ST"/>
+          <xs:attribute name="datatype" type="DataType-ST" use="required"/>
+          <xs:attribute name="datatype-customized" type="xs:boolean"/>
+          <xs:attribute name="user-datatype" type="DataType-ST"/>
+          <xs:attribute name="default-format" type="xs:string"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="pivot" type="PivotStrategy-ST"/>
+          <xs:attribute name="hidden" type="xs:boolean"/>
+          <xs:attribute name="auto-hidden" type="xs:boolean"/>
+          <xs:attribute name="layered" type="xs:boolean"/>
+          <xs:attribute name="is-adhoc-cluster" type="xs:boolean"/>
+          <xs:attribute name="fiscal-year-start" type="xs:unsignedInt"/>
+          <xs:attribute name="semantic-role" type="QualifiedName-ST"/>
+          <xs:attribute name="semantic-layer" type="xs:boolean"/>
+          <xs:attribute name="parent-model" type="xs:string"/>
+          <xs:attribute name="alias-types-defined" type="xs:int"/>
+          <xs:attribute name="aliastype" type="AliasType-ST"/>
+          <xs:attribute name="approximate-count" type="xs:long"/>
+          <xs:attribute name="source-field" type="QualifiedName-ST"/>
+          <xs:attribute name="param-domain-type" type="DomainType-ST"/>
+          <xs:attribute name="value" type="DataValue-ST"/>
+          <xs:attribute name="alias" type="xs:string"/>
+          <xs:attribute name="folder-name" type="xs:string"/>
+          <xs:attribute name="default-value-field" type="QualifiedName-ST"/>
+          <xs:attribute name="aggregate-role-from" type="QualifiedName-ST"/>
+          <xs:attribute name="is-auto-gen-lod-field" type="xs:boolean"/>
+          <xs:attributeGroup ref="user:UserAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="MemberProperty-CT">
+    <xs:attribute name="key" type="DataValue-ST" use="required"/>
+    <xs:attribute name="value" type="DataValue-ST" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="MemberProperty-WithStringValue-CT">
+    <xs:attribute name="key" type="DataValue-ST" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:group name="CalculatedMembers-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="calculated-members">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="DataSource-CalculatedMember-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Columns-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="Column-G"/>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="ColumnInstance-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceInline-G">
+    <xs:sequence>
+      <xs:element name="datasource" type="DataSource-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-ObjectGraph-G">
+    <xs:sequence>
+      <xs:group ref="ObjectGraph-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-DataSourceTree-G">
+    <xs:sequence>
+      <xs:group ref="DataSourceTree-Wrapper-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="DataSource-CT">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DocumentManifest-G"/>
+      <xs:group ref="RepositoryLocation-G"/>
+      <xs:group minOccurs="0" ref="Connection-G"/>
+      <xs:group ref="UtilityDimension-G"/>
+      <xs:group ref="Dimensions-G"/>
+      <xs:group ref="OverridableSettings-G"/>
+      <xs:group ref="Aliases-G"/>
+      <xs:group ref="Columns-G"/>
+      <xs:group ref="Groups-G"/>
+      <xs:group ref="MappedImages-G"/>
+      <xs:group ref="DrillPaths-G"/>
+      <xs:element minOccurs="0" name="folders-common" type="FieldFolders-CT"/>
+      <xs:element minOccurs="0" name="folders-parameters" type="FieldFolders-CT"/>
+      <xs:group ref="DataSource-Actions-G"/>
+      <xs:group ref="CalculatedMembers-G"/>
+      <xs:group ref="Extract-G"/>
+      <xs:group ref="Layout-G"/>
+      <xs:group ref="Styles-G"/>
+      <xs:group ref="SemanticRoleDefaults-G"/>
+      <xs:group ref="DataSource-DateOptions-G"/>
+      <xs:group ref="DefaultDateFormat-G"/>
+      <xs:group ref="DefaultSorts-G"/>
+      <xs:group ref="FieldSortInfo-G"/>
+      <xs:group ref="DataSourceDependencies-G"/>
+      <xs:group ref="Explainability-G"/>
+      <xs:group ref="DataSourceFilters-G"/>
+      <xs:group ref="AnalyticModel-G"/>
+      <xs:group minOccurs="0" ref="DataSource-ObjectGraph-G"/>
+      <xs:group ref="DefaultCalendarType-G"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="caption" type="xs:string"/>
+    <xs:attribute name="formatted-name" type="xs:string"/>
+    <xs:attribute ref="xml:base"/>
+    <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+    <xs:attribute fixed="true" name="inline" type="xs:boolean" use="required"/>
+    <xs:attribute name="hasconnection" type="xs:boolean"/>
+    <xs:attribute name="source-platform" type="OSShortName-ST"/>
+  </xs:complexType>
+  <xs:group name="OverridableSettings-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="overridable-settings">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="DateOptions-G"/>
+            <xs:element name="default-date-format" type="xs:string"/>
+            <xs:element name="default-calendar-type" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Extract-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="extract">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Connection-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Filter-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="DataSource-Aggregation-G"/>
+          </xs:sequence>
+          <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+          <xs:attribute name="units" type="SortUnits-ST" use="required"/>
+          <xs:attribute name="count" type="Float-ST" use="required"/>
+          <xs:attribute name="object-id" type="xs:string" use="required"/>
+          <xs:attribute name="type" type="Extract-Type-ST"/>
+          <xs:attribute name="user-specific" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Extract-Type-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="normalized"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="MappedImages-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="mapped-images">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="MappedImageSpec-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GeocodingEnhancements-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="geocoding-enhancements">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="GeocodingEnhancement-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DrillPaths-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="drill-paths">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="DrillPath-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element minOccurs="0" name="unlinked-server-hierarchies">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="hierarchy">
+              <xs:complexType>
+                <xs:attribute name="server-id" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DrillPath-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="drill-path">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="field" type="QualifiedName-ST"/>
+            <xs:element minOccurs="0" name="desc">
+              <xs:complexType>
+                <xs:group ref="FormattedText-G"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="server-id" type="xs:string"/>
+          <xs:attribute name="layered" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="FolderItems-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="folder-item">
+        <xs:complexType>
+          <xs:attribute name="type" type="FolderItemType-ST" use="required"/>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="FieldFolders-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="folder" type="FieldFolder-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="FieldFolder-CT">
+    <xs:group ref="FolderItems-G"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="layered" type="xs:boolean"/>
+  </xs:complexType>
+  <xs:group name="DataSource-Actions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="actions">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="ActionSpec-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceLink-G">
+    <xs:sequence>
+      <xs:element name="datasource">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="caption" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceInlineOrLink-G">
+    <xs:sequence>
+      <xs:element name="datasource">
+        <xs:complexType>
+          <xs:sequence minOccurs="0">
+            <xs:group ref="RepositoryLocation-G"/>
+            <xs:group minOccurs="0" ref="Connection-G"/>
+            <xs:group ref="UtilityDimension-G"/>
+            <xs:group ref="Dimensions-G"/>
+            <xs:group ref="OverridableSettings-G"/>
+            <xs:group ref="Aliases-G"/>
+            <xs:group ref="Columns-G"/>
+            <xs:group ref="Groups-G"/>
+            <xs:group ref="MappedImages-G"/>
+            <xs:group ref="DrillPaths-G"/>
+            <xs:element minOccurs="0" name="folders-common" type="FieldFolders-CT"/>
+            <xs:element minOccurs="0" name="folders-parameters" type="FieldFolders-CT"/>
+            <xs:group ref="DataSource-Actions-G"/>
+            <xs:group ref="CalculatedMembers-G"/>
+            <xs:group ref="Extract-G"/>
+            <xs:group ref="Layout-G"/>
+            <xs:group ref="Styles-G"/>
+            <xs:group ref="SemanticRoleDefaults-G"/>
+            <xs:group ref="DataSource-DateOptions-G"/>
+            <xs:group ref="DefaultDateFormat-G"/>
+            <xs:group ref="DefaultSorts-G"/>
+            <xs:group ref="FieldSortInfo-G"/>
+            <xs:group ref="DataSourceDependencies-G"/>
+            <xs:group ref="Explainability-G"/>
+            <xs:group ref="DataSourceFilters-G"/>
+            <xs:group ref="AnalyticModel-G"/>
+            <xs:group minOccurs="0" ref="DataSource-ObjectGraph-G"/>
+            <xs:group ref="DefaultCalendarType-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="formatted-name" type="xs:string"/>
+          <xs:attribute ref="xml:base"/>
+          <xs:attribute name="version" type="VersionNumber-ST"/>
+          <xs:attribute name="inline" type="xs:boolean"/>
+          <xs:attribute name="hasconnection" type="xs:boolean"/>
+          <xs:attribute name="source-platform" type="OSShortName-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ConnectionInfo-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Connection-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Hierarchy-G">
+    <xs:sequence>
+      <xs:element name="hierarchy">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="default-member">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="Tuple-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="hidden" type="xs:boolean"/>
+          <xs:attribute name="layered" type="xs:boolean"/>
+          <xs:attribute name="pivot" type="PivotStrategy-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Dimensions-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="dimension">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Hierarchy-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="default-hierarchy" type="QualifiedName-ST"/>
+          <xs:attribute name="shared-members" type="DataSource-YesNo-ST" use="required"/>
+          <xs:attribute name="aliastype" type="AliasType-ST"/>
+          <xs:attribute name="caption" type="xs:string"/>
+          <xs:attribute name="hidden" type="xs:boolean"/>
+          <xs:attribute name="layered" type="xs:boolean"/>
+          <xs:attribute name="pivot" type="PivotStrategy-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="LayoutPercentages-AG">
+    <xs:attribute name="dim-percentage-v2" type="Float-ST"/>
+    <xs:attribute name="measure-percentage-v2" type="Float-ST"/>
+    <xs:attribute name="common-percentage" type="Float-ST"/>
+    <xs:attribute name="group-percentage" type="Float-ST"/>
+    <xs:attribute name="parameter-percentage" type="Float-ST"/>
+    <xs:attribute name="user-set-layout-v2" type="xs:boolean"/>
+  </xs:attributeGroup>
+  <xs:group name="Layout-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="layout">
+        <xs:complexType>
+          <xs:attributeGroup ref="LayoutPercentages-AG"/>
+          <xs:attribute name="dim-ordering" type="ColumnOrdering-ST" use="required"/>
+          <xs:attribute name="measure-ordering" type="ColumnOrdering-ST" use="required"/>
+          <xs:attribute name="show-structure" type="xs:boolean" use="required"/>
+          <xs:attribute name="show-hidden-fields" type="xs:boolean"/>
+          <xs:attribute name="auto-hide-new-columns" type="xs:boolean"/>
+          <xs:attribute name="show-aliased-fields" type="xs:boolean"/>
+          <xs:attribute name="rowDisplayCount" type="xs:positiveInteger"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Styles-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Stylesheet-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SemanticRoleDefaults-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="semantic-values">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="semantic-value">
+              <xs:complexType>
+                <xs:attribute name="key" type="QualifiedName-ST" use="required"/>
+                <xs:attribute name="value" type="DataValue-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-DateOptions-G">
+    <xs:sequence>
+      <xs:group ref="DateOptions-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DefaultCalendarType-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="default-calendar-type" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DefaultDateFormat-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="default-date-format" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DefaultSorts-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="default-sorts">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="Sort-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="UtilityDimension-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="utility-dimensions">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="utility-dimension">
+              <xs:complexType>
+                <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ParameterList-G">
+    <xs:sequence>
+      <xs:element name="members">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="member">
+              <xs:complexType>
+                <xs:attribute name="value" type="DataValue-ST" use="required"/>
+                <xs:attribute name="alias" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ParameterRange-G">
+    <xs:sequence>
+      <xs:element name="range">
+        <xs:complexType>
+          <xs:attribute name="min" type="DataValue-ST"/>
+          <xs:attribute name="max" type="DataValue-ST"/>
+          <xs:attribute name="granularity" type="DataValue-ST"/>
+          <xs:attribute name="period-type-v2" type="PeriodTypeV2-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceDependencies-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="datasource-dependencies">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded" minOccurs="0">
+              <xs:group ref="Column-G"/>
+              <xs:group ref="ColumnInstance-G"/>
+              <xs:group minOccurs="0" ref="Stylesheet-G"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="datasource" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Explainability-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="explainability">
+        <xs:complexType>
+          <xs:sequence maxOccurs="unbounded" minOccurs="0">
+            <xs:element name="explainability-field">
+              <xs:complexType>
+                <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+                <xs:attribute name="used" type="xs:boolean" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourcesAndDependencies-G">
+    <xs:sequence>
+      <xs:sequence minOccurs="0">
+        <xs:element name="datasources">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:group maxOccurs="unbounded" minOccurs="0" ref="DataSourceLink-G"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:group ref="DataSourceDependencies-G"/>
+      </xs:sequence>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceFilters-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="Filter-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="FieldSortInfo-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="field-sort-info">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="field-sort-custom-order">
+              <xs:complexType>
+                <xs:attribute name="field" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="field-sort-order-type" type="FieldOrderType-ST"/>
+          <xs:attribute name="field-sort-order" type="SortOrder-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-UserDescription-G">
+    <xs:sequence>
+      <xs:element name="desc">
+        <xs:complexType>
+          <xs:group ref="FormattedText-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-SemanticRole-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="semantic-values">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="semantic-value" type="MemberProperty-CT"/>
+          </xs:sequence>
+          <xs:attribute name="semantic-role" type="QualifiedName-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-LocalizedServerCaptions-G">
+    <xs:sequence>
+      <xs:element name="server-captions">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="caption">
+              <xs:complexType mixed="true">
+                <xs:attribute name="locale" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-Calculation-G">
+    <xs:sequence>
+      <xs:element name="calculation">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="TableCalc-G"/>
+            <xs:group minOccurs="0" ref="DataSource-Bins-G"/>
+          </xs:sequence>
+          <xs:attribute name="class" type="DataSource-CalculationType-ST" use="required"/>
+          <xs:attribute name="formula" type="xs:string"/>
+          <xs:attribute name="scope-isolation" type="xs:boolean"/>
+          <xs:attribute name="solve-order" type="xs:string"/>
+          <xs:attribute name="peg" type="Float-ST"/>
+          <xs:attribute name="decimals" type="xs:int"/>
+          <xs:attribute name="size-parameter" type="QualifiedName-ST"/>
+          <xs:attribute name="size" type="Float-ST"/>
+          <xs:attribute name="new-bin" type="xs:boolean"/>
+          <xs:attribute name="column" type="QualifiedName-ST"/>
+          <xs:attribute name="default" type="DataValue-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DataSource-CalculationType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="tableau"/>
+      <xs:enumeration value="passthrough"/>
+      <xs:enumeration value="bin"/>
+      <xs:enumeration value="categorical-bin"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DataSource-Bins-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="bin">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="value" type="DataValue-ST"/>
+          </xs:sequence>
+          <xs:attribute name="value" type="DataValue-ST" use="required"/>
+          <xs:attribute name="default-name" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-UtilityDimension-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="utility-members">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="utility-member">
+              <xs:complexType>
+                <xs:attribute name="level" type="QualifiedName-ST" use="required"/>
+                <xs:attribute name="default-member" type="DataValue-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-CalculatedMember-G">
+    <xs:sequence>
+      <xs:element name="calculated-member">
+        <xs:complexType>
+          <xs:attribute name="type" type="DataSource-CalculatedMemberType-ST"/>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="solve-order" type="xs:unsignedInt"/>
+          <xs:attribute name="scope-isolation" type="xs:boolean"/>
+          <xs:attribute name="formula" type="xs:string"/>
+          <xs:attribute name="parent" type="DataValue-ST"/>
+          <xs:attribute name="field" type="QualifiedName-ST"/>
+          <xs:attribute name="dialect" type="DataSource-DAX-ST"/>
+          <xs:attribute name="from" type="QualifiedName-ST"/>
+          <xs:attribute name="aggregation" type="AggType-ST"/>
+          <xs:attribute name="enabled" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DataSource-CalculatedMemberType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="member"/>
+      <xs:enumeration value="measure"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DataSource-Aggregation-G">
+    <xs:sequence>
+      <xs:element name="aggregation">
+        <xs:complexType>
+          <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="derivation" type="AggType-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSource-Aliases-G">
+    <xs:sequence>
+      <xs:element name="aliases">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="alias" type="MemberProperty-WithStringValue-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DataSource-DAX-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="DAX"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DataSourceRelationships-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DataSourceDependencies-G"/>
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="DataSourceRelationship-DataSourceRelationship-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ColumnMapping-G">
+    <xs:sequence>
+      <xs:element name="column-mapping">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="map">
+              <xs:complexType>
+                <xs:attribute name="key" type="QualifiedName-ST"/>
+                <xs:attribute name="value" type="QualifiedName-ST"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="DataSourceRelationship-DataSourceRelationship-G">
+    <xs:sequence>
+      <xs:element name="datasource-relationship">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ColumnMapping-G"/>
+          </xs:sequence>
+          <xs:attribute name="source" type="xs:string" use="required"/>
+          <xs:attribute name="target" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DateFormat_5-ST">
+    <xs:restriction base="DateFormat_5-Base-ST">
+      <xs:pattern value="[^#].*[^#]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_6-ST">
+    <xs:restriction base="DateFormat_6-Base-ST">
+      <xs:pattern value="[^#].*[^#]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_11-ST">
+    <xs:restriction base="DateFormat_11-Base-ST">
+      <xs:pattern value="[^#].*[^#]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_13-ST">
+    <xs:restriction base="DateFormat_13-Base-ST">
+      <xs:pattern value="[^#].*[^#]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_19-ST">
+    <xs:restriction base="DateFormat_19-Base-ST">
+      <xs:pattern value="[^#].*[^#]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_5-Base-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#?[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}#?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_6-Base-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#?[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}#?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_11-Base-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#?[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}#?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_13-Base-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#?[0-9]{2}:[0-9]{2}:[0-9]{2}#?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateFormat_19-Base-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#?[0-9]{4}-[0-9]{2}-[0-9]{2}#?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataValue-ST">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="DataType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="unknown"/>
+      <xs:enumeration value="integer"/>
+      <xs:enumeration value="real"/>
+      <xs:enumeration value="string"/>
+      <xs:enumeration value="datetime"/>
+      <xs:enumeration value="date"/>
+      <xs:enumeration value="boolean"/>
+      <xs:enumeration value="tuple"/>
+      <xs:enumeration value="spatial"/>
+      <xs:enumeration value="table"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Special-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="%null%"/>
+      <xs:enumeration value="%all%"/>
+      <xs:enumeration value="%wildcard%"/>
+      <xs:enumeration value="%skipped%"/>
+      <xs:enumeration value="%no-access%"/>
+      <xs:enumeration value="%ragged%"/>
+      <xs:enumeration value="%error%"/>
+      <xs:enumeration value="%many-values%"/>
+      <xs:enumeration value="%missing%"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Date-ST">
+    <xs:restriction base="DateFormat_19-Base-ST">
+      <xs:pattern value="#.*#"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateTime-ST">
+    <xs:union memberTypes="DataValue-DateFormat_5-Hashes-ST DataValue-DateFormat_6-Hashes-ST DataValue-DateFormat_11-Hashes-ST DataValue-DateFormat_13-Hashes-ST"/>
+  </xs:simpleType>
+  <xs:simpleType name="String-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="&quot;.*&quot;"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Tuple-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\(.*\)"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Spatial-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="POINT"/>
+      <xs:enumeration value="LINESTRING"/>
+      <xs:enumeration value="POLYGON"/>
+      <xs:enumeration value="MULTIPOINT"/>
+      <xs:enumeration value="MULTILINESTRING"/>
+      <xs:enumeration value="MULTIPOLYGON"/>
+      <xs:enumeration value="MIXED"/>
+      <xs:enumeration value="UNKNOWN"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataValue-DateFormat_5-Hashes-ST">
+    <xs:restriction base="DateFormat_5-Base-ST">
+      <xs:pattern value="#.*#"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataValue-DateFormat_6-Hashes-ST">
+    <xs:restriction base="DateFormat_6-Base-ST">
+      <xs:pattern value="#.*#"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataValue-DateFormat_11-Hashes-ST">
+    <xs:restriction base="DateFormat_11-Base-ST">
+      <xs:pattern value="#.*#"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataValue-DateFormat_13-Hashes-ST">
+    <xs:restriction base="DateFormat_13-Base-ST">
+      <xs:pattern value="#.*#"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DensificationFillType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="fill-missing"/>
+      <xs:enumeration value="fill-zero"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="DocumentManifest-CT">
+    <xs:sequence>
+      <xs:any maxOccurs="unbounded" minOccurs="0" processContents="skip"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="DocumentManifest-G">
+    <xs:sequence>
+      <xs:element name="document-format-change-manifest" type="DocumentManifest-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ColorObject-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#[0-9A-Fa-f]{6}|#[0-9A-Fa-f]{8}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="MapProvider-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="connection">
+        <xs:complexType>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="UnknownMapProvider-G">
+    <xs:sequence>
+      <xs:group ref="MapProvider-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapProvider-Connection-G">
+    <xs:sequence>
+      <xs:group ref="MapProvider-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapSourceDefaults-G">
+    <xs:sequence>
+      <xs:element name="mapsource-defaults">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Stylesheet-G"/>
+          </xs:sequence>
+          <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+          <xs:attribute name="source-platform" type="OSShortName-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Layer-G">
+    <xs:sequence>
+      <xs:element name="layer">
+        <xs:complexType>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Layers-G">
+    <xs:sequence>
+      <xs:element name="layers">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" minOccurs="0" ref="Layer-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Language-G">
+    <xs:sequence>
+      <xs:element name="language">
+        <xs:complexType>
+          <xs:attribute name="iso" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Languages-G">
+    <xs:sequence>
+      <xs:element name="languages">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" minOccurs="0" ref="Language-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapStyle-G">
+    <xs:sequence>
+      <xs:element name="map-style">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="map-layer-style">
+              <xs:complexType>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="request-string" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="display-name" type="xs:string" use="required"/>
+          <xs:attribute name="wait-tile-color" type="ColorObject-ST" use="required"/>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapStyles-G">
+    <xs:sequence>
+      <xs:element name="map-styles">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" minOccurs="0" ref="MapStyle-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="UserAttributes-G">
+    <xs:sequence>
+      <xs:element name="properties">
+        <xs:complexType>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapSourceInline-G">
+    <xs:sequence>
+      <xs:group ref="MapSource-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapSource-G">
+    <xs:sequence>
+      <xs:element name="mapsource" type="MapSource-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="MapSource-CT">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DocumentManifest-G"/>
+      <xs:group ref="MapProvider-Connection-G"/>
+      <xs:group minOccurs="0" ref="Languages-G"/>
+      <xs:group minOccurs="0" ref="Layers-G"/>
+      <xs:group minOccurs="0" ref="UserAttributes-G"/>
+      <xs:group minOccurs="0" ref="MapStyles-G"/>
+      <xs:group ref="Defaults-G"/>
+      <xs:group minOccurs="0" ref="MapAttribution-G"/>
+      <xs:group minOccurs="0" ref="MapAttribution2-G"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+    <xs:attribute name="inline" type="xs:boolean" use="required"/>
+    <xs:attribute name="source-platform" type="OSShortName-ST"/>
+  </xs:complexType>
+  <xs:group name="MapSourceLink-G">
+    <xs:sequence>
+      <xs:element name="mapsource">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapSourceInlineOrLink-G">
+    <xs:sequence>
+      <xs:element name="mapsource">
+        <xs:complexType>
+          <xs:sequence minOccurs="0">
+            <xs:group ref="MapProvider-Connection-G"/>
+            <xs:group ref="Languages-G"/>
+            <xs:group minOccurs="0" ref="Layers-G"/>
+            <xs:group minOccurs="0" ref="UserAttributes-G"/>
+            <xs:group ref="MapStyles-G"/>
+            <xs:group ref="Defaults-G"/>
+            <xs:group minOccurs="0" ref="MapAttribution-G"/>
+            <xs:group minOccurs="0" ref="MapAttribution2-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="version" type="VersionNumber-ST"/>
+          <xs:attribute name="inline" type="xs:boolean"/>
+          <xs:attribute name="source-platform" type="OSShortName-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Defaults-G">
+    <xs:sequence>
+      <xs:group ref="MapSourceDefaults-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapAttribution-G">
+    <xs:sequence>
+      <xs:element name="map-attribution">
+        <xs:complexType>
+          <xs:attribute name="copyright-string" type="xs:string" use="required"/>
+          <xs:attribute name="short-copyright-string" type="xs:string" use="required"/>
+          <xs:attribute name="copyright-url" type="xs:string" use="required"/>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapAttribution2-G">
+    <xs:sequence>
+      <xs:element name="map-attribution2">
+        <xs:complexType>
+          <xs:attribute name="copyright-string" type="xs:string" use="required"/>
+          <xs:attribute name="short-copyright-string" type="xs:string" use="required"/>
+          <xs:attribute name="copyright-url" type="xs:string" use="required"/>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="PaletteType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="regular"/>
+      <xs:enumeration value="ordered-diverging"/>
+      <xs:enumeration value="ordered-sequential"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="ColorPalette-G">
+    <xs:sequence>
+      <xs:element name="color-palette">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="color" type="ColorObject-ST"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="type" type="PaletteType-ST" use="required"/>
+          <xs:attribute name="not-reference-band" type="xs:boolean"/>
+          <xs:attribute name="not-filled" type="xs:boolean"/>
+          <xs:attribute name="not-categorical" type="xs:boolean"/>
+          <xs:attribute name="not-quantitative" type="xs:boolean"/>
+          <xs:attribute name="custom" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Preferences-G">
+    <xs:sequence>
+      <xs:element name="preferences">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Preference-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="ColorPalette-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Preference-G">
+    <xs:sequence>
+      <xs:element name="preference">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="ReferencedView-CT">
+    <xs:sequence maxOccurs="1"/>
+    <xs:attribute name="instances" type="xs:int" use="required"/>
+    <xs:attribute name="viewId" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ReferencedViews-CT">
+    <xs:sequence maxOccurs="unbounded">
+      <xs:element name="referenced-view" type="ReferencedView-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ReferencedExtension-CT">
+    <xs:sequence maxOccurs="1">
+      <xs:element name="manifest" type="ExtensionManifest-CT"/>
+      <xs:element name="referenced-views" type="ReferencedViews-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ReferencedExtensions-CT">
+    <xs:sequence maxOccurs="unbounded">
+      <xs:element name="referenced-extension" type="ReferencedExtension-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="RepositoryLocation-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="repository-location">
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:string" use="required"/>
+          <xs:attribute name="path" type="xs:string" use="required"/>
+          <xs:attribute name="revision" type="xs:string" use="required"/>
+          <xs:attribute name="server-base" type="xs:string"/>
+          <xs:attribute name="site" type="xs:string"/>
+          <xs:attribute name="derived-from" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ShapeType-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="([^/]*/)?[^/]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Shapes-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="external">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="shapes">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="shape">
+                    <xs:complexType>
+                      <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                          <xs:attribute name="name" type="ShapeType-ST"/>
+                        </xs:extension>
+                      </xs:simpleContent>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="FieldType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="nominal"/>
+      <xs:enumeration value="ordinal"/>
+      <xs:enumeration value="quantitative"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TickSpacingUnits-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="years"/>
+      <xs:enumeration value="iso-years"/>
+      <xs:enumeration value="quarters"/>
+      <xs:enumeration value="iso-quarters"/>
+      <xs:enumeration value="months"/>
+      <xs:enumeration value="weeks"/>
+      <xs:enumeration value="iso-weeks"/>
+      <xs:enumeration value="days"/>
+      <xs:enumeration value="hours"/>
+      <xs:enumeration value="minutes"/>
+      <xs:enumeration value="seconds"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ScaleType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="linear"/>
+      <xs:enumeration value="log"/>
+      <xs:enumeration value="symlog"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="RangeTypeEncodings-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="automatic"/>
+      <xs:enumeration value="independent"/>
+      <xs:enumeration value="uniform"/>
+      <xs:enumeration value="fixed"/>
+      <xs:enumeration value="fixedmin"/>
+      <xs:enumeration value="fixedmax"/>
+      <xs:enumeration value="fixedminindependentmax"/>
+      <xs:enumeration value="fixedmaxindependentmin"/>
+      <xs:enumeration value="fixedminuniformmax"/>
+      <xs:enumeration value="fixedmaxuniformmin"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:attributeGroup name="EncodingTagAttributes-AG">
+    <xs:attribute name="type" type="StyleEncodingType-ST"/>
+    <xs:attribute name="attr" type="StyleAttribute-ST"/>
+    <xs:attribute name="class" type="xs:string"/>
+    <xs:attribute name="field" type="xs:string"/>
+    <xs:attribute name="pseudo-class" type="StylePseudoClass-ST"/>
+    <xs:attribute name="scope" type="StyleFieldScope-ST"/>
+    <xs:attribute name="field-type" type="FieldType-ST"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="Encoding-AG">
+  </xs:attributeGroup>
+  <xs:group name="Map-G">
+    <xs:sequence>
+      <xs:element name="map">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="MultiBucket-Or-Bucket-G"/>
+          </xs:sequence>
+          <xs:attribute name="to" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapPri-G">
+    <xs:sequence>
+      <xs:element name="map-pri">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Bucket-G"/>
+          </xs:sequence>
+          <xs:attribute name="to" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Encoding-G">
+    <xs:sequence>
+      <xs:element name="encoding">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="ColorPalette-G"/>
+            <xs:choice maxOccurs="unbounded" minOccurs="0">
+              <xs:group ref="Map-G"/>
+              <xs:group ref="MapPri-G"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attributeGroup ref="EncodingTagAttributes-AG"/>
+          <xs:attribute name="center" type="DataValue-ST"/>
+          <xs:attribute name="domain-expand" type="xs:boolean"/>
+          <xs:attribute name="fold" type="xs:boolean"/>
+          <xs:attribute name="include-totals" type="xs:boolean"/>
+          <xs:attribute name="major-origin" type="DataValue-ST"/>
+          <xs:attribute name="major-show" type="xs:boolean"/>
+          <xs:attribute name="major-spacing" type="DataValue-ST"/>
+          <xs:attribute name="major-units" type="TickSpacingUnits-ST"/>
+          <xs:attribute name="max" type="DataValue-ST"/>
+          <xs:attribute name="max-size" type="Double-ST"/>
+          <xs:attribute name="min" type="DataValue-ST"/>
+          <xs:attribute name="min-size" type="Double-ST"/>
+          <xs:attribute name="minor-origin" type="DataValue-ST"/>
+          <xs:attribute name="minor-show" type="xs:boolean"/>
+          <xs:attribute name="minor-spacing" type="DataValue-ST"/>
+          <xs:attribute name="minor-units" type="TickSpacingUnits-ST"/>
+          <xs:attribute name="num-steps" type="xs:int"/>
+          <xs:attribute name="palette" type="xs:string"/>
+          <xs:attribute name="projection" type="xs:string"/>
+          <xs:attribute name="range-type" type="RangeTypeEncodings-ST"/>
+          <xs:attribute name="reverse" type="xs:boolean"/>
+          <xs:attribute name="scale" type="ScaleType-ST"/>
+          <xs:attribute name="symmetric" type="xs:boolean"/>
+          <xs:attribute name="synchronized" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Stylesheet-G">
+    <xs:sequence>
+      <xs:element name="style">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="style-rule">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group maxOccurs="unbounded" minOccurs="0" ref="Attribute-G"/>
+                </xs:sequence>
+                <xs:attribute name="element" type="StyleElement-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="delta-type" type="StoryDelta-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Attribute-G">
+    <xs:sequence>
+      <xs:choice minOccurs="0">
+        <xs:group ref="Format-G"/>
+        <xs:group ref="Encoding-G"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Format-G">
+    <xs:sequence>
+      <xs:element name="format">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="FormattedText-G"/>
+          </xs:sequence>
+          <xs:attribute name="attr" type="StyleAttribute-ST" use="required"/>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+          <xs:attribute name="class" type="xs:string"/>
+          <xs:attribute name="id" type="xs:string"/>
+          <xs:attribute name="data-class" type="StyleDataClass-ST"/>
+          <xs:attribute name="scope" type="StyleFieldScope-ST"/>
+          <xs:attribute name="field" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="StyleElement-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="animation"/>
+      <xs:enumeration value="axis"/>
+      <xs:enumeration value="cell"/>
+      <xs:enumeration value="datalabel"/>
+      <xs:enumeration value="dropspot"/>
+      <xs:enumeration value="header"/>
+      <xs:enumeration value="field-labels"/>
+      <xs:enumeration value="field-labels-decoration"/>
+      <xs:enumeration value="field-labels-spanner"/>
+      <xs:enumeration value="label"/>
+      <xs:enumeration value="mark"/>
+      <xs:enumeration value="page-card-body"/>
+      <xs:enumeration value="pane"/>
+      <xs:enumeration value="table"/>
+      <xs:enumeration value="worksheet"/>
+      <xs:enumeration value="basesheet"/>
+      <xs:enumeration value="dashboard"/>
+      <xs:enumeration value="storyboard"/>
+      <xs:enumeration value="caption"/>
+      <xs:enumeration value="dropline"/>
+      <xs:enumeration value="refline"/>
+      <xs:enumeration value="refband"/>
+      <xs:enumeration value="refboxplot"/>
+      <xs:enumeration value="gridline"/>
+      <xs:enumeration value="zeroline"/>
+      <xs:enumeration value="trendline"/>
+      <xs:enumeration value="table-div"/>
+      <xs:enumeration value="header-div"/>
+      <xs:enumeration value="mapped-image"/>
+      <xs:enumeration value="action"/>
+      <xs:enumeration value="title"/>
+      <xs:enumeration value="legend"/>
+      <xs:enumeration value="legend-title"/>
+      <xs:enumeration value="legend-title-text"/>
+      <xs:enumeration value="axis-title"/>
+      <xs:enumeration value="annotation"/>
+      <xs:enumeration value="dash-title"/>
+      <xs:enumeration value="dash-subtitle"/>
+      <xs:enumeration value="dash-text"/>
+      <xs:enumeration value="dash-zone"/>
+      <xs:enumeration value="dash-container"/>
+      <xs:enumeration value="scrollbar"/>
+      <xs:enumeration value="map-layer"/>
+      <xs:enumeration value="map"/>
+      <xs:enumeration value="map-data-layer"/>
+      <xs:enumeration value="quick-filter"/>
+      <xs:enumeration value="quick-filter-title"/>
+      <xs:enumeration value="data-highlighter"/>
+      <xs:enumeration value="data-highlighter-title"/>
+      <xs:enumeration value="parameter-ctrl"/>
+      <xs:enumeration value="parameter-ctrl-title"/>
+      <xs:enumeration value="page-card-title"/>
+      <xs:enumeration value="story-title"/>
+      <xs:enumeration value="story-description"/>
+      <xs:enumeration value="story-point-caption"/>
+      <xs:enumeration value="tooltip"/>
+      <xs:enumeration value="all"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StyleAttribute-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="alternate-text"/>
+      <xs:enumeration value="alt-mark-color"/>
+      <xs:enumeration value="animation-on"/>
+      <xs:enumeration value="animation-duration"/>
+      <xs:enumeration value="animation-style"/>
+      <xs:enumeration value="aspect"/>
+      <xs:enumeration value="auto-subtitle"/>
+      <xs:enumeration value="background-color"/>
+      <xs:enumeration value="background-transparency"/>
+      <xs:enumeration value="band-size"/>
+      <xs:enumeration value="band-color"/>
+      <xs:enumeration value="band-level"/>
+      <xs:enumeration value="body-type"/>
+      <xs:enumeration value="border-color"/>
+      <xs:enumeration value="border-color-top"/>
+      <xs:enumeration value="border-color-right"/>
+      <xs:enumeration value="border-color-bottom"/>
+      <xs:enumeration value="border-color-left"/>
+      <xs:enumeration value="border-style"/>
+      <xs:enumeration value="border-style-top"/>
+      <xs:enumeration value="border-style-right"/>
+      <xs:enumeration value="border-style-bottom"/>
+      <xs:enumeration value="border-style-left"/>
+      <xs:enumeration value="border-width"/>
+      <xs:enumeration value="border-width-top"/>
+      <xs:enumeration value="border-width-right"/>
+      <xs:enumeration value="border-width-bottom"/>
+      <xs:enumeration value="border-width-left"/>
+      <xs:enumeration value="break-on-special"/>
+      <xs:enumeration value="cell"/>
+      <xs:enumeration value="cell-w"/>
+      <xs:enumeration value="cell-h"/>
+      <xs:enumeration value="cell-q"/>
+      <xs:enumeration value="cell-qmark"/>
+      <xs:enumeration value="color"/>
+      <xs:enumeration value="color-mode"/>
+      <xs:enumeration value="col-levels"/>
+      <xs:enumeration value="col-vert-levels"/>
+      <xs:enumeration value="col-horiz-height"/>
+      <xs:enumeration value="col-vert-height"/>
+      <xs:enumeration value="col-height"/>
+      <xs:enumeration value="col-width"/>
+      <xs:enumeration value="content"/>
+      <xs:enumeration value="corner-radius"/>
+      <xs:enumeration value="corner-radius-top-left"/>
+      <xs:enumeration value="corner-radius-top-right"/>
+      <xs:enumeration value="corner-radius-bottom-right"/>
+      <xs:enumeration value="corner-radius-bottom-left"/>
+      <xs:enumeration value="density-color"/>
+      <xs:enumeration value="density-kernel-size"/>
+      <xs:enumeration value="density-intensity"/>
+      <xs:enumeration value="density-max-value"/>
+      <xs:enumeration value="display-field-labels"/>
+      <xs:enumeration value="display"/>
+      <xs:enumeration value="display-alternate-text"/>
+      <xs:enumeration value="div-level"/>
+      <xs:enumeration value="enabled"/>
+      <xs:enumeration value="fill-above"/>
+      <xs:enumeration value="fill-below"/>
+      <xs:enumeration value="fill-color"/>
+      <xs:enumeration value="fog-bg-color"/>
+      <xs:enumeration value="fog-desaturation-without-selection"/>
+      <xs:enumeration value="fog-desaturation-with-selection"/>
+      <xs:enumeration value="font-family"/>
+      <xs:enumeration value="font-size"/>
+      <xs:enumeration value="font-style"/>
+      <xs:enumeration value="font-weight"/>
+      <xs:enumeration value="geo-area-type"/>
+      <xs:enumeration value="halign"/>
+      <xs:enumeration value="halo-color"/>
+      <xs:enumeration value="halo-color-selected"/>
+      <xs:enumeration value="has-label"/>
+      <xs:enumeration value="has-fill"/>
+      <xs:enumeration value="has-stroke"/>
+      <xs:enumeration value="has-halo"/>
+      <xs:enumeration value="height"/>
+      <xs:enumeration value="height-header"/>
+      <xs:enumeration value="highlight-legend"/>
+      <xs:enumeration value="hnaxis"/>
+      <xs:enumeration value="hnlabel"/>
+      <xs:enumeration value="in-tooltip"/>
+      <xs:enumeration value="line-end"/>
+      <xs:enumeration value="line-end-size"/>
+      <xs:enumeration value="line-interpolation"/>
+      <xs:enumeration value="line-marker-position"/>
+      <xs:enumeration value="line-pattern"/>
+      <xs:enumeration value="line-pattern-only"/>
+      <xs:enumeration value="line-visibility"/>
+      <xs:enumeration value="map"/>
+      <xs:enumeration value="map-style"/>
+      <xs:enumeration value="map-snap-zoom"/>
+      <xs:enumeration value="margin"/>
+      <xs:enumeration value="margin-top"/>
+      <xs:enumeration value="margin-right"/>
+      <xs:enumeration value="margin-bottom"/>
+      <xs:enumeration value="margin-left"/>
+      <xs:enumeration value="mark-color"/>
+      <xs:enumeration value="mark-transparency"/>
+      <xs:enumeration value="mark-markers-mode"/>
+      <xs:enumeration value="mark-labels-show"/>
+      <xs:enumeration value="mark-labels-mode"/>
+      <xs:enumeration value="mark-labels-cull"/>
+      <xs:enumeration value="mark-labels-line-first"/>
+      <xs:enumeration value="mark-labels-line-last"/>
+      <xs:enumeration value="mark-labels-range-min"/>
+      <xs:enumeration value="mark-labels-range-max"/>
+      <xs:enumeration value="mark-labels-range-scope"/>
+      <xs:enumeration value="mark-labels-range-field"/>
+      <xs:enumeration value="mark-line-pattern"/>
+      <xs:enumeration value="maxheight"/>
+      <xs:enumeration value="max-font-size"/>
+      <xs:enumeration value="max-stroke-width"/>
+      <xs:enumeration value="maxwidth"/>
+      <xs:enumeration value="middle-stroke-width"/>
+      <xs:enumeration value="minheight"/>
+      <xs:enumeration value="min-font-size"/>
+      <xs:enumeration value="min-stroke-width"/>
+      <xs:enumeration value="minwidth"/>
+      <xs:enumeration value="nonhighlight-color"/>
+      <xs:enumeration value="min-length"/>
+      <xs:enumeration value="min-map-size"/>
+      <xs:enumeration value="min-size"/>
+      <xs:enumeration value="omit-on-special"/>
+      <xs:enumeration value="orientation"/>
+      <xs:enumeration value="padding"/>
+      <xs:enumeration value="padding-top"/>
+      <xs:enumeration value="padding-right"/>
+      <xs:enumeration value="padding-bottom"/>
+      <xs:enumeration value="padding-left"/>
+      <xs:enumeration value="palette"/>
+      <xs:enumeration value="render-fold-reversed"/>
+      <xs:enumeration value="reverse-palette"/>
+      <xs:enumeration value="rounding"/>
+      <xs:enumeration value="row-horiz-levels"/>
+      <xs:enumeration value="row-horiz-width"/>
+      <xs:enumeration value="row-levels"/>
+      <xs:enumeration value="row-vert-width"/>
+      <xs:enumeration value="separator"/>
+      <xs:enumeration value="shape"/>
+      <xs:enumeration value="show-labels"/>
+      <xs:enumeration value="show-null-value-warning"/>
+      <xs:enumeration value="size"/>
+      <xs:enumeration value="size-bar"/>
+      <xs:enumeration value="smart-auto-align"/>
+      <xs:enumeration value="space"/>
+      <xs:enumeration value="stroke-color"/>
+      <xs:enumeration value="stroke-size"/>
+      <xs:enumeration value="subtitle"/>
+      <xs:enumeration value="text-align"/>
+      <xs:enumeration value="text-align-default"/>
+      <xs:enumeration value="text-decoration"/>
+      <xs:enumeration value="text-indent"/>
+      <xs:enumeration value="text-orientation"/>
+      <xs:enumeration value="text-format"/>
+      <xs:enumeration value="tick-color"/>
+      <xs:enumeration value="tick-length"/>
+      <xs:enumeration value="tick-spacing"/>
+      <xs:enumeration value="total-label"/>
+      <xs:enumeration value="title"/>
+      <xs:enumeration value="washout"/>
+      <xs:enumeration value="width"/>
+      <xs:enumeration value="width-header"/>
+      <xs:enumeration value="wrap"/>
+      <xs:enumeration value="valign"/>
+      <xs:enumeration value="vertical-align"/>
+      <xs:enumeration value="vertical-align-default"/>
+      <xs:enumeration value="vnaxis"/>
+      <xs:enumeration value="vnlabel"/>
+      <xs:enumeration value="zoom"/>
+      <xs:enumeration value="whisker-stroke-size"/>
+      <xs:enumeration value="whisker-stroke-color"/>
+      <xs:enumeration value="whisker-end"/>
+      <xs:enumeration value="boxplot-style"/>
+      <xs:enumeration value="opacity"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StylePseudoClass-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="selected"/>
+      <xs:enumeration value="highlighted"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StyleEncodingType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="diverging"/>
+      <xs:enumeration value="palette"/>
+      <xs:enumeration value="interpolated"/>
+      <xs:enumeration value="shape"/>
+      <xs:enumeration value="space"/>
+      <xs:enumeration value="catsize"/>
+      <xs:enumeration value="cat-highlight"/>
+      <xs:enumeration value="quantsize"/>
+      <xs:enumeration value="rangesize"/>
+      <xs:enumeration value="centersize"/>
+      <xs:enumeration value="text"/>
+      <xs:enumeration value="custom-interpolated"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StyleDataClass-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="total"/>
+      <xs:enumeration value="subtotal"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StyleFieldScope-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="rows"/>
+      <xs:enumeration value="cols"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StyleSwatch-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="light"/>
+      <xs:enumeration value="dark"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StyleTheme-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+      <xs:enumeration value="classic"/>
+      <xs:enumeration value="modern"/>
+      <xs:enumeration value="clean"/>
+      <xs:enumeration value="smooth"/>
+      <xs:enumeration value="custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Verbosity-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="high"/>
+      <xs:enumeration value="low"/>
+      <xs:enumeration value="medium"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="InsightType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="NONE"/>
+      <xs:enumeration value="RISKY_MONOPOLY"/>
+      <xs:enumeration value="TOP_DRIVERS"/>
+      <xs:enumeration value="CURRENT_TREND"/>
+      <xs:enumeration value="NEW_TREND"/>
+      <xs:enumeration value="TOP_DIMENSION_MEMBER_MOVERS"/>
+      <xs:enumeration value="METRIC_FORECAST"/>
+      <xs:enumeration value="BOTTOM_CONTRIBUTORS"/>
+      <xs:enumeration value="TOP_DETRACTORS"/>
+      <xs:enumeration value="UNUSUAL_CHANGE"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="TabAgentConfig-ExcludedSheets-CT">
+    <xs:sequence>
+      <xs:group ref="SimpleIdentifier-G" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TabAgentConfig-Item-CT">
+    <xs:sequence>
+      <xs:group ref="SimpleIdentifier-G"/>
+      <xs:element name="summary-enabled" type="xs:boolean" minOccurs="0"/>
+      <xs:element name="insight-enabled" type="xs:boolean" minOccurs="0"/>
+      <xs:element name="verbosity" type="Verbosity-ST" minOccurs="0"/>
+      <xs:element name="excluded-insight-type" type="InsightType-ST" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="excluded-sheets" type="TabAgentConfig-ExcludedSheets-CT" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="TabAgentConfig-G">
+    <xs:sequence>
+      <xs:element name="tab-agent-config">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="tab-agent-config-item" type="TabAgentConfig-Item-CT" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="UniqueTabAgentItemIdentifier">
+          <xs:selector xpath="tab-agent-config-item/simple-id"/>
+          <xs:field xpath="@uuid"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Thumbnail-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="thumbnail">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="name" type="xs:string" use="required"/>
+              <xs:attribute name="width" type="xs:int" use="required"/>
+              <xs:attribute name="height" type="xs:int" use="required"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="VersionNumber-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(\d+)((\.)(\d+))*((-)(\d+))*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Perspective-G">
+    <xs:sequence>
+      <xs:element name="perspectives">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="perspective">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="perspective-dimension">
+                    <xs:complexType>
+                      <xs:group ref="Tuple-G"/>
+                      <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+                <xs:attribute name="perspective-type" type="Perspective-Type-ST" use="required"/>
+                <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Perspective-Type-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="reality"/>
+      <xs:enumeration value="first"/>
+      <xs:enumeration value="last"/>
+      <xs:enumeration value="custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="ShelfSorts-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="ShelfSortLists-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSort-G">
+    <xs:sequence>
+      <xs:element name="shelf-sort">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ShelfSortInfo-DimensionList-G"/>
+            <xs:group ref="ShelfSortInfo-FilterInfo-G"/>
+          </xs:sequence>
+          <xs:attribute name="direction" type="SortDirection-ST" use="required"/>
+          <xs:attribute name="measure-to-sort-by" type="QualifiedName-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortLists-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="ShelfSortList-G"/>
+      <xs:group minOccurs="0" ref="SingleValuePerNestShelfSortList-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortList-G">
+    <xs:sequence>
+      <xs:element name="shelf-sorts">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="shelf-sort-v2" type="ShelfSortInfo-ShelfSort-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SingleValuePerNestShelfSortList-G">
+    <xs:sequence>
+      <xs:element name="single-value-per-nest-shelf-sorts">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="single-value-per-nest-shelf-sort" type="ShelfSortInfo-ShelfSort-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="ShelfSortInfo-ShelfSort-CT">
+    <xs:sequence>
+      <xs:group ref="ShelfSortInfo-FilterInfo-G"/>
+    </xs:sequence>
+    <xs:attribute name="dimension-to-sort" type="QualifiedName-ST" use="required"/>
+    <xs:attribute name="direction" type="SortDirection-ST" use="required"/>
+    <xs:attribute name="is-on-innermost-dimension" type="xs:boolean"/>
+    <xs:attribute name="measure-to-sort-by" type="QualifiedName-ST" use="required"/>
+    <xs:attribute name="shelf" type="ShelfSortInfo-ShelfType-ST" use="required"/>
+  </xs:complexType>
+  <xs:group name="ShelfSortInfo-DimensionList-G">
+    <xs:sequence>
+      <xs:element name="dimensions-to-sort">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="dimension" type="QualifiedName-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortInfo-FilterInfo-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="sort-filter-info">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="sort-filter">
+              <xs:complexType>
+                <xs:attribute name="level-name" type="QualifiedName-ST" use="required"/>
+                <xs:attribute name="member-value" type="DataValue-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ShelfSortInfo-ShelfType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="columns"/>
+      <xs:enumeration value="rows"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="ViewSpec-ShelfSorts-G">
+    <xs:sequence>
+      <xs:group ref="ShelfSorts-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ViewSpec-HideSortControls-G">
+    <xs:sequence>
+      <xs:element name="hide-sort-controls"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ViewSpecification-G">
+    <xs:sequence>
+      <xs:sequence maxOccurs="unbounded" minOccurs="0">
+        <xs:group maxOccurs="2" minOccurs="0" ref="FilterOrHideDataFilter-G"/>
+        <xs:group minOccurs="0" ref="Sort-G"/>
+      </xs:sequence>
+      <xs:group minOccurs="0" ref="Perspective-G"/>
+      <xs:group minOccurs="0" ref="ViewSpec-ShelfSorts-G"/>
+      <xs:group minOccurs="0" ref="ViewSpec-HideSortControls-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="SelectionRelaxationOption-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="selection-relaxation-allow"/>
+      <xs:enumeration value="selection-relaxation-disallow"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PrimitiveType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Automatic"/>
+      <xs:enumeration value="Text"/>
+      <xs:enumeration value="Icon"/>
+      <xs:enumeration value="Shape"/>
+      <xs:enumeration value="Rectangle"/>
+      <xs:enumeration value="Bar"/>
+      <xs:enumeration value="GanttBar"/>
+      <xs:enumeration value="Square"/>
+      <xs:enumeration value="Circle"/>
+      <xs:enumeration value="Heatmap"/>
+      <xs:enumeration value="PolyLine"/>
+      <xs:enumeration value="Line"/>
+      <xs:enumeration value="Polygon"/>
+      <xs:enumeration value="Area"/>
+      <xs:enumeration value="Pie"/>
+      <xs:enumeration value="Multipolygon"/>
+      <xs:enumeration value="VizExtension"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DropWhen-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="never"/>
+      <xs:enumeration value="always"/>
+      <xs:enumeration value="selected"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StackingMode-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="off"/>
+      <xs:enumeration value="on"/>
+      <xs:enumeration value="auto"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MarkSizingSetting-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="marks-scaling-automatic"/>
+      <xs:enumeration value="marks-scaling-on"/>
+      <xs:enumeration value="marks-scaling-off"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MarkAlignment-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="mark-alignment-left"/>
+      <xs:enumeration value="mark-alignment-center"/>
+      <xs:enumeration value="mark-alignment-right"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TrendLineFitType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="linear"/>
+      <xs:enumeration value="polynomial"/>
+      <xs:enumeration value="log"/>
+      <xs:enumeration value="exp"/>
+      <xs:enumeration value="power"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineScopeType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="per-cell"/>
+      <xs:enumeration value="per-pane"/>
+      <xs:enumeration value="per-table"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineLabelType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="automatic"/>
+      <xs:enumeration value="value"/>
+      <xs:enumeration value="computation"/>
+      <xs:enumeration value="custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineTooltipType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="automatic"/>
+      <xs:enumeration value="custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineShowLines-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="both"/>
+      <xs:enumeration value="upper"/>
+      <xs:enumeration value="lower"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineStDevType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="sample"/>
+      <xs:enumeration value="population"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineFormulaType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="constant"/>
+      <xs:enumeration value="total"/>
+      <xs:enumeration value="sum"/>
+      <xs:enumeration value="min"/>
+      <xs:enumeration value="max"/>
+      <xs:enumeration value="average"/>
+      <xs:enumeration value="median"/>
+      <xs:enumeration value="quantiles"/>
+      <xs:enumeration value="percentile"/>
+      <xs:enumeration value="stdev"/>
+      <xs:enumeration value="confidence"/>
+      <xs:enumeration value="medianconfidence"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReferenceLineBoxplotWhiskerType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="standard"/>
+      <xs:enumeration value="minmax"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="PaneSpecification-G">
+    <xs:sequence>
+      <xs:element name="pane">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="PaneSpecification-View-G"/>
+            <xs:group ref="PaneSpecification-Mark-G"/>
+            <xs:group ref="PaneSpecification-MarkSizing-G"/>
+            <xs:element minOccurs="0" name="add-in" type="Extension-CT"/>
+            <xs:element minOccurs="0" name="encodings">
+              <xs:complexType>
+                <xs:group ref="PaneSpecification-MarkEncodings-G"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:group ref="PaneSpecification-HiddenFields-G"/>
+            <xs:group ref="PaneSpecification-DropLine-G"/>
+            <xs:group ref="PaneSpecification-Trendline-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="ReferenceLine-G"/>
+            <xs:group minOccurs="0" ref="PaneSpecification-CustomTooltip-G"/>
+            <xs:group minOccurs="0" ref="PaneSpecification-CustomLabel-G"/>
+            <xs:group minOccurs="0" ref="Stylesheet-G"/>
+          </xs:sequence>
+          <xs:attribute name="decimalplaces" type="xs:integer"/>
+          <xs:attribute name="id" type="xs:integer"/>
+          <xs:attribute name="title" type="xs:string"/>
+          <xs:attribute name="generated-title" type="xs:string"/>
+          <xs:attribute name="ignore-extent" type="xs:boolean"/>
+          <xs:attribute name="inert" type="xs:boolean"/>
+          <xs:attribute name="hidden" type="xs:boolean"/>
+          <xs:attribute name="x-axis-name" type="QualifiedName-ST"/>
+          <xs:attribute name="x-index" type="xs:integer"/>
+          <xs:attribute name="y-axis-name" type="QualifiedName-ST"/>
+          <xs:attribute name="y-index" type="xs:integer"/>
+          <xs:attribute name="selection-relaxation-option" type="SelectionRelaxationOption-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ReferenceLine-G">
+    <xs:sequence>
+      <xs:element name="reference-line">
+        <xs:complexType>
+          <xs:sequence minOccurs="0">
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="reference-line-value">
+              <xs:complexType>
+                <xs:attribute name="percentile" type="Float-ST"/>
+                <xs:attribute name="factor" type="Float-ST"/>
+                <xs:attribute name="percentage" type="Float-ST"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="id" type="xs:string" use="required"/>
+          <xs:attribute name="axis-column" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="value-column" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="scope" type="ReferenceLineScopeType-ST" use="required"/>
+          <xs:attribute name="label-type" type="ReferenceLineLabelType-ST" use="required"/>
+          <xs:attribute name="z-order" type="xs:integer" use="required"/>
+          <xs:attribute name="boxplot-whisker-type" type="ReferenceLineBoxplotWhiskerType-ST"/>
+          <xs:attribute name="boxplot-mark-exclusion" type="xs:boolean"/>
+          <xs:attribute name="reference-parameter" type="QualifiedName-ST"/>
+          <xs:attribute name="paired-id" type="xs:string"/>
+          <xs:attribute name="paired-distribution-id" type="xs:string"/>
+          <xs:attribute name="symmetric" type="xs:boolean"/>
+          <xs:attribute name="fill-above" type="xs:boolean"/>
+          <xs:attribute name="fill-below" type="xs:boolean"/>
+          <xs:attribute name="label" type="xs:string"/>
+          <xs:attribute name="formula" type="ReferenceLineFormulaType-ST" use="required"/>
+          <xs:attribute name="tooltip-type" type="ReferenceLineTooltipType-ST"/>
+          <xs:attribute name="tooltip" type="xs:string"/>
+          <xs:attribute name="value" type="DataValue-ST"/>
+          <xs:attribute name="probability" type="Float-ST"/>
+          <xs:attribute name="tile-count" type="xs:integer"/>
+          <xs:attribute name="type" type="ReferenceLineStDevType-ST"/>
+          <xs:attribute name="show-lines" type="ReferenceLineShowLines-ST"/>
+          <xs:attribute name="percentage-bands" type="xs:boolean"/>
+          <xs:attribute name="enable-instant-analytics" type="xs:boolean" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-View-G">
+    <xs:sequence>
+      <xs:element name="view">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="breakdown">
+              <xs:complexType>
+                <xs:attribute name="value" type="StackingMode-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-Mark-G">
+    <xs:sequence>
+      <xs:element name="mark">
+        <xs:complexType>
+          <xs:attribute name="class" type="PrimitiveType-ST" use="required"/>
+          <xs:attribute name="orientation" type="PaneSpecification-MarkOrientation-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="PaneSpecification-MarkOrientation-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="x"/>
+      <xs:enumeration value="y"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="PaneSpecification-MarkEncoding-CT">
+    <xs:attribute name="column" type="QualifiedName-ST"/>
+    <xs:attribute name="separate-domains" type="xs:boolean"/>
+    <xs:attribute name="encoding-id" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="PaneSpecification-CustomMarkEncoding-CT">
+    <xs:complexContent>
+      <xs:extension base="PaneSpecification-MarkEncoding-CT">
+        <xs:attribute name="custom-type-name" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:group name="PaneSpecification-MarkEncodings-G">
+    <xs:sequence>
+      <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="color" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="size" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="text" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="shape" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="wedge-size" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="lod" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="geometry" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="image" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="tooltip" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="path" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="level" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="edge" type="PaneSpecification-MarkEncoding-CT"/>
+        <xs:element name="custom" type="PaneSpecification-CustomMarkEncoding-CT"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-MarkSizing-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="mark-sizing">
+        <xs:complexType>
+          <xs:attribute name="mark-sizing-setting" type="MarkSizingSetting-ST" use="required"/>
+          <xs:attribute name="use-custom-mark-size" type="xs:boolean"/>
+          <xs:attribute name="mark-alignment" type="MarkAlignment-ST"/>
+          <xs:attribute name="custom-mark-size-in-axis-units" type="DataValue-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-HiddenFields-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="label-data">
+        <xs:complexType>
+          <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-DropLine-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="dropline">
+        <xs:complexType>
+          <xs:attribute name="x-axis" type="xs:boolean" use="required"/>
+          <xs:attribute name="y-axis" type="xs:boolean" use="required"/>
+          <xs:attribute name="drop-when" type="DropWhen-ST" use="required"/>
+          <xs:attribute name="haslabel" type="xs:boolean" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-Trendline-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="trendline">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="excluded-factors">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" name="column" type="QualifiedName-ST"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+          <xs:attribute name="fit" type="TrendLineFitType-ST" use="required"/>
+          <xs:attribute name="exclude-intercept" type="xs:boolean" use="required"/>
+          <xs:attribute name="enable-confidence-bands" type="xs:boolean" use="required"/>
+          <xs:attribute name="exclude-color" type="xs:boolean" use="required"/>
+          <xs:attribute name="enable-instant-analytics" type="xs:boolean"/>
+          <xs:attribute name="enable-tooltips" type="xs:boolean"/>
+          <xs:attribute name="degree" type="xs:integer"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-CustomTooltip-G">
+    <xs:sequence>
+      <xs:element name="customized-tooltip">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="FormattedText-G"/>
+          </xs:sequence>
+          <xs:attribute name="show-buttons" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="PaneSpecification-CustomLabel-G">
+    <xs:sequence>
+      <xs:element name="customized-label">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="FormattedText-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-VisualSpecification-G">
+    <xs:sequence>
+      <xs:element name="table">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="view">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="Workbook-DataSources-G"/>
+                  <xs:group minOccurs="0" ref="Workbook-MapSources-G"/>
+                  <xs:group ref="DataSourceDependencies-G"/>
+                  <xs:group ref="Workbook-ViewSpecification-G"/>
+                  <xs:element minOccurs="0" name="slices" type="Workbook-Fields-CT"/>
+                  <xs:element name="aggregation">
+                    <xs:complexType>
+                      <xs:attribute name="value" type="xs:boolean"/>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element minOccurs="0" name="calcs-on-densified-marks">
+                    <xs:complexType>
+                      <xs:attribute name="value" type="xs:boolean"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:group ref="Workbook-Stylesheet-G"/>
+            <xs:element name="panes">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group maxOccurs="unbounded" minOccurs="0" ref="PaneSpecification-G"/>
+                </xs:sequence>
+                <xs:attribute name="customization-axis" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:group ref="Workbook-MarkLayout-G"/>
+            <xs:element name="rows">
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="include-empty" type="xs:boolean"/>
+                    <xs:attribute name="total" type="xs:boolean"/>
+                    <xs:attribute name="onTop" type="xs:boolean"/>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="cols">
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="include-empty" type="xs:boolean"/>
+                    <xs:attribute name="total" type="xs:boolean"/>
+                    <xs:attribute name="onLeft" type="xs:boolean"/>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="table-calc-densification">
+              <xs:complexType>
+                <xs:attribute fixed="false" name="enabled" type="xs:boolean"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="pages">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" name="column" type="QualifiedName-ST"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="join-lod-include-overrides" type="Workbook-Fields-CT"/>
+            <xs:element minOccurs="0" name="join-lod-exclude-overrides" type="Workbook-Fields-CT"/>
+            <xs:element minOccurs="0" name="subtotals">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" name="column" type="QualifiedName-ST"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="table-calculations">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="partitionable-measures">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element maxOccurs="unbounded" name="column" type="QualifiedName-ST"/>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="show-full-range">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" name="column" type="QualifiedName-ST"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="extend-time-series">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" name="extended-column">
+                    <xs:complexType>
+                      <xs:attribute name="column" type="QualifiedName-ST" use="required"/>
+                      <xs:attribute name="num-periods" type="xs:int" use="required"/>
+                      <xs:attribute name="period-type" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="consider-zeros-empty">
+              <xs:complexType>
+                <xs:attribute name="value" type="xs:boolean" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="percentages">
+              <xs:complexType>
+                <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+                <xs:attribute name="mode" type="PercentMode-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="mark-labels">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" name="mark-label">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:group ref="TupleReference-G"/>
+                        <xs:element minOccurs="0" name="label-position" type="BoxCoordinate-CT"/>
+                      </xs:sequence>
+                      <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                      <xs:attribute name="label-state" type="Workbook-OnOff-ST"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="annotations">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group maxOccurs="unbounded" ref="AnnotationSpecification-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:group ref="Workbook-PageTrailOptions-G"/>
+            <xs:element minOccurs="0" name="trail-overrides">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="trail-override">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:group ref="TupleReference-G"/>
+                      </xs:sequence>
+                      <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                      <xs:attribute name="state" type="Workbook-OnOff-ST" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="tooltip-style">
+              <xs:complexType>
+                <xs:attribute name="tooltip-mode" type="TooltipMode-ST" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:group ref="Workbook-ForecastSpecification-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DashboardSizingMode-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="unspecified"/>
+      <xs:enumeration value="automatic"/>
+      <xs:enumeration value="fixed"/>
+      <xs:enumeration value="range"/>
+      <xs:enumeration value="vscroll"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="VizLayoutOptions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="layout-options">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="title">
+              <xs:complexType>
+                <xs:group ref="FormattedText-G"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="caption">
+              <xs:complexType>
+                <xs:group ref="FormattedText-G"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="alt-text">
+              <xs:complexType>
+                <xs:group ref="FormattedText-G"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="filter-alt-text">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="0" maxOccurs="unbounded" name="filter">
+                    <xs:complexType>
+                      <xs:attribute name="field" type="xs:string" use="required"/>
+                      <xs:attribute name="alt-text" type="xs:string" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attributeGroup ref="VizLayoutOptions-Attributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="VizLayoutOptions-Attributes-AG">
+    <xs:attribute name="export-no-title" type="xs:boolean"/>
+    <xs:attribute name="export-no-caption" type="xs:boolean"/>
+    <xs:attribute name="export-all-view-pages" type="xs:boolean"/>
+    <xs:attribute name="export-margin-left" type="Float-ST"/>
+    <xs:attribute name="export-margin-right" type="Float-ST"/>
+    <xs:attribute name="export-margin-top" type="Float-ST"/>
+    <xs:attribute name="export-margin-bottom" type="Float-ST"/>
+    <xs:attribute name="export-per-page-headers" type="xs:boolean"/>
+    <xs:attribute name="export-smart-breaks" type="xs:boolean"/>
+    <xs:attribute name="export-scale-mode-auto" type="xs:boolean"/>
+    <xs:attribute name="export-scale-fitpage" type="xs:boolean"/>
+    <xs:attribute name="export-scale-percent" type="xs:int"/>
+    <xs:attribute name="export-pages-across" type="xs:int"/>
+    <xs:attribute name="export-pages-down" type="xs:int"/>
+    <xs:attribute name="export-center-horz" type="xs:boolean"/>
+    <xs:attribute name="export-center-vert" type="xs:boolean"/>
+    <xs:attribute name="export-visual" type="xs:boolean"/>
+    <xs:attribute name="export-color-legend" type="xs:boolean"/>
+    <xs:attribute name="export-shape-legend" type="xs:boolean"/>
+    <xs:attribute name="export-size-legend" type="xs:boolean"/>
+    <xs:attribute name="export-map-legend" type="xs:boolean"/>
+    <xs:attribute name="export-orientation" type="PageOrientation-ST"/>
+    <xs:attribute name="export-legend-location" type="LegendLayoutLocation-ST"/>
+    <xs:attribute name="export-legend-direction" type="LegendLayoutDirection-ST"/>
+    <xs:attribute name="tooltip-mark-announcement" type="xs:boolean"/>
+  </xs:attributeGroup>
+  <xs:simpleType name="EdgeLocation-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="right"/>
+      <xs:enumeration value="top"/>
+      <xs:enumeration value="bottom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Cards-G">
+    <xs:sequence>
+      <xs:element name="cards">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" minOccurs="0" ref="Edge-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Edge-G">
+    <xs:sequence>
+      <xs:element name="edge">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Strip-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="EdgeLocation-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Strip-G">
+    <xs:sequence>
+      <xs:element name="strip">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Card-G"/>
+          </xs:sequence>
+          <xs:attribute name="size" type="xs:int" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Card-G">
+    <xs:sequence>
+      <xs:element name="card">
+        <xs:complexType>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Button-Format-CT">
+    <xs:attribute name="attr" type="StyleAttribute-ST" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:attributeGroup name="ButtonZone-ButtonCaptionFontStyleAttributes-AG">
+    <xs:attribute name="fontname" type="xs:string"/>
+    <xs:attribute name="fontcolor" type="xs:string"/>
+    <xs:attribute name="fontsize" type="xs:int"/>
+    <xs:attribute name="bold" type="xs:boolean"/>
+    <xs:attribute name="italic" type="xs:boolean"/>
+    <xs:attribute name="underline" type="xs:boolean"/>
+  </xs:attributeGroup>
+  <xs:complexType name="Button-Caption-Font-Style-CT">
+    <xs:attributeGroup ref="ButtonZone-ButtonCaptionFontStyleAttributes-AG"/>
+  </xs:complexType>
+  <xs:complexType name="Button-Visual-State-CT">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="caption" type="xs:string"/>
+      <xs:element minOccurs="0" name="image-path" type="xs:string"/>
+      <xs:element minOccurs="0" name="tooltip-text" type="xs:string"/>
+      <xs:element minOccurs="0" name="button-caption-font-style" type="Button-Caption-Font-Style-CT"/>
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="format" type="Button-Format-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Button-CT">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="toggle-action" type="xs:string"/>
+      <xs:element minOccurs="0" name="export-button-action" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" name="button-visual-state" type="Button-Visual-State-CT"/>
+    </xs:sequence>
+    <xs:attribute name="action" type="xs:string" use="required"/>
+    <xs:attribute name="button-type" type="xs:string"/>
+    <xs:attribute name="active-visual-state-index" type="xs:string"/>
+    <xs:attribute name="button-click-action-metadata" type="xs:string"/>
+  </xs:complexType>
+  <xs:simpleType name="AnchorPoint-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="begin"/>
+      <xs:enumeration value="end"/>
+      <xs:enumeration value="size"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AnchorType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="relative"/>
+      <xs:enumeration value="fixed"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="FlexibleLayoutRoot-AnchoringRule-CT">
+    <xs:attribute name="anchor-point" type="AnchorPoint-ST" use="required"/>
+    <xs:attribute name="anchor-type" type="AnchorType-ST" use="required"/>
+    <xs:attribute name="value" type="xs:float" use="required"/>
+    <xs:attribute name="user-provided" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="FlexibleLayoutRoot-DimensionAnchoringRules-CT">
+    <xs:sequence>
+      <xs:element name="first-rule" type="FlexibleLayoutRoot-AnchoringRule-CT"/>
+      <xs:element name="second-rule" type="FlexibleLayoutRoot-AnchoringRule-CT"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="FlexibleLayoutRoot-AnchoringProperties-G">
+    <xs:sequence>
+      <xs:element name="anchoring-properties">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="horizontal-rules" type="FlexibleLayoutRoot-DimensionAnchoringRules-CT"/>
+            <xs:element name="vertical-rules" type="FlexibleLayoutRoot-DimensionAnchoringRules-CT"/>
+          </xs:sequence>
+          <xs:attribute name="zone-id" type="xs:unsignedInt" use="required"/>
+          <xs:attribute name="anchored-to-zoneid" type="xs:unsignedInt" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="FlexibleLayoutRoot-G">
+    <xs:sequence>
+      <xs:element name="anchored-zones">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="FlexibleLayoutRoot-AnchoringProperties-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortDelta-G">
+    <xs:sequence>
+      <xs:element name="shelf-sort-delta">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:choice>
+              <xs:group ref="ShelfSortDelta-ClearShelfSort-G"/>
+              <xs:group ref="ShelfSort-G"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="shelf" type="ShelfSortDelta-ShelfType-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortDeltas-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="shelf-sort-deltas">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="ShelfSortLists-G"/>
+            <xs:group minOccurs="0" ref="ShelfSortDelta-ClearShelfSorts-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortDelta-ClearShelfSort-G">
+    <xs:sequence>
+      <xs:element name="clear-shelf-sort"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortDelta-ClearShelfSorts-G">
+    <xs:sequence>
+      <xs:element name="clear-shelf-sorts">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="ShelfSortDelta-ClearShelfSort-V2-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ShelfSortDelta-ClearShelfSort-V2-G">
+    <xs:sequence>
+      <xs:element name="clear-shelf-sort-v2">
+        <xs:complexType>
+          <xs:attribute name="dimension" type="QualifiedName-ST"/>
+          <xs:attribute name="is-on-innermost-dimension" type="xs:boolean"/>
+          <xs:attribute name="shelf" type="ShelfSortDelta-ShelfType-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ShelfSortDelta-ShelfType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="columns"/>
+      <xs:enumeration value="rows"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Flipboard-FlipboardNavType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="caption"/>
+      <xs:enumeration value="number"/>
+      <xs:enumeration value="dot"/>
+      <xs:enumeration value="arrowonly"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="WorksheetDeltas-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Flipboard-DatasourceDependencies-G"/>
+      <xs:element minOccurs="0" name="columns" type="Flipboard-TableColumns-CT"/>
+      <xs:element minOccurs="0" name="rows" type="Flipboard-TableColumns-CT"/>
+      <xs:group minOccurs="0" ref="Flipboard-FilterSettings-G"/>
+      <xs:group minOccurs="0" ref="Flipboard-Sorting-G"/>
+      <xs:group minOccurs="0" ref="Flipboard-Annotations-G"/>
+      <xs:group minOccurs="0" ref="Flipboard-Stylesheet-G"/>
+      <xs:group minOccurs="0" ref="ShelfSortDeltas-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="OneDelta-G">
+    <xs:sequence>
+      <xs:sequence maxOccurs="unbounded" minOccurs="0">
+        <xs:element minOccurs="0" name="worksheet">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:group minOccurs="0" ref="WorksheetDeltas-G"/>
+              <xs:group minOccurs="0" ref="Flipboard-VizDeltas-G"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element minOccurs="0" name="dashboard">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:group ref="Flipboard-DashboardDeltas-G"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:element minOccurs="0" name="datasource">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Flipboard-ParameterDeltas-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Deltas-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="currentDeltas">
+        <xs:complexType>
+          <xs:group ref="OneDelta-G"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element minOccurs="0" name="capturedDeltas">
+        <xs:complexType>
+          <xs:group ref="OneDelta-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StoryPoint-G">
+    <xs:sequence>
+      <xs:element name="story-point">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="Deltas-G"/>
+          </xs:sequence>
+          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+          <xs:attribute name="captured-sheet" type="xs:string" use="required"/>
+          <xs:attribute name="current-sheet" type="xs:string"/>
+          <xs:attribute name="caption" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="FlipboardDoc-G">
+    <xs:sequence>
+      <xs:element name="flipboard">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="story-points">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group maxOccurs="unbounded" minOccurs="0" ref="StoryPoint-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="active-id" type="xs:unsignedInt"/>
+          <xs:attribute name="nav-type" type="Flipboard-FlipboardNavType-ST"/>
+          <xs:attribute name="show-nav-arrows" type="xs:boolean" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Flipboard-TableColumns-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+        <xs:complexType>
+          <xs:attribute name="field" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="delta-type" type="StoryDelta-ST" use="required"/>
+          <xs:attribute name="index" type="xs:unsignedInt"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="Flipboard-DatasourceDependencies-G">
+    <xs:sequence>
+      <xs:element name="datasource-dependencies">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Column-G"/>
+            <xs:group maxOccurs="unbounded" ref="ColumnInstance-G"/>
+          </xs:sequence>
+          <xs:attribute name="datasource" type="RootValue-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-FilterSettings-G">
+    <xs:sequence>
+      <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="filter">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+            </xs:sequence>
+            <xs:anyAttribute processContents="skip"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-Sorting-G">
+    <xs:sequence>
+      <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:group ref="ClearSort-G"/>
+        <xs:group ref="Sort-G"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-Annotations-G">
+    <xs:sequence>
+      <xs:element name="annotations">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="annotation">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:any maxOccurs="unbounded" minOccurs="0" namespace="##local" processContents="skip"/>
+                </xs:sequence>
+                <xs:anyAttribute namespace="##local" processContents="skip"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-Stylesheet-G">
+    <xs:sequence>
+      <xs:group maxOccurs="2" minOccurs="0" ref="Stylesheet-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-ShelfSortDelta-G">
+    <xs:sequence>
+      <xs:group maxOccurs="2" minOccurs="0" ref="ShelfSortDelta-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Flipboard-FilterKind-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="hide"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Flipboard-VizDeltas-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="current-page">
+        <xs:complexType>
+          <xs:group ref="MultiBucket-Only-G"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:group minOccurs="0" ref="SelectionCollection-G"/>
+      <xs:group minOccurs="0" ref="HighlightSpecification-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-DashboardDeltas-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="zone">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="FormattedText-G"/>
+          </xs:sequence>
+          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Flipboard-ParameterDeltas-G">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="column">
+        <xs:complexType>
+          <xs:attribute name="name" type="QualifiedName-ST" use="required"/>
+          <xs:attribute name="value" type="DataValue-ST" use="required"/>
+          <xs:attribute name="alias" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GroupLayout-GroupChildProperties-G">
+    <xs:sequence>
+      <xs:element name="group-child-properties">
+        <xs:complexType>
+          <xs:attribute name="child-id" type="xs:unsignedInt" use="required"/>
+          <xs:attribute name="left" type="xs:float" use="required"/>
+          <xs:attribute name="right" type="xs:float" use="required"/>
+          <xs:attribute name="top" type="xs:float" use="required"/>
+          <xs:attribute name="bottom" type="xs:float" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GroupLayout-G">
+    <xs:sequence>
+      <xs:element name="group-layout">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="GroupLayout-GroupChildProperties-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GridLayout-Proportions-G">
+    <xs:sequence>
+      <xs:element name="proportions">
+        <xs:complexType>
+          <xs:attribute name="left" type="xs:float" use="required"/>
+          <xs:attribute name="right" type="xs:float" use="required"/>
+          <xs:attribute name="top" type="xs:float" use="required"/>
+          <xs:attribute name="bottom" type="xs:float" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GridLayout-GridChild-G">
+    <xs:sequence>
+      <xs:element name="grid-child">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="GridLayout-Proportions-G"/>
+            <xs:group ref="Zone-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="GridLayout-G">
+    <xs:sequence>
+      <xs:element name="grid-layout">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="GridLayout-GridChild-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StackLayout-Automatic-G">
+    <xs:sequence>
+      <xs:element name="automatic">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:maxLength value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StackLayout-FixedSize-G">
+    <xs:sequence>
+      <xs:element name="fixed-size">
+        <xs:complexType>
+          <xs:attribute name="value" type="xs:unsignedInt" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StackLayout-ProportionalRatio-G">
+    <xs:sequence>
+      <xs:element name="proportional-ratio">
+        <xs:complexType>
+          <xs:attribute name="value" type="Float-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StackLayout-ResizingProperties-G">
+    <xs:choice>
+      <xs:group ref="StackLayout-Automatic-G"/>
+      <xs:group ref="StackLayout-FixedSize-G"/>
+      <xs:group ref="StackLayout-ProportionalRatio-G"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="StackLayout-StackChild-G">
+    <xs:sequence>
+      <xs:element name="stack-child">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="StackLayout-ResizingProperties-G"/>
+            <xs:group ref="Zone-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StackLayout-Direction-G">
+    <xs:sequence>
+      <xs:element name="direction">
+        <xs:complexType>
+          <xs:attribute name="value" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="horizontal"/>
+                <xs:enumeration value="vertical"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="StackLayout-G">
+    <xs:sequence>
+      <xs:element name="stack-layout">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="StackLayout-Direction-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="StackLayout-StackChild-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="ZoneLayoutType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="basic"/>
+      <xs:enumeration value="free-form"/>
+      <xs:enumeration value="flow"/>
+      <xs:enumeration value="distribute-evenly"/>
+      <xs:enumeration value="trivial"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ZoneType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="invalid"/>
+      <xs:enumeration value="visual"/>
+      <xs:enumeration value="color"/>
+      <xs:enumeration value="shape"/>
+      <xs:enumeration value="size"/>
+      <xs:enumeration value="map"/>
+      <xs:enumeration value="highlighter"/>
+      <xs:enumeration value="filter"/>
+      <xs:enumeration value="currpage"/>
+      <xs:enumeration value="empty"/>
+      <xs:enumeration value="title"/>
+      <xs:enumeration value="text"/>
+      <xs:enumeration value="bitmap"/>
+      <xs:enumeration value="web"/>
+      <xs:enumeration value="add-in"/>
+      <xs:enumeration value="dashboard-object"/>
+      <xs:enumeration value="paramctrl"/>
+      <xs:enumeration value="flipboard"/>
+      <xs:enumeration value="flipboard-nav"/>
+      <xs:enumeration value="layout-basic"/>
+      <xs:enumeration value="layout-flow"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Zone-G">
+    <xs:sequence>
+      <xs:element name="zone">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="FormattedText-G"/>
+            <xs:group ref="Zone-LayoutCache-G"/>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Zone-G"/>
+            <xs:group minOccurs="0" ref="FlipboardDoc-G"/>
+            <xs:choice>
+              <xs:element minOccurs="0" name="button" type="Button-CT"/>
+              <xs:element minOccurs="0" name="add-in" type="Extension-CT"/>
+            </xs:choice>
+            <xs:group ref="Zone-ZoneStyle-G"/>
+          </xs:sequence>
+          <xs:attribute name="x" type="xs:int" use="required"/>
+          <xs:attribute name="y" type="xs:int" use="required"/>
+          <xs:attribute name="w" type="xs:int" use="required"/>
+          <xs:attribute name="h" type="xs:int" use="required"/>
+          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+          <xs:attribute name="story-point-id" type="xs:unsignedInt"/>
+          <xs:attribute name="flipboard-zone-id" type="xs:unsignedInt"/>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="type-v2" type="xs:string"/>
+          <xs:attribute name="layout-strategy-id" type="ZoneLayoutType-ST"/>
+          <xs:attribute name="param">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:minLength value="1"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="hidden" type="xs:boolean"/>
+          <xs:attribute name="hidden-by-user" type="xs:boolean"/>
+          <xs:attribute name="is-fixed" type="xs:boolean"/>
+          <xs:attribute name="fixed-size" type="xs:int"/>
+          <xs:attribute name="alt-text" type="xs:string"/>
+          <xs:attribute name="friendly-name" type="xs:string"/>
+          <xs:attribute name="url" type="xs:string"/>
+          <xs:attribute name="tip" type="xs:string"/>
+          <xs:attribute name="scroll" type="xs:string"/>
+          <xs:attribute name="error-action" type="xs:string"/>
+          <xs:attribute name="error-text" type="xs:string"/>
+          <xs:attribute name="error-url" type="xs:string"/>
+          <xs:attribute name="show-title" type="xs:boolean"/>
+          <xs:attribute name="show-caption" type="xs:boolean"/>
+          <xs:attribute name="show-context-menu" type="xs:boolean"/>
+          <xs:attribute name="suppress-dialogs" type="xs:boolean"/>
+          <xs:attribute name="removable" type="xs:boolean"/>
+          <xs:attribute name="is-centered" type="xs:string"/>
+          <xs:attribute name="is-scaled" type="xs:string"/>
+          <xs:attribute name="image-file-url" type="xs:string"/>
+          <xs:attribute name="paired-zone-id" type="xs:unsignedInt"/>
+          <xs:anyAttribute namespace="##local" processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Zone-ZoneStyle-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="zone-style">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="format">
+              <xs:complexType>
+                <xs:attribute name="attr" type="StyleAttribute-ST" use="required"/>
+                <xs:attribute name="value" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Zone-LayoutCache-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="layout-cache">
+        <xs:complexType>
+          <xs:attribute name="type-w" type="DashboardLayoutType-ST" use="required"/>
+          <xs:attribute name="fixed-size-w" type="xs:int"/>
+          <xs:attribute name="cell-count-w" type="xs:int"/>
+          <xs:attribute name="non-cell-size-w" type="xs:int"/>
+          <xs:attribute name="has-max-size-w" type="xs:boolean"/>
+          <xs:attribute name="maxwidth" type="xs:int"/>
+          <xs:attribute name="minwidth" type="xs:int"/>
+          <xs:attribute name="type-h" type="DashboardLayoutType-ST" use="required"/>
+          <xs:attribute name="fixed-size-h" type="xs:int"/>
+          <xs:attribute name="cell-count-h" type="xs:int"/>
+          <xs:attribute name="non-cell-size-h" type="xs:int"/>
+          <xs:attribute name="has-max-size-h" type="xs:boolean"/>
+          <xs:attribute name="maxheight" type="xs:int"/>
+          <xs:attribute name="minheight" type="xs:int"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DashboardLayoutType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="fixed"/>
+      <xs:enumeration value="cell"/>
+      <xs:enumeration value="scalable"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DashboardDoc-G">
+    <xs:sequence>
+      <xs:element name="dashboard">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Dashboard-VizLayoutOptionsOrRepositoryLocation-G"/>
+            <xs:group minOccurs="0" ref="Stylesheet-G"/>
+            <xs:group ref="Dashboard-DashboardSizeOptions-G"/>
+            <xs:group ref="DataSourcesAndDependencies-G"/>
+            <xs:group ref="ZoneCollection-G"/>
+            <xs:group minOccurs="0" ref="DeviceLayouts-G"/>
+            <xs:group ref="SimpleIdentifierForThisDashboard-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="lock-updates" type="xs:boolean"/>
+          <xs:attribute name="lock-quick-filters" type="xs:boolean"/>
+          <xs:attribute name="type" type="Dashboard-DashboardType-ST"/>
+          <xs:attribute name="enable-sort-zone-taborder" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="FormattedNameForDeviceLayout-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Desktop"/>
+      <xs:enumeration value="Phone"/>
+      <xs:enumeration value="Tablet"/>
+      <xs:enumeration value="default"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DeviceLayouts-G">
+    <xs:sequence>
+      <xs:element name="devicelayouts">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="devicelayout" type="Dashboard-DeviceLayout-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ZoneCollection-G">
+    <xs:sequence>
+      <xs:element name="zones">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Zone-G"/>
+          </xs:sequence>
+          <xs:attribute name="is-pixels" type="xs:boolean"/>
+          <xs:attribute name="use-insets" type="xs:boolean"/>
+        </xs:complexType>
+        <xs:unique name="DemandZoneIdUnique">
+          <xs:selector xpath="zone"/>
+          <xs:field xpath="@id"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Dashboard-DashboardType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="storyboard"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Dashboard-DeviceLayout-CT">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="VizLayoutOptions-G"/>
+      <xs:group minOccurs="0" ref="Dashboard-DashboardSizeOptions-G"/>
+      <xs:group minOccurs="0" ref="ZoneCollection-G"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="FormattedNameForDeviceLayout-ST" use="required"/>
+    <xs:attribute name="active" type="xs:boolean"/>
+    <xs:attribute name="auto-generated" type="xs:boolean"/>
+  </xs:complexType>
+  <xs:group name="Dashboard-DashboardSizeOptions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="size">
+        <xs:complexType>
+          <xs:attribute name="fit-to-story" type="xs:string"/>
+          <xs:attribute name="minwidth" type="xs:int"/>
+          <xs:attribute name="minheight" type="xs:int"/>
+          <xs:attribute name="maxwidth" type="xs:int"/>
+          <xs:attribute name="maxheight" type="xs:int"/>
+          <xs:attribute name="preset-index" type="xs:unsignedInt"/>
+          <xs:attribute name="sizing-mode" type="DashboardSizingMode-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SimpleIdentifierForThisDashboard-G">
+    <xs:sequence>
+      <xs:group minOccurs="1" ref="SimpleIdentifier-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Dashboard-VizLayoutOptionsOrRepositoryLocation-G">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="2">
+        <xs:group ref="VizLayoutOptions-G"/>
+        <xs:group ref="RepositoryLocation-G"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="GridOverlayMode-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="automatic"/>
+      <xs:enumeration value="on"/>
+      <xs:enumeration value="off"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DefaultMapToolSelection-G">
+    <xs:sequence>
+      <xs:element name="default-map-tool-selection">
+        <xs:complexType>
+          <xs:attribute name="tool" type="DefaultMapToolSelection-DMT-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DefaultMapToolSelection-DMT-ST">
+    <xs:restriction base="xs:int">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+      <xs:enumeration value="4"/>
+      <xs:enumeration value="8"/>
+      <xs:enumeration value="16"/>
+      <xs:enumeration value="32"/>
+      <xs:enumeration value="12"/>
+      <xs:enumeration value="29"/>
+      <xs:enumeration value="30"/>
+      <xs:enumeration value="31"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DefaultMapUnitSelection-G">
+    <xs:sequence>
+      <xs:element name="default-map-unit-selection">
+        <xs:complexType>
+          <xs:attribute name="mapunit" type="DefaultMapUnitSelection-MUS-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="DefaultMapUnitSelection-MUS-ST">
+    <xs:restriction base="xs:int">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="FloatingToolbarVisibility-G">
+    <xs:sequence>
+      <xs:element name="floating-toolbar-visibility">
+        <xs:complexType>
+          <xs:attribute name="value" type="FloatingToolbarVisibility-FTV-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="FloatingToolbarVisibility-FTV-ST">
+    <xs:restriction base="xs:int">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="GeoSearchVisibility-G">
+    <xs:sequence>
+      <xs:element name="geo-search-visibility">
+        <xs:complexType>
+          <xs:attribute name="value" type="GeoSearchVisibility-GSV-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="GeoSearchVisibility-GSV-ST">
+    <xs:restriction base="xs:integer">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="GlobalFieldNames-ST">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="((\[([^\]]|\]\])*\](\.\[([^\]]|\]\])*\])*)?\n)*(\[([^\]]|\]\])*\](\.\[([^\]]|\]\])*\])*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EncodingType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="color"/>
+      <xs:enumeration value="size"/>
+      <xs:enumeration value="shape"/>
+      <xs:enumeration value="highlight"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="HighlightSpecification-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="highlight">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="HighlightSpecification-ColorOneWay-G"/>
+            <xs:element minOccurs="0" name="bucket-selection">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group maxOccurs="unbounded" minOccurs="0" ref="MultiBucket-Or-Bucket-G"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="color-one-way" type="xs:boolean"/>
+          <xs:attribute name="type" type="EncodingType-ST"/>
+          <xs:attribute name="field" type="GlobalFieldNames-ST"/>
+          <xs:attribute name="pattern" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="HighlightSpecification-ColorOneWay-G">
+    <xs:sequence>
+      <xs:element name="color-one-way">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="field" type="QualifiedName-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="LayerControl-G">
+    <xs:sequence>
+      <xs:element name="layer-control">
+        <xs:complexType>
+          <xs:attribute name="toolbar-button-enabled" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="NAV-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="MapNavigation-G">
+    <xs:sequence>
+      <xs:element name="map-navigation">
+        <xs:complexType>
+          <xs:attribute name="value" type="NAV-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MapScaleVisibility-G">
+    <xs:sequence>
+      <xs:element name="map-scale-visibility">
+        <xs:complexType>
+          <xs:attribute name="value" type="MapScaleVisibility-GSV-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="MapScaleVisibility-GSV-ST">
+    <xs:restriction base="xs:integer">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ShelfType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="columns"/>
+      <xs:enumeration value="rows"/>
+      <xs:enumeration value="pages"/>
+      <xs:enumeration value="filter"/>
+      <xs:enumeration value="image"/>
+      <xs:enumeration value="measures"/>
+      <xs:enumeration value="showme"/>
+      <xs:enumeration value="geometry"/>
+      <xs:enumeration value="encoding"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="OrientedNodeReference-G">
+    <xs:sequence>
+      <xs:element name="oriented-node-reference">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="NodeReference-G"/>
+            <xs:group ref="PageReference-G"/>
+          </xs:sequence>
+          <xs:attribute name="orientation" type="Selection-Orientation-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="NodeSelection-G">
+    <xs:sequence>
+      <xs:element name="node-selection">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="OrientedNodeReference-G"/>
+          </xs:sequence>
+          <xs:attribute name="select-tuples" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="TupleSelection-G">
+    <xs:sequence>
+      <xs:element name="tuple-selection">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="TupleReference-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="FieldSelection-G">
+    <xs:sequence>
+      <xs:element name="field-selection">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="field-reference" type="Selection-FieldReference-CT"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="BucketSelection-G">
+    <xs:sequence>
+      <xs:element name="bucket-selection">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="MultiBucket-Only-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ReferenceLineSelection-G">
+    <xs:sequence>
+      <xs:element name="reference-line-selection">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="reference-line" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="TrendLineSelection-G">
+    <xs:sequence>
+      <xs:element name="trendline-selection">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="trendline" type="xs:int"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SelectionCollection-G">
+    <xs:sequence>
+      <xs:element name="selection-collection">
+        <xs:complexType>
+          <xs:choice maxOccurs="unbounded" minOccurs="0">
+            <xs:group ref="NodeSelection-G"/>
+            <xs:group ref="TupleSelection-G"/>
+            <xs:group ref="FieldSelection-G"/>
+            <xs:group ref="BucketSelection-G"/>
+            <xs:group ref="ReferenceLineSelection-G"/>
+            <xs:group ref="TrendLineSelection-G"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Selection-Orientation-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="horizontal"/>
+      <xs:enumeration value="vertical"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Selection-FieldReference-CT">
+    <xs:simpleContent>
+      <xs:extension base="QualifiedName-ST">
+        <xs:attribute name="position" type="xs:unsignedInt" use="required"/>
+        <xs:attribute name="shelf" type="ShelfType-ST" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:group name="VisualDoc-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="viewpoint">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="VisualDoc-Viewpoint-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="VisualDocs-G">
+    <xs:sequence>
+      <xs:element name="viewpoints">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="VisualDoc-Viewpoints-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="VisualDoc-Viewpoint-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="VisualDoc-CurrentPage-G"/>
+      <xs:group minOccurs="0" ref="VisualDoc-Zoom-G"/>
+      <xs:group minOccurs="0" ref="SelectionCollection-G"/>
+      <xs:group minOccurs="0" ref="HighlightSpecification-G"/>
+      <xs:group minOccurs="0" ref="FloatingToolbarVisibility-G"/>
+      <xs:group minOccurs="0" ref="GeoSearchVisibility-G"/>
+      <xs:group minOccurs="0" ref="MapScaleVisibility-G"/>
+      <xs:group minOccurs="0" ref="DefaultMapToolSelection-G"/>
+      <xs:group minOccurs="0" ref="MapNavigation-G"/>
+      <xs:group minOccurs="0" ref="DefaultMapUnitSelection-G"/>
+      <xs:group minOccurs="0" ref="LayerControl-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="VisualDoc-Viewpoints-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" minOccurs="0" ref="VisualDoc-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="VisualDoc-ZoomType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="percent"/>
+      <xs:enumeration value="entire-view"/>
+      <xs:enumeration value="fit-width"/>
+      <xs:enumeration value="fit-height"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="VisualDoc-CurrentPage-G">
+    <xs:sequence>
+      <xs:element name="current-page">
+        <xs:complexType>
+          <xs:group ref="MultiBucket-Only-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="VisualDoc-Zoom-G">
+    <xs:sequence>
+      <xs:element name="zoom">
+        <xs:complexType>
+          <xs:attribute name="type" type="VisualDoc-ZoomType-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Window-G">
+    <xs:sequence>
+      <xs:element name="window">
+        <xs:complexType>
+          <xs:group ref="Window-Window-G"/>
+          <xs:attributeGroup ref="Window-WindowAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Bookmark-G">
+    <xs:sequence>
+      <xs:element name="window">
+        <xs:complexType>
+          <xs:group ref="Window-WorksheetWindow-G"/>
+          <xs:attributeGroup ref="Window-WindowBookmarkAttributes-AG"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Windows-G">
+    <xs:sequence>
+      <xs:element name="windows">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Window-Windows-G"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="Window-WindowsAttributes-AG"/>
+        </xs:complexType>
+        <xs:unique name="DemandWindowNameUnique">
+          <xs:selector xpath="window"/>
+          <xs:field xpath="@name"/>
+        </xs:unique>
+        <xs:unique name="DemandWindowSimpleIdUnique">
+          <xs:selector xpath="window/simple-id"/>
+          <xs:field xpath="@uuid"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="Window-WindowAttributes-AG">
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="class" type="Window-WindowType-ST"/>
+    <xs:attribute name="hidden" type="xs:boolean"/>
+    <xs:attribute name="maximized" type="xs:boolean"/>
+    <xs:attribute name="tab-color" type="ColorObject-ST"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="Window-WindowBookmarkAttributes-AG">
+    <xs:attribute name="tab-color" type="ColorObject-ST"/>
+  </xs:attributeGroup>
+  <xs:group name="Window-Window-G">
+    <xs:choice>
+      <xs:group ref="Window-WorksheetWindow-G"/>
+      <xs:group ref="Window-DashboardWindow-G"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="Window-WorksheetWindow-G">
+    <xs:sequence>
+      <xs:group ref="Cards-G"/>
+      <xs:group ref="VisualDoc-G"/>
+      <xs:group ref="SimpleIdentifierForThisWindow-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Window-DashboardWindow-G">
+    <xs:sequence>
+      <xs:group ref="VisualDocs-G"/>
+      <xs:element name="active">
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:int"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:group minOccurs="0" ref="Window-DevicePreviewSettings-G"/>
+      <xs:group ref="Window-DashboardGridOptions-G"/>
+      <xs:group ref="SimpleIdentifierForThisWindow-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SimpleIdentifierForThisWindow-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="SimpleIdentifier-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Window-DevicePreviewSettings-G">
+    <xs:sequence>
+      <xs:element name="device-preview">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="device">
+              <xs:complexType>
+                <xs:attribute name="type" type="FormattedNameForDeviceLayout-ST" use="required"/>
+                <xs:attribute name="name" type="xs:string"/>
+                <xs:attribute name="is-portrait" type="xs:boolean"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="visible" type="xs:boolean"/>
+          <xs:attribute name="selected" type="FormattedNameForDeviceLayout-ST"/>
+          <xs:attribute name="mobileapp-chrome-visible" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Window-DashboardGridOptions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="grid">
+        <xs:complexType>
+          <xs:attribute name="grid-overlay-mode" type="GridOverlayMode-ST"/>
+          <xs:attribute name="grid-size" type="xs:int"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Window-WindowType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="worksheet"/>
+      <xs:enumeration value="dashboard"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Window-Windows-G">
+    <xs:sequence>
+      <xs:group maxOccurs="unbounded" ref="Window-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="Window-WindowsAttributes-AG">
+    <xs:attribute name="pres-mode" type="xs:boolean"/>
+    <xs:attribute name="film-mode" type="xs:boolean"/>
+    <xs:attribute name="show-side-pane" type="xs:boolean"/>
+    <xs:attribute name="source-height" type="xs:int"/>
+    <xs:attribute name="saved-dpi-scale-factor" type="xs:float"/>
+  </xs:attributeGroup>
+  <xs:simpleType name="PageOrientation-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="auto"/>
+      <xs:enumeration value="portrait"/>
+      <xs:enumeration value="landscape"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="LegendLayoutDirection-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="vertical"/>
+      <xs:enumeration value="horizontal"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="LegendLayoutLocation-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="right"/>
+      <xs:enumeration value="bottom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PercentMode-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="table"/>
+      <xs:enumeration value="column"/>
+      <xs:enumeration value="row"/>
+      <xs:enumeration value="pane"/>
+      <xs:enumeration value="row-in-pane"/>
+      <xs:enumeration value="column-in-pane"/>
+      <xs:enumeration value="cell-in-pane"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PageSizeOption-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="letter"/>
+      <xs:enumeration value="legal"/>
+      <xs:enumeration value="note"/>
+      <xs:enumeration value="folio"/>
+      <xs:enumeration value="tabloid"/>
+      <xs:enumeration value="ledger"/>
+      <xs:enumeration value="statement"/>
+      <xs:enumeration value="executive"/>
+      <xs:enumeration value="a3"/>
+      <xs:enumeration value="a4"/>
+      <xs:enumeration value="a5"/>
+      <xs:enumeration value="b4"/>
+      <xs:enumeration value="b5"/>
+      <xs:enumeration value="quarto"/>
+      <xs:enumeration value="unspecified"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="WorkbookLayoutType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="cartesian"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ForecastRangeType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="auto"/>
+      <xs:enumeration value="next"/>
+      <xs:enumeration value="end-of"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ForecastModelType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="auto-season"/>
+      <xs:enumeration value="auto"/>
+      <xs:enumeration value="custom"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ForecastComponentType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ets-none"/>
+      <xs:enumeration value="ets-additive"/>
+      <xs:enumeration value="ets-multiplicative"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TooltipMode-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="sticky"/>
+      <xs:enumeration value="smooth"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Workbook-DataSource-G">
+    <xs:sequence>
+      <xs:group ref="DataSourceInlineOrLink-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-DataSources-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="datasources">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Workbook-DataSource-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-MapSources-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="mapsources">
+        <xs:complexType>
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="MapSourceInlineOrLink-G"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-ViewSpecification-G">
+    <xs:sequence>
+      <xs:group ref="ViewSpecification-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Workbook-Fields-CT">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="column" type="QualifiedName-ST"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="Workbook-Stylesheet-G">
+    <xs:sequence>
+      <xs:group ref="Stylesheet-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-MarkLayout-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="mark-layout">
+        <xs:complexType>
+          <xs:attribute name="type" type="WorkbookLayoutType-ST" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-PageTrailOptions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="page-trail-options">
+        <xs:complexType>
+          <xs:attribute name="enabled" type="xs:boolean"/>
+          <xs:attribute name="mark-type" type="Workbook-MarkType-ST"/>
+          <xs:attribute name="marks" type="xs:boolean"/>
+          <xs:attribute name="lines" type="xs:boolean"/>
+          <xs:attribute name="size" type="xs:int"/>
+          <xs:attribute name="trail-effect" type="Workbook-TrailEffect-ST"/>
+          <xs:attribute name="start" type="xs:int"/>
+          <xs:attribute name="end" type="xs:int"/>
+          <xs:attribute name="mark-color" type="ColorObject-ST"/>
+          <xs:attribute name="mark-color-auto" type="xs:boolean"/>
+          <xs:attribute name="line-color" type="ColorObject-ST"/>
+          <xs:attribute name="line-stroke-width" type="xs:float"/>
+          <xs:attribute name="line-pattern" type="Workbook-LinePattern-ST"/>
+          <xs:attribute name="line-color-auto" type="xs:boolean"/>
+          <xs:attribute name="mark-line-pattern" type="Workbook-MarkLinePattern-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Workbook-MarkType-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="manual"/>
+      <xs:enumeration value="all"/>
+      <xs:enumeration value="selected"/>
+      <xs:enumeration value="highlighted"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Workbook-TrailEffect-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="transparency"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Workbook-LinePattern-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="line-pattern-none"/>
+      <xs:enumeration value="line-pattern-solid"/>
+      <xs:enumeration value="line-pattern-dashed"/>
+      <xs:enumeration value="line-pattern-dotted"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Workbook-MarkLinePattern-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="solid"/>
+      <xs:enumeration value="dashed"/>
+      <xs:enumeration value="dotted"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Workbook-ForecastSpecification-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="forecast-specification">
+        <xs:complexType>
+          <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+          <xs:attribute name="range-type" type="ForecastRangeType-ST" use="required"/>
+          <xs:attribute name="ignore-last" type="xs:int" use="required"/>
+          <xs:attribute name="auto-forecast-agg" type="xs:boolean" use="required"/>
+          <xs:attribute name="model-type" type="ForecastModelType-ST" use="required"/>
+          <xs:attribute name="fill-type" type="DensificationFillType-ST" use="required"/>
+          <xs:attribute name="show-prediction-bands" type="xs:boolean" use="required"/>
+          <xs:attribute name="band-confidence-level" type="xs:float" use="required"/>
+          <xs:attribute name="range-size" type="xs:int"/>
+          <xs:attribute name="range-periods" type="AggType-ST"/>
+          <xs:attribute name="forecast-agg" type="AggType-ST"/>
+          <xs:attribute name="trend-type" type="ForecastComponentType-ST"/>
+          <xs:attribute name="season-type" type="ForecastComponentType-ST"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="WorkbookStylesheet-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Stylesheet-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="WorkbookOptimizer-G">
+    <xs:sequence>
+      <xs:element name="workbook-optimizer">
+        <xs:complexType>
+          <xs:group minOccurs="0" ref="WorkbookOptimizer-RuleConfig-G"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="WorkbookOptimizer-RuleId-ST">
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="WorkbookOptimizer-RuleConfig-G">
+    <xs:sequence>
+      <xs:element name="rule-config">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="WorkbookOptimizer-Rule-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="WorkbookOptimizer-Rule-G">
+    <xs:sequence>
+      <xs:element name="rule">
+        <xs:complexType>
+          <xs:attribute name="ruleID" type="WorkbookOptimizer-RuleId-ST" use="required"/>
+          <xs:attribute name="ignored" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="BookmarkFile-CT">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DocumentManifest-G"/>
+      <xs:group minOccurs="0" ref="VizLayoutOptions-G"/>
+      <xs:group ref="RepositoryLocation-G"/>
+      <xs:group ref="Workbook-Preferences-G"/>
+      <xs:group ref="Workbook-DataSources-G"/>
+      <xs:group minOccurs="0" ref="Workbook-DataSourceRelationships-G"/>
+      <xs:group minOccurs="0" ref="Workbook-MapSources-G"/>
+      <xs:group minOccurs="0" ref="Actions-G"/>
+      <xs:group minOccurs="0" ref="Bookmark-G"/>
+      <xs:group ref="Workbook-VisualSpecification-G"/>
+    </xs:sequence>
+    <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+    <xs:attribute ref="xml:base"/>
+    <xs:attribute name="source-platform" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="WorkbookFile-CT">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DocumentManifest-G"/>
+      <xs:group ref="Workbook-RepositoryLocation-G"/>
+      <xs:group ref="Workbook-Preferences-G"/>
+      <xs:group ref="Workbook-StyleTheme-G"/>
+      <xs:group ref="Workbook-Styles-G"/>
+      <xs:group ref="Workbook-LocalData-G"/>
+      <xs:group ref="Workbook-DataSources-G"/>
+      <xs:group ref="Workbook-DataSourceRelationships-G"/>
+      <xs:group ref="Workbook-MapSources-G"/>
+      <xs:group ref="Workbook-SharedViews-G"/>
+      <xs:group ref="Workbook-Actions-G"/>
+      <xs:group ref="Workbook-Worksheets-G"/>
+      <xs:group ref="Workbook-Dashboards-G"/>
+      <xs:group ref="Workbook-Windows-G"/>
+      <xs:group ref="Workbook-Datagraph-G"/>
+      <xs:group ref="Workbook-Thumbnails-G"/>
+      <xs:group ref="Shapes-G"/>
+      <xs:group ref="Workbook-ReferencedExtensions-G"/>
+      <xs:group ref="Workbook-ExplainData-G"/>
+      <xs:group minOccurs="0" ref="Workbook-DataOrientation-G"/>
+      <xs:group minOccurs="0" ref="Workbook-TabAgentConfig-G"/>
+      <xs:group minOccurs="0" ref="Workbook-AcceleratorDetails-G"/>
+      <xs:group minOccurs="0" ref="Workbook-WorkbookOptimizer-G"/>
+    </xs:sequence>
+    <xs:attributeGroup ref="Workbook-WorkbookAttributes-AG"/>
+  </xs:complexType>
+  <xs:attributeGroup name="Workbook-WorkbookAttributes-AG">
+    <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+    <xs:attribute name="original-version" type="VersionNumber-ST"/>
+    <xs:attribute name="source-build" type="xs:string" use="required"/>
+    <xs:attribute ref="xml:base"/>
+    <xs:attribute name="upgrade-extracts" type="xs:boolean"/>
+    <xs:attribute name="locale" type="xs:string"/>
+    <xs:attribute name="source-platform" type="xs:string"/>
+    <xs:attribute name="include-phone-layouts" type="xs:boolean"/>
+  </xs:attributeGroup>
+  <xs:group name="Workbook-WorksheetDocRef-G">
+    <xs:sequence>
+      <xs:element name="worksheet">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="RepositoryLocation-G"/>
+            <xs:group ref="Workbook-DataSources-G"/>
+            <xs:group minOccurs="0" ref="Workbook-MapSources-G"/>
+            <xs:group ref="Workbook-VisualSpecification-G"/>
+          </xs:sequence>
+          <xs:attribute name="version" type="VersionNumber-ST" use="required"/>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-DataSourceRelationships-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="datasource-relationships">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="DataSourceRelationships-G"/>
+          </xs:sequence>
+          <xs:attribute name="target-secondaries" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-QuantitativeDomain-G">
+    <xs:sequence>
+      <xs:element name="domain">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="min" type="DataValue-ST"/>
+            <xs:element name="max" type="DataValue-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-CategoricalDomain-G">
+    <xs:sequence>
+      <xs:element name="domain">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="value" type="DataValue-ST"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-LocalData-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="local-data">
+        <xs:complexType>
+          <xs:attribute name="directory" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element minOccurs="0" name="local-data-typed">
+        <xs:complexType>
+          <xs:attribute name="directory" type="xs:string" use="required"/>
+          <xs:attribute name="type" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Preferences-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Preferences-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-StyleTheme-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="style-theme">
+        <xs:complexType>
+          <xs:attribute name="name" type="StyleTheme-ST"/>
+          <xs:attribute name="value">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:minLength value="1"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-SharedView-G">
+    <xs:sequence>
+      <xs:element name="shared-view">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Workbook-DataSources-G"/>
+            <xs:group ref="DataSourceDependencies-G"/>
+            <xs:group ref="Workbook-ViewSpecification-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="Workbook-FieldSet-CT">
+    <xs:complexContent>
+      <xs:extension base="Workbook-Fields-CT"/>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="Workbook-OnOff-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="on"/>
+      <xs:enumeration value="off"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Workbook-Worksheets-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="worksheets">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="Workbook-WorksheetDocPtr-G"/>
+          </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="DemandWorksheetNameUnique">
+          <xs:selector xpath="worksheet"/>
+          <xs:field xpath="@name"/>
+        </xs:unique>
+        <xs:unique name="UniqueWorksheetIdentifier">
+          <xs:selector xpath="worksheet/simple-id"/>
+          <xs:field xpath="@uuid"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-WorksheetDocPtr-G">
+    <xs:sequence>
+      <xs:element name="worksheet">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="Workbook-VizLayoutOptionsOrRepositoryLocation-G"/>
+            <xs:group ref="Workbook-VisualSpecification-G"/>
+            <xs:group ref="SimpleIdentifierForThisWorksheet-G"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="lock-updates" type="xs:boolean"/>
+          <xs:attribute name="lock-quick-filters" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Worksheet-WorksheetNumber-G">
+    <xs:sequence>
+      <xs:element name="worksheet-number">
+        <xs:complexType>
+          <xs:attribute name="number" use="required" type="xs:int"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="SimpleIdentifierForThisWorksheet-G">
+    <xs:sequence>
+      <xs:group minOccurs="1" ref="SimpleIdentifier-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Dashboards-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="dashboards">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="DashboardDoc-G"/>
+          </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="UniqueDashboardIdentifier">
+          <xs:selector xpath="dashboard/simple-id"/>
+          <xs:field xpath="@uuid"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-VizLayoutOptionsOrRepositoryLocation-G">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="2">
+        <xs:group ref="VizLayoutOptions-G"/>
+        <xs:group ref="RepositoryLocation-G"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-RepositoryLocation-G">
+    <xs:sequence>
+      <xs:group ref="RepositoryLocation-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Styles-G">
+    <xs:sequence>
+      <xs:group ref="WorkbookStylesheet-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-SharedViews-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="shared-views">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" minOccurs="0" ref="Workbook-SharedView-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Windows-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Windows-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Thumbnails-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="thumbnails">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="Thumbnail-G"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-ReferencedExtensions-G">
+    <xs:sequence>
+      <xs:element minOccurs="0" maxOccurs="1" name="referenced-extensions" type="ReferencedExtensions-CT"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Actions-G">
+    <xs:sequence>
+      <xs:group ref="ActionsOrActionList-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-DataOrientation-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="DataOrientation-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-TabAgentConfig-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="TabAgentConfig-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Workbook-Explanations-ST">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="number-of-records"/>
+      <xs:enumeration value="average-of-records"/>
+      <xs:enumeration value="extreme-values"/>
+      <xs:enumeration value="distribution-of-records"/>
+      <xs:enumeration value="aggregated-dimensions"/>
+      <xs:enumeration value="unvisualized-measures"/>
+      <xs:enumeration value="null-value"/>
+      <xs:enumeration value="explain-average"/>
+      <xs:enumeration value="tvd-single-value"/>
+      <xs:enumeration value="ad-single-value"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Workbook-ExplanationTypes-G">
+    <xs:sequence>
+      <xs:element name="explanation-types">
+        <xs:complexType>
+          <xs:sequence maxOccurs="unbounded" minOccurs="0">
+            <xs:element name="explanation-type">
+              <xs:complexType>
+                <xs:attribute name="type" type="Workbook-Explanations-ST" use="required"/>
+                <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-ExplainData-G">
+    <xs:sequence>
+      <xs:element name="explain-data">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group maxOccurs="unbounded" ref="Workbook-ExplanationTypes-G"/>
+          </xs:sequence>
+          <xs:attribute name="enabled-for-viewer" type="xs:boolean" use="required"/>
+          <xs:attribute name="extreme-values-enabled-for-all" type="xs:boolean" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-Datagraph-G">
+    <xs:sequence>
+      <xs:group minOccurs="0" ref="Datagraph-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-AcceleratorDetails-G">
+    <xs:sequence>
+      <xs:element name="accelerator-details">
+        <xs:complexType>
+          <xs:all>
+            <xs:element name="exchange-product-id" type="xs:unsignedInt"/>
+            <xs:element minOccurs="0" name="data-mapper-enabled" type="xs:boolean"/>
+            <xs:element minOccurs="0" name="dataMapperState">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="selectedSourceDataSourceCaption" type="xs:string"/>
+                  <xs:element name="selectedSourceDataSourceName" type="xs:string"/>
+                  <xs:element name="selectedTargetDataSourceCaption" type="xs:string"/>
+                  <xs:element name="selectedTargetDataSourceName" type="xs:string"/>
+                  <xs:element name="targetFields">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="tableName" type="xs:string"/>
+                        <xs:element name="fields">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="field" maxOccurs="unbounded" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="sourceFullyQualifiedFieldName" type="xs:string"/>
+                                    <xs:element name="targetFullyQualifiedFieldName" type="xs:string"/>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:all>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Workbook-WorkbookOptimizer-G">
+    <xs:sequence>
+      <xs:group ref="WorkbookOptimizer-G"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="workbook" type="WorkbookFile-CT"/>
+</xs:schema>

--- a/skills/tableau-build/references/xsd/user.xsd
+++ b/skills/tableau-build/references/xsd/user.xsd
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.tableausoftware.com/xml/user"
+           elementFormDefault="qualified">
+  <xs:attributeGroup name="UserAttributes-AG">
+    <xs:anyAttribute namespace="##any" processContents="skip"/>
+  </xs:attributeGroup>
+</xs:schema>

--- a/skills/tableau-build/references/xsd/xml.xsd
+++ b/skills/tableau-build/references/xsd/xml.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/XML/1998/namespace"
+           xml:lang="en">
+  <xs:attribute name="lang">
+    <xs:simpleType>
+      <xs:union memberTypes="xs:language">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value=""/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:union>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="space">
+    <xs:simpleType>
+      <xs:restriction base="xs:NCName">
+        <xs:enumeration value="default"/>
+        <xs:enumeration value="preserve"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="base" type="xs:anyURI"/>
+  <xs:attribute name="id" type="xs:ID"/>
+  <xs:attributeGroup name="specialAttrs">
+    <xs:attribute ref="xml:base"/>
+    <xs:attribute ref="xml:lang"/>
+    <xs:attribute ref="xml:space"/>
+    <xs:attribute ref="xml:id"/>
+  </xs:attributeGroup>
+</xs:schema>

--- a/skills/tableau-build/scripts/build.py
+++ b/skills/tableau-build/scripts/build.py
@@ -17,11 +17,16 @@ filesystem:
 3. **STATE.md transition** - committing flips ``build`` to ``approved``. Build is the last
    step, so there is nothing downstream to stale (§4.2 is a no-op here).
 
+4. **Assembly** - ``build`` turns the validated manifest into the deliverable: the XML comes
+   from :mod:`twb` (pure, correct by construction), and this module supplies the CSV header
+   rows it needs, runs both migrated validators over the result, and packages the ``.twb``
+   plus the CSVs into a ``.twbx``.
+
 The module is pure and stdlib-only (it does **not** import the router) so the contract test
 can call its functions directly, exactly like ``spec.py``. The CLI exposes ``precheck``
 (before authoring - reports the target ``v_N`` and the inputs), ``validate`` (the manifest
-schema check), and ``commit`` (after approval). Program output goes to stdout; diagnostics
-through ``logging``.
+schema check), ``build`` (manifest -> validated ``.twbx``), and ``commit`` (after approval).
+Program output goes to stdout; diagnostics through ``logging``.
 
 Keep ``STEP_ORDER`` in lock-step with CONTRACT.md §1.
 """
@@ -29,14 +34,18 @@ Keep ``STEP_ORDER`` in lock-step with CONTRACT.md §1.
 from __future__ import annotations
 
 import argparse
+import csv
+import importlib.util
 import json
 import logging
 import re
 import sys
+import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+import twb
 from manifest import load_manifest, placed_layout_ids, validate_manifest
 
 logger = logging.getLogger(__name__)
@@ -49,6 +58,9 @@ SPEC_FILENAME = "IMPLEMENTATION-SPEC.md"
 #: Build-internal, not a handoff artifact - hence lowercase (CONTRACT.md §3).
 MANIFEST_FILENAME = "build-manifest.json"
 WORKBOOK_FILENAME = "dashboard.twbx"
+#: The unpackaged workbook, kept beside the .twbx: it is what the validators read, and it
+#: stays on disk after a failed build so the XML can be inspected.
+TWB_FILENAME = "dashboard.twb"
 VERSION_DIR = "mock-version"
 DATA_DIR = "data"
 SCAFFOLD_DATA_DIR = "scaffold/sample-data"
@@ -518,6 +530,202 @@ def validate(project_dir: Path | str) -> ValidationResult:
     return ValidationResult(not errors, errors, version, manifest_rel)
 
 
+# --- build (manifest -> validated .twbx) --------------------------------------
+
+#: The 2026.1 XSD requires ``<explain-data>``, which a workbook targeting 2024.2-2025.x must
+#: not carry. That single "missing child element" complaint is the documented version shift
+#: and the only XSD error a build tolerates.
+_VERSION_SHIFT_MARKERS = ("Missing child element", "explain-data")
+
+
+def read_csv_header(csv_path: Path) -> list[str]:
+    """Return a CSV's header row - the physical schema and its column order.
+
+    Args:
+        csv_path: Path to the CSV file.
+
+    Returns:
+        The column names in file order (empty for an empty file).
+    """
+    with csv_path.open(newline="", encoding="utf-8-sig") as handle:
+        for row in csv.reader(handle):
+            return [name.strip() for name in row]
+    return []
+
+
+def create_twbx(twb_path: Path, csv_paths: list[Path]) -> Path:
+    """Package a ``.twb`` and its CSVs into a flat ``.twbx`` beside it.
+
+    Flat (no directory entries) is what ``directory='.'`` in the workbook's connection
+    expects: Tableau unpacks the archive and finds each CSV next to the ``.twb``.
+
+    Args:
+        twb_path: The workbook XML file to package.
+        csv_paths: The CSVs the workbook reads.
+
+    Returns:
+        The path of the written ``.twbx``.
+    """
+    twbx_path = twb_path.with_suffix(".twbx")
+    with zipfile.ZipFile(twbx_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.write(twb_path, twb_path.name)
+        for csv_path in csv_paths:
+            archive.write(csv_path, csv_path.name)
+    return twbx_path
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    """Outcome of assembling the workbook from the validated manifest.
+
+    Attributes:
+        ok: True when the workbook was built, validated, and packaged.
+        errors: Why it was not; empty when ``ok``.
+        version: The version directory built into.
+        twb_path: Project-relative path of the workbook XML (written even on a validator
+            failure, so the XML can be inspected).
+        twbx_path: Project-relative path of the package; ``""`` when nothing was packaged.
+        warnings: Non-fatal notes (a skipped XSD check, the documented version shift).
+    """
+
+    ok: bool
+    errors: list[str]
+    version: str
+    twb_path: str = ""
+    twbx_path: str = ""
+    warnings: list[str] = field(default_factory=list)
+
+
+def _semantic_errors(twb_path: Path) -> list[str]:
+    """Run the migrated semantic validator and return one message per failed check.
+
+    Args:
+        twb_path: The workbook XML to check.
+
+    Returns:
+        ``"<check name>: <detail>"`` messages; empty when every check passes.
+    """
+    import validate_twb  # same scripts/ dir - already importable, no subprocess
+
+    report = validate_twb.TwbValidator(str(twb_path)).validate()
+    return [
+        f"{result.name}: {detail}"
+        for result in report.results if not result.passed
+        for detail in (result.details or ["check failed"])
+    ]
+
+
+def _xsd_errors(twb_path: Path, target_tableau_version: str) -> tuple[list[str], list[str]]:
+    """Run the migrated XSD validator, tolerating the documented version shift.
+
+    Args:
+        twb_path: The workbook XML to check.
+        target_tableau_version: STATE.md's target (CONTRACT.md §2).
+
+    Returns:
+        ``(errors, warnings)``. For the 2026.1+ target every schema error is fatal; for
+        2024.2-2025.x the single ``<explain-data>`` complaint is downgraded to a warning.
+        When ``lxml`` is absent the check is skipped with a warning.
+    """
+    if importlib.util.find_spec("lxml") is None:
+        return [], ["XSD check skipped: lxml is not installed (pip install lxml)."]
+
+    import validate_twb_xsd  # imports lxml at module level - guarded above
+
+    schema = validate_twb_xsd.load_schema(validate_twb_xsd.XSD_PATH)
+    _, raw_errors = validate_twb_xsd.validate(twb_path, schema)
+    messages = [f"line {error.line}: {error.message}" for error in raw_errors]
+    if target_tableau_version.strip() == twb.TARGET_2026:
+        return messages, []
+
+    tolerated = [
+        message for message in messages
+        if all(marker in message for marker in _VERSION_SHIFT_MARKERS)
+    ]
+    fatal = [message for message in messages if message not in tolerated]
+    warnings = [
+        f"XSD (expected for the {target_tableau_version} target): {message}"
+        for message in tolerated
+    ]
+    return fatal, warnings
+
+
+def build_workbook(project_dir: Path | str) -> BuildResult:
+    """Assemble, validate, and package the workbook from the validated manifest.
+
+    The manifest must validate first (:func:`validate`), so the assembler never sees an
+    entry it cannot build. The XML then goes through both migrated validators before it is
+    packaged: a workbook that fails either is left on disk unpackaged, for debugging.
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`BuildResult`.
+    """
+    project_root = Path(project_dir)
+    validation = validate(project_root)
+    if not validation.ok:
+        return BuildResult(False, validation.errors, validation.version)
+
+    version = validation.version
+    version_dir = project_root / VERSION_DIR / version
+    document, _ = load_manifest(version_dir / MANIFEST_FILENAME)
+
+    csv_paths = [project_root / relative for relative in _sample_csvs(project_root)]
+    headers = {path.name: read_csv_header(path) for path in csv_paths}
+    missing = sorted(
+        {
+            str(source.get("csv", "")).strip()
+            for source in document.get("datasources", [])
+            if str(source.get("csv", "")).strip() not in headers
+        }
+    )
+    if missing:
+        return BuildResult(
+            False,
+            [
+                f"datasource csv '{name}' is not on disk (found: "
+                f"{', '.join(sorted(headers)) or 'none'}) - the workbook would bind to "
+                f"nothing. Re-run 'tableau-data' or fix the manifest's 'csv'."
+                for name in missing
+            ],
+            version,
+        )
+
+    twb_path = version_dir / TWB_FILENAME
+    twb_path.write_text(
+        twb.render_workbook(
+            document,
+            (project_root / DATA_MODEL_FILENAME).read_text(encoding="utf-8-sig"),
+            headers,
+        ),
+        encoding="utf-8",
+    )
+    twb_relative = f"{VERSION_DIR}/{version}/{TWB_FILENAME}"
+
+    target = read_target_tableau_version(
+        (project_root / STATE_FILENAME).read_text(encoding="utf-8-sig")
+    )
+    errors = _semantic_errors(twb_path)
+    xsd_errors, warnings = _xsd_errors(twb_path, target)
+    errors += xsd_errors
+    if errors:
+        # Leave the .twb for inspection, but never package a workbook that failed a check.
+        return BuildResult(False, errors, version, twb_relative, warnings=warnings)
+
+    create_twbx(twb_path, csv_paths)
+    logger.info(f"Built {twb_relative} and its .twbx from the validated manifest.")
+    return BuildResult(
+        ok=True,
+        errors=[],
+        version=version,
+        twb_path=twb_relative,
+        twbx_path=f"{VERSION_DIR}/{version}/{WORKBOOK_FILENAME}",
+        warnings=warnings,
+    )
+
+
 # --- commit ------------------------------------------------------------------
 
 @dataclass
@@ -529,15 +737,12 @@ class CommitResult:
         message: Human-readable explanation (the refusal reason when not ``ok``).
         version: The version directory the (attempted) build lives in.
         errors: Manifest validation errors that refused the commit, when any.
-        project_dir: The project the commit ran against (so the report can check what
-            actually landed on disk).
     """
 
     ok: bool
     message: str
     version: str = "v_1"
     errors: list[str] = field(default_factory=list)
-    project_dir: str = "."
 
 
 def commit(project_dir: Path | str) -> CommitResult:
@@ -554,8 +759,6 @@ def commit(project_dir: Path | str) -> CommitResult:
         A :class:`CommitResult`. ``ok`` is False (STATE.md untouched) when the entry gate is
         closed or the manifest is missing / invalid.
     """
-    # TODO(builder ticket): once the deterministic builder lands, also require
-    # mock-version/<v_N>/dashboard.twbx to exist and pass XSD validation before approving.
     project_root = Path(project_dir)
     validation = validate(project_root)
     if not validation.ok:
@@ -569,6 +772,17 @@ def commit(project_dir: Path | str) -> CommitResult:
             errors=validation.errors,
         )
 
+    # The workbook is the deliverable, so approval requires one on disk. The validators ran
+    # in 'build' and refused to package a workbook that failed them - no need to re-run.
+    workbook_relative = f"{VERSION_DIR}/{validation.version}/{WORKBOOK_FILENAME}"
+    if not (project_root / workbook_relative).exists():
+        return CommitResult(
+            False,
+            f"Cannot approve build: '{workbook_relative}' does not exist. Run "
+            f"'build.py build' to assemble and package the workbook first.",
+            version=validation.version,
+        )
+
     state_path = project_root / STATE_FILENAME
     text = state_path.read_text(encoding="utf-8-sig")
     state_path.write_text(
@@ -580,7 +794,6 @@ def commit(project_dir: Path | str) -> CommitResult:
         ok=True,
         message=f"build -> approved ({validation.version})",
         version=validation.version,
-        project_dir=str(project_root),
     )
 
 
@@ -626,6 +839,24 @@ def format_validation(result: ValidationResult) -> str:
     return "\n".join(lines)
 
 
+def format_build(result: BuildResult) -> str:
+    """Render a :class:`BuildResult` as the assembly report."""
+    # Plain ASCII only (see format_precheck).
+    lines: list[str]
+    if result.ok:
+        lines = [
+            f"[BUILT] {result.twbx_path}",
+            f"  workbook xml : {result.twb_path} (semantic + XSD validated)",
+        ]
+    else:
+        lines = ["[INVALID] the workbook did not build:"]
+        lines += [f"  - {error}" for error in result.errors]
+        if result.twb_path:
+            lines.append(f"  the XML is at {result.twb_path} for inspection; nothing packaged.")
+    lines += [f"  [WARN] {warning}" for warning in result.warnings]
+    return "\n".join(lines)
+
+
 def format_commit(result: CommitResult) -> str:
     """Render a :class:`CommitResult` as a human-readable, plain-ASCII block."""
     # Plain ASCII only (see format_precheck).
@@ -635,21 +866,12 @@ def format_commit(result: CommitResult) -> str:
             text += f"\n  - {error}"
         return text
 
-    lines = [
+    return "\n".join([
         f"[BUILD] {result.message}.",
         f"  manifest: {VERSION_DIR}/{result.version}/{MANIFEST_FILENAME} (validated)",
-    ]
-    workbook = Path(result.project_dir) / VERSION_DIR / result.version / WORKBOOK_FILENAME
-    if workbook.exists():
-        lines.append(f"  deliverable: {VERSION_DIR}/{result.version}/{WORKBOOK_FILENAME}")
-    else:
-        # The deterministic generator is the next ticket; say so rather than announcing a
-        # workbook that is not on disk.
-        lines.append(
-            f"  note: no {WORKBOOK_FILENAME} yet - the workbook generator is in development."
-        )
-    lines.append("  the pipeline is complete - run 'tableau-route' to confirm.")
-    return "\n".join(lines)
+        f"  deliverable: {VERSION_DIR}/{result.version}/{WORKBOOK_FILENAME}",
+        "  the pipeline is complete - run 'tableau-route' to confirm.",
+    ])
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -670,6 +892,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     for name, help_text in (
         ("precheck", "Report whether build may run, what it reads, and where it writes."),
         ("validate", "Schema-check the build manifest against DATA-MODEL.md and the layout."),
+        ("build", "Assemble, validate, and package the workbook from the manifest."),
         ("commit", "Approve the build in STATE.md (never bumps current_version)."),
     ):
         sub = subparsers.add_parser(name, help=help_text)
@@ -689,6 +912,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         validation = validate(project_dir)
         print(format_validation(validation))
         return 0 if validation.ok else 2
+
+    if args.command == "build":
+        build_result = build_workbook(project_dir)
+        print(format_build(build_result))
+        return 0 if build_result.ok else 2
 
     commit_result = commit(project_dir)
     print(format_commit(commit_result))

--- a/skills/tableau-build/scripts/build.py
+++ b/skills/tableau-build/scripts/build.py
@@ -638,14 +638,18 @@ def _xsd_errors(twb_path: Path, target_tableau_version: str) -> tuple[list[str],
     if target_tableau_version.strip() == twb.TARGET_2026:
         return messages, []
 
-    tolerated = [
-        message for message in messages
+    # At most *one* such error is the documented shift; a second is a real problem, so
+    # forgive by position rather than by message text.
+    forgiven = [
+        index for index, message in enumerate(messages)
         if all(marker in message for marker in _VERSION_SHIFT_MARKERS)
+    ][:1]
+    fatal = [
+        message for index, message in enumerate(messages) if index not in forgiven
     ]
-    fatal = [message for message in messages if message not in tolerated]
     warnings = [
-        f"XSD (expected for the {target_tableau_version} target): {message}"
-        for message in tolerated
+        f"XSD (expected for the {target_tableau_version} target): {messages[index]}"
+        for index in forgiven
     ]
     return fatal, warnings
 
@@ -672,15 +676,19 @@ def build_workbook(project_dir: Path | str) -> BuildResult:
     version_dir = project_root / VERSION_DIR / version
     document, _ = load_manifest(version_dir / MANIFEST_FILENAME)
 
-    csv_paths = [project_root / relative for relative in _sample_csvs(project_root)]
-    headers = {path.name: read_csv_header(path) for path in csv_paths}
-    missing = sorted(
-        {
-            str(source.get("csv", "")).strip()
-            for source in document.get("datasources", [])
-            if str(source.get("csv", "")).strip() not in headers
-        }
-    )
+    # Drop any previous package before anything else can fail: 'commit' approves on the
+    # .twbx's existence, so a stale one left behind by a failed build would be approved.
+    (version_dir / WORKBOOK_FILENAME).unlink(missing_ok=True)
+
+    on_disk = {
+        (project_root / relative).name: project_root / relative
+        for relative in _sample_csvs(project_root)
+    }
+    headers = {name: read_csv_header(path) for name, path in on_disk.items()}
+    wanted = [
+        str(source.get("csv", "")).strip() for source in document.get("datasources", [])
+    ]
+    missing = sorted({name for name in wanted if name not in headers})
     if missing:
         return BuildResult(
             False,
@@ -714,7 +722,9 @@ def build_workbook(project_dir: Path | str) -> BuildResult:
         # Leave the .twb for inspection, but never package a workbook that failed a check.
         return BuildResult(False, errors, version, twb_relative, warnings=warnings)
 
-    create_twbx(twb_path, csv_paths)
+    # Only the CSVs the manifest actually binds to: an unrelated file in data/ has no
+    # business shipping inside the analyst's deliverable.
+    create_twbx(twb_path, [on_disk[name] for name in dict.fromkeys(wanted)])
     logger.info(f"Built {twb_relative} and its .twbx from the validated manifest.")
     return BuildResult(
         ok=True,

--- a/skills/tableau-build/scripts/manifest.py
+++ b/skills/tableau-build/scripts/manifest.py
@@ -74,20 +74,22 @@ _DATASOURCE_HEADING = re.compile(
 )
 
 
-def documented_fields(data_model_text: str) -> dict[str, set[str]]:
-    """Recover ``{csv filename: {field name}}`` from a DATA-MODEL.md.
+def documented_field_types(data_model_text: str) -> dict[str, dict[str, str]]:
+    """Recover ``{csv filename: {field name: type}}`` from a DATA-MODEL.md.
 
-    Only the field table's first column is needed here (types are the data step's
-    business); the parse is the tolerant mirror of ``tableau-data``'s renderer, so it keeps
+    ``DATA-MODEL.md`` is the field authority (CONTRACT.md §3), so the builder takes each
+    column's Tableau datatype from here rather than from the manifest - one authority, no
+    drift. The parse is the tolerant mirror of ``tableau-data``'s renderer, so it keeps
     working after the model enriches the Role/Description columns.
 
     Args:
         data_model_text: The contents of a ``DATA-MODEL.md`` file.
 
     Returns:
-        A mapping of CSV filename to the set of field names documented for it.
+        A mapping of CSV filename to ``{field name: lower-cased type}``. A field whose Type
+        cell is blank maps to ``""``.
     """
-    documented: dict[str, set[str]] = {}
+    documented: dict[str, dict[str, str]] = {}
     current: Optional[str] = None
     in_field_table = False
 
@@ -96,7 +98,7 @@ def documented_fields(data_model_text: str) -> dict[str, set[str]]:
         heading = _DATASOURCE_HEADING.match(line)
         if heading:
             current = heading.group(1)
-            documented.setdefault(current, set())
+            documented.setdefault(current, {})
             in_field_table = False
             continue
         if line.startswith("## "):  # a non-data-source section ends the current one
@@ -118,8 +120,23 @@ def documented_fields(data_model_text: str) -> dict[str, set[str]]:
             continue
         if not in_field_table or not name or set(name) <= set("-: "):
             continue  # separator row, or a table that is not the field table
-        documented[current].add(name)
+        documented[current][name] = cells[1].lower() if len(cells) >= 2 else ""
     return documented
+
+
+def documented_fields(data_model_text: str) -> dict[str, set[str]]:
+    """Recover ``{csv filename: {field name}}`` from a DATA-MODEL.md.
+
+    Args:
+        data_model_text: The contents of a ``DATA-MODEL.md`` file.
+
+    Returns:
+        A mapping of CSV filename to the set of field names documented for it.
+    """
+    return {
+        csv_name: set(fields)
+        for csv_name, fields in documented_field_types(data_model_text).items()
+    }
 
 
 def load_manifest(path: Path | str) -> tuple[Optional[dict], Optional[str]]:
@@ -470,9 +487,12 @@ def _validate_worksheets(
         The element ids the worksheets fill.
     """
     filled: set[str] = set()
-    if not isinstance(worksheets, list) or not worksheets:
-        errors.append("worksheets: must be a non-empty list (one per mock zone that is a view)")
+    if not isinstance(worksheets, list):
+        errors.append("worksheets: must be a list (one entry per mock zone that is a view)")
         return filled
+    # An empty list is legal: a dashboard of nothing but objects (a title, a logo, filter
+    # cards) has no view. The "every leaf zone is filled" check below is what actually
+    # catches a translation that dropped the views.
 
     seen_names: set[str] = set()
     for index, worksheet in enumerate(worksheets):

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -1,0 +1,545 @@
+"""The deterministic ``.twb`` assembler of tableau-build (CONTRACT.md step 8).
+
+Everything Tableau is strict about - the order of ``<workbook>``'s children, the uniqueness
+of generated ids, the fact that every datasource column must appear in *four* places, the
+version-dependent ``<explain-data>`` element - is expressed here as code rather than as a
+checklist an agent has to remember. A manifest that :mod:`manifest` accepted therefore
+builds a workbook that is correct by construction, which is what stops "Tableau refuses to
+open the file" at the source.
+
+The module is **pure** and stdlib-only: it takes the manifest, the ``DATA-MODEL.md`` text and
+the CSV header rows, and returns XML as a string. No filesystem, no ``STATE.md`` - that is
+:mod:`build`'s job, and it is why the tests can drive :func:`render_workbook` directly.
+
+Two authorities, deliberately kept apart:
+
+* the **CSV header** is the physical schema (which columns exist, and in what order) - an
+  incomplete ``relation > columns`` is a schema mismatch the moment Tableau loads the file;
+* ``DATA-MODEL.md`` is the **field authority** (CONTRACT.md §3) - it supplies each column's
+  type, from which the role, aggregation and remote-type all follow.
+
+The manifest's own ``fields[].type`` is validated but not read here: one authority, no drift.
+
+Scope: datasources, placeholder worksheets, a one-zone dashboard sized from the layout
+canvas, windows, and version targeting. Worksheet bodies (shelves, encodings, marks) and the
+dashboard's zone tree are the next ticket.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+
+from manifest import documented_field_types
+
+# --- Version targeting (CONTRACT.md §2 values) -------------------------------
+
+#: STATE.md's ``target_tableau_version`` for the newer Tableau line.
+TARGET_2026 = "2026.1+"
+
+#: Workbook ``version`` / ``original-version`` per target. 18.1 is the document format
+#: Tableau 2024.2-2025.x writes; 26.1 is 2026.1's.
+_WORKBOOK_VERSION = {TARGET_2026: "26.1"}
+_DEFAULT_WORKBOOK_VERSION = "18.1"
+
+#: Free-text provenance string; no verified 2026.1 build string exists, so both targets
+#: carry the one we have observed.
+SOURCE_BUILD = "2025.1.10 (20251.25.1121.1650)"
+
+#: The document-format feature flags, copied verbatim from a Tableau-saved workbook.
+#: Adding or removing one changes Tableau's behaviour - keep the set as-is.
+FORMAT_CHANGE_FLAGS: tuple[str, ...] = (
+    "AccessibleZoneTabOrder",
+    "AnimationOnByDefault",
+    "AutoCreateAndUpdateDSDPhoneLayouts",
+    "MarkAnimation",
+    "ObjectModelEncapsulateLegacy",
+    "ObjectModelTableType",
+    "SchemaViewerObjectModel",
+    "SetMembershipControl",
+    "SheetIdentifierTracking",
+    "WindowsPersistSimpleIdentifiers",
+    "ZoneFriendlyName",
+)
+
+#: The single dashboard this ticket emits (the zone tree from ``layout.root`` is next).
+DASHBOARD_NAME = "Dashboard 1"
+
+#: Dashboard zones live in a 100,000 x 100,000 virtual coordinate space.
+ZONE_SPACE = "100000"
+
+
+# --- Column types -------------------------------------------------------------
+
+@dataclass(frozen=True)
+class TypeFacts:
+    """What one DATA-MODEL.md type implies everywhere a column is rendered.
+
+    Attributes:
+        remote_type: The OLEDB type code in the column's metadata-record.
+        aggregation: Tableau's default aggregation for the type.
+        role: ``dimension`` / ``measure`` - derived from the type, mirroring
+            ``datamodel.suggest_role`` rather than parsing the model's Role column.
+        type_attr: The ``type`` attribute of the UI-level ``<column>``.
+        text_like: Whether the metadata-record carries the string trio
+            (``scale`` / ``width`` / ``collation``).
+    """
+
+    remote_type: int
+    aggregation: str
+    role: str
+    type_attr: str
+    text_like: bool = False
+
+
+#: DATA-MODEL.md type -> everything derived from it. 129/133/20/5 are attested in the
+#: legacy scaffold; 135 (datetime) and 11 (boolean) are the standard OLEDB codes.
+TYPE_FACTS: dict[str, TypeFacts] = {
+    "string": TypeFacts(129, "Count", "dimension", "nominal", text_like=True),
+    "integer": TypeFacts(20, "Sum", "measure", "quantitative"),
+    "real": TypeFacts(5, "Sum", "measure", "quantitative"),
+    "date": TypeFacts(133, "Year", "dimension", "ordinal"),
+    "datetime": TypeFacts(135, "Year", "dimension", "ordinal"),
+    "boolean": TypeFacts(11, "Count", "dimension", "nominal"),
+}
+
+#: A CSV column the data model does not document still has to exist in the physical schema,
+#: or Tableau reports a schema mismatch on load. String is the lossless fallback.
+FALLBACK_TYPE = "string"
+
+
+@dataclass(frozen=True)
+class Column:
+    """One physical CSV column, built once and rendered into all four locations.
+
+    Attributes:
+        name: The column name as it appears in the CSV header row.
+        ordinal: Its zero-based position in that header row.
+        datatype: The DATA-MODEL.md type (a key of :data:`TYPE_FACTS`).
+    """
+
+    name: str
+    ordinal: int
+    datatype: str
+
+    @property
+    def facts(self) -> TypeFacts:
+        """TypeFacts: Everything the datatype implies (remote-type, role, aggregation)."""
+        return TYPE_FACTS[self.datatype]
+
+    @property
+    def caption(self) -> str:
+        """str: The UI caption Tableau shows (``order_date`` -> ``Order Date``)."""
+        return self.name.replace("_", " ").title()
+
+
+# --- Deterministic ids ---------------------------------------------------------
+# ponytail: ids are hash-derived, not random - the same manifest rebuilds byte-identical,
+# which makes uniqueness testable and a re-run diff-free.
+
+def _hashed(seed: str) -> str:
+    """Return a stable 32-character hex id for ``seed``."""
+    return hashlib.sha1(seed.encode("utf-8")).hexdigest()[:32]
+
+
+def datasource_id(name: str) -> str:
+    """Return the ``federated.*`` id for a datasource name."""
+    return f"federated.{_hashed(f'ds:{name}')}"
+
+
+def connection_id(csv_name: str) -> str:
+    """Return the ``textscan.*`` named-connection id for a CSV filename."""
+    return f"textscan.{_hashed(f'conn:{csv_name}')}"
+
+
+def object_id(csv_name: str) -> str:
+    """Return the object-graph object id for a CSV filename."""
+    return f"{csv_name}_{_hashed(f'obj:{csv_name}').upper()}"
+
+
+def simple_id(kind: str, name: str) -> str:
+    """Return the braced, upper-case UUID a ``<simple-id>`` carries.
+
+    Args:
+        kind: What the id identifies (``worksheet`` / ``dashboard`` / ``window``).
+        name: The sheet or window name.
+
+    Returns:
+        A ``{XXXXXXXX-...}`` UUID, stable for the ``(kind, name)`` pair.
+    """
+    return "{" + str(uuid.uuid5(uuid.NAMESPACE_URL, f"twb:{kind}:{name}")).upper() + "}"
+
+
+# --- Datasources ---------------------------------------------------------------
+
+def _columns_for(header: list[str], field_types: dict[str, str]) -> list[Column]:
+    """Build the column list for one CSV from its header row and the data model.
+
+    Args:
+        header: The physical column order, as read from the CSV's header row.
+        field_types: ``{field name: type}`` documented for this CSV.
+
+    Returns:
+        One :class:`Column` per header entry, in physical order.
+    """
+    columns: list[Column] = []
+    for ordinal, name in enumerate(header):
+        datatype = field_types.get(name, FALLBACK_TYPE)
+        columns.append(
+            Column(name, ordinal, datatype if datatype in TYPE_FACTS else FALLBACK_TYPE)
+        )
+    return columns
+
+
+def _render_relation(parent: ET.Element, csv_name: str, columns: list[Column]) -> ET.Element:
+    """Render a live ``<relation>`` over a local CSV, with its physical ``<columns>``.
+
+    This is redundancy locations 1 and 3 (``connection > relation`` and
+    ``object-graph > object > properties > relation``), which must stay identical - hence
+    one renderer for both. The connection is always live: no ``<extract>`` is ever emitted
+    (the ``.twbx`` carries the CSVs, and the analyst does Replace Data Source anyway).
+
+    Args:
+        parent: The element to append the relation to.
+        csv_name: The CSV filename.
+        columns: The physical schema.
+
+    Returns:
+        The relation element.
+    """
+    stem = csv_name.rsplit(".", 1)[0]
+    relation = ET.SubElement(parent, "relation", {
+        "connection": connection_id(csv_name),
+        "name": csv_name,
+        "table": f"[{stem}#csv]",
+        "type": "table",
+    })
+    columns_element = ET.SubElement(relation, "columns", {
+        "character-set": "UTF-8", "header": "yes", "locale": "en_US", "separator": ",",
+    })
+    for column in columns:
+        ET.SubElement(columns_element, "column", {
+            "datatype": column.datatype, "name": column.name, "ordinal": str(column.ordinal),
+        })
+    return relation
+
+
+def _render_metadata_records(
+    parent: ET.Element, csv_name: str, columns: list[Column]
+) -> None:
+    """Render redundancy location 2: the capability record plus one record per column.
+
+    Args:
+        parent: The ``<connection class='federated'>`` element.
+        csv_name: The CSV filename (the records' ``parent-name``).
+        columns: The physical schema.
+    """
+    records = ET.SubElement(parent, "metadata-records")
+    parent_name = f"[{csv_name}]"
+
+    capability = ET.SubElement(records, "metadata-record", {"class": "capability"})
+    ET.SubElement(capability, "remote-name")
+    ET.SubElement(capability, "remote-type").text = "0"
+    ET.SubElement(capability, "parent-name").text = parent_name
+    ET.SubElement(capability, "remote-alias")
+    ET.SubElement(capability, "aggregation").text = "Count"
+    ET.SubElement(capability, "contains-null").text = "true"
+    attributes = ET.SubElement(capability, "attributes")
+    for attribute_name, value in (
+        ("character-set", "UTF-8"), ("collation", "en_US"), ("field-delimiter", ","),
+        ("header-row", "true"), ("locale", "en_US"), ("single-char", ""),
+    ):
+        ET.SubElement(
+            attributes, "attribute", {"datatype": "string", "name": attribute_name}
+        ).text = f'"{value}"'
+
+    for column in columns:
+        facts = column.facts
+        record = ET.SubElement(records, "metadata-record", {"class": "column"})
+        ET.SubElement(record, "remote-name").text = column.name
+        ET.SubElement(record, "remote-type").text = str(facts.remote_type)
+        ET.SubElement(record, "local-name").text = f"[{column.name}]"
+        ET.SubElement(record, "parent-name").text = parent_name
+        ET.SubElement(record, "remote-alias").text = column.name
+        ET.SubElement(record, "ordinal").text = str(column.ordinal)
+        ET.SubElement(record, "local-type").text = column.datatype
+        ET.SubElement(record, "aggregation").text = facts.aggregation
+        if facts.text_like:
+            ET.SubElement(record, "scale").text = "1"
+            ET.SubElement(record, "width").text = "1073741823"
+        ET.SubElement(record, "contains-null").text = "true"
+        if facts.text_like:
+            # Tableau rewrites the collation from the system locale on save; the value only
+            # has to be a valid one.
+            ET.SubElement(record, "collation", {"flag": "0", "name": "LEN_RUS"})
+        ET.SubElement(record, "object-id").text = f"[{object_id(csv_name)}]"
+
+
+def _render_datasource(
+    parent: ET.Element, name: str, csv_name: str, columns: list[Column], version: str
+) -> None:
+    """Render one inline, live-connection datasource over a single CSV.
+
+    Args:
+        parent: The ``<datasources>`` element.
+        name: The datasource name from the manifest (its caption).
+        csv_name: The CSV the datasource reads.
+        columns: The physical schema, rendered into all four required locations.
+        version: The workbook document version (the datasource carries it too).
+    """
+    datasource = ET.SubElement(parent, "datasource", {
+        "caption": name,
+        "inline": "true",
+        "name": datasource_id(name),
+        "version": version,
+    })
+
+    connection = ET.SubElement(datasource, "connection", {"class": "federated"})
+    named_connections = ET.SubElement(connection, "named-connections")
+    named_connection = ET.SubElement(named_connections, "named-connection", {
+        "caption": name, "name": connection_id(csv_name),
+    })
+    # directory='.' - the CSV sits beside the .twb inside the .twbx.
+    ET.SubElement(named_connection, "connection", {
+        "class": "textscan", "directory": ".", "filename": csv_name,
+        "password": "", "server": "",
+    })
+    _render_relation(connection, csv_name, columns)          # location 1
+    _render_metadata_records(connection, csv_name, columns)  # location 2
+
+    ET.SubElement(datasource, "aliases", {"enabled": "yes"})
+    # location 4: the UI-level columns, led by the table's internal object-id column.
+    ET.SubElement(datasource, "column", {
+        "caption": csv_name,
+        "datatype": "table",
+        "name": f"[__tableau_internal_object_id__].[{object_id(csv_name)}]",
+        "role": "measure",
+        "type": "quantitative",
+    })
+    for column in columns:
+        facts = column.facts
+        ET.SubElement(datasource, "column", {
+            "caption": column.caption,
+            "datatype": column.datatype,
+            "name": f"[{column.name}]",
+            "role": facts.role,
+            "type": facts.type_attr,
+        })
+    ET.SubElement(datasource, "layout", {
+        "dim-ordering": "alphabetic", "measure-ordering": "alphabetic",
+        "show-structure": "true",
+    })
+
+    object_graph = ET.SubElement(datasource, "object-graph")
+    objects = ET.SubElement(object_graph, "objects")
+    graph_object = ET.SubElement(objects, "object", {
+        "caption": csv_name, "id": object_id(csv_name),
+    })
+    properties = ET.SubElement(graph_object, "properties", {"context": ""})
+    _render_relation(properties, csv_name, columns)          # location 3
+
+
+# --- Worksheets, dashboard, windows --------------------------------------------
+
+def _render_worksheet(parent: ET.Element, name: str) -> None:
+    """Render a placeholder worksheet body (the shelves/marks are the next ticket).
+
+    Args:
+        parent: The ``<worksheets>`` element.
+        name: The sheet name, which its window must match exactly.
+    """
+    worksheet = ET.SubElement(parent, "worksheet", {"name": name})
+    table = ET.SubElement(worksheet, "table")
+    view = ET.SubElement(table, "view")
+    ET.SubElement(view, "datasources")
+    ET.SubElement(view, "aggregation", {"value": "true"})
+    ET.SubElement(table, "style")
+    panes = ET.SubElement(table, "panes")
+    pane = ET.SubElement(
+        panes, "pane", {"selection-relaxation-option": "selection-relaxation-allow"}
+    )
+    ET.SubElement(ET.SubElement(pane, "view"), "breakdown", {"value": "auto"})
+    ET.SubElement(pane, "mark", {"class": "Automatic"})
+    ET.SubElement(table, "rows")
+    ET.SubElement(table, "cols")
+    ET.SubElement(worksheet, "simple-id", {"uuid": simple_id("worksheet", name)})
+
+
+def _render_zone_style(parent: ET.Element, margin: str) -> None:
+    """Append the four-format ``<zone-style>`` block Tableau writes on every zone."""
+    zone_style = ET.SubElement(parent, "zone-style")
+    for attribute, value in (
+        ("border-color", "#000000"), ("border-style", "none"), ("border-width", "0"),
+        ("margin", margin),
+    ):
+        ET.SubElement(zone_style, "format", {"attr": attribute, "value": value})
+
+
+def _render_dashboard(parent: ET.Element, canvas: dict, root_zone_id: str) -> None:
+    """Render the dashboard: its size from the mock's canvas, and one root zone.
+
+    The zone *tree* (``layout.root``) is the next ticket; what this pins is the geometry
+    the mock was approved at, so the workbook opens at the right size.
+
+    Args:
+        parent: The ``<dashboards>`` element.
+        canvas: The layout's ``canvas`` object (``width`` / ``height`` in px).
+        root_zone_id: The id of the root zone (the dashboard window's ``active`` target).
+    """
+    dashboard = ET.SubElement(parent, "dashboard", {
+        "enable-sort-zone-taborder": "true", "name": DASHBOARD_NAME,
+    })
+    ET.SubElement(dashboard, "style")
+    width = str(int(canvas.get("width", 1000)))
+    height = str(int(canvas.get("height", 800)))
+    ET.SubElement(dashboard, "size", {
+        "maxheight": height, "maxwidth": width, "minheight": height, "minwidth": width,
+    })
+    zones = ET.SubElement(dashboard, "zones")
+    root_zone = ET.SubElement(zones, "zone", {
+        "h": ZONE_SPACE, "id": root_zone_id, "type-v2": "layout-basic",
+        "w": ZONE_SPACE, "x": "0", "y": "0",
+    })
+    _render_zone_style(root_zone, "8")  # zone-style is always the zone's last child
+    ET.SubElement(dashboard, "simple-id", {"uuid": simple_id("dashboard", DASHBOARD_NAME)})
+
+
+def _render_windows(
+    parent: ET.Element, worksheet_names: list[str], root_zone_id: str
+) -> None:
+    """Render one hidden window per worksheet plus the dashboard window.
+
+    Args:
+        parent: The ``<workbook>`` element.
+        worksheet_names: The sheet names, in manifest order.
+        root_zone_id: The zone the dashboard window opens on.
+    """
+    windows = ET.SubElement(parent, "windows", {"source-height": "30"})
+
+    for name in worksheet_names:
+        # hidden: these sheets only ever appear embedded in the dashboard.
+        window = ET.SubElement(
+            windows, "window", {"class": "worksheet", "hidden": "true", "name": name}
+        )
+        cards = ET.SubElement(window, "cards")
+        left = ET.SubElement(cards, "edge", {"name": "left"})
+        left_strip = ET.SubElement(left, "strip", {"size": "160"})
+        for card_type in ("pages", "filters", "marks"):
+            ET.SubElement(left_strip, "card", {"type": card_type})
+        top = ET.SubElement(cards, "edge", {"name": "top"})
+        for card_type, size in (("columns", "2147483647"), ("rows", "2147483647"),
+                                ("title", "31")):
+            ET.SubElement(
+                ET.SubElement(top, "strip", {"size": size}), "card", {"type": card_type}
+            )
+        ET.SubElement(window, "simple-id", {"uuid": simple_id("window", name)})
+
+    dashboard_window = ET.SubElement(windows, "window", {
+        "class": "dashboard", "maximized": "true", "name": DASHBOARD_NAME,
+    })
+    viewpoints = ET.SubElement(dashboard_window, "viewpoints")
+    for name in worksheet_names:
+        # Never a self-closing viewpoint: without entire-view zoom the sheet does not fill
+        # its allocated space.
+        ET.SubElement(
+            ET.SubElement(viewpoints, "viewpoint", {"name": name}),
+            "zoom", {"type": "entire-view"},
+        )
+    ET.SubElement(dashboard_window, "active", {"id": root_zone_id})
+    ET.SubElement(
+        dashboard_window, "simple-id", {"uuid": simple_id("window", DASHBOARD_NAME)}
+    )
+
+
+# --- The workbook --------------------------------------------------------------
+
+def workbook_version(target_tableau_version: str) -> str:
+    """Return the document-format version for a STATE.md target (CONTRACT.md §2).
+
+    Args:
+        target_tableau_version: ``2024.2-2025.x`` or ``2026.1+``.
+
+    Returns:
+        ``"26.1"`` for the 2026.1+ target, ``"18.1"`` otherwise.
+    """
+    return _WORKBOOK_VERSION.get(
+        target_tableau_version.strip(), _DEFAULT_WORKBOOK_VERSION
+    )
+
+
+def render_workbook(
+    manifest_document: dict,
+    data_model_text: str,
+    csv_headers: dict[str, list[str]],
+) -> str:
+    """Assemble a validated build manifest into ``.twb`` XML.
+
+    Children of ``<workbook>`` are emitted in the order the 2026.1 XSD's ``WorkbookFile-CT``
+    prescribes. Two elements are *omitted rather than emitted empty*, because the schema
+    requires at least one child of each: ``<worksheets>`` when the manifest declares none,
+    and ``<thumbnails>`` always (Tableau regenerates thumbnails on save).
+
+    Args:
+        manifest_document: The parsed, validated ``build-manifest.json``.
+        data_model_text: The contents of ``DATA-MODEL.md`` (the type authority).
+        csv_headers: ``{csv filename: header row}`` - the physical schema and its order.
+
+    Returns:
+        The workbook XML, ready to write as ``dashboard.twb``.
+    """
+    target = str(manifest_document.get("target_tableau_version", "")).strip()
+    version = workbook_version(target)
+
+    workbook = ET.Element("workbook", {
+        "original-version": version,
+        "source-build": SOURCE_BUILD,
+        "source-platform": "win",
+        "version": version,
+        "xmlns:user": "http://www.tableausoftware.com/xml/user",
+    })
+
+    format_manifest = ET.SubElement(workbook, "document-format-change-manifest")
+    for flag in FORMAT_CHANGE_FLAGS:
+        ET.SubElement(format_manifest, flag)
+
+    field_types = documented_field_types(data_model_text)
+    datasources = ET.SubElement(workbook, "datasources")
+    for entry in manifest_document.get("datasources", []):
+        csv_name = str(entry.get("csv", "")).strip()
+        _render_datasource(
+            datasources,
+            str(entry.get("name", "")).strip(),
+            csv_name,
+            _columns_for(csv_headers.get(csv_name, []), field_types.get(csv_name, {})),
+            version,
+        )
+
+    worksheet_names = [
+        str(worksheet.get("name", "")).strip()
+        for worksheet in manifest_document.get("worksheets", [])
+    ]
+    if worksheet_names:  # the XSD requires >=1 <worksheet>; omit the element otherwise
+        worksheets = ET.SubElement(workbook, "worksheets")
+        for name in worksheet_names:
+            _render_worksheet(worksheets, name)
+
+    layout = manifest_document.get("layout")
+    canvas = layout.get("canvas", {}) if isinstance(layout, dict) else {}
+    root_zone_id = "1"  # zone ids are sequential from 1; the tree is the next ticket
+    _render_dashboard(ET.SubElement(workbook, "dashboards"), canvas, root_zone_id)
+    _render_windows(workbook, worksheet_names, root_zone_id)
+
+    if target == TARGET_2026:
+        explain_data = ET.SubElement(workbook, "explain-data", {
+            "enabled-for-viewer": "false", "extreme-values-enabled-for-all": "false",
+        })
+        ET.SubElement(explain_data, "explanation-types")
+
+    ET.indent(workbook, space="  ")
+    return (
+        "<?xml version='1.0' encoding='utf-8' ?>\n\n"
+        + ET.tostring(workbook, encoding="unicode")
+        + "\n"
+    )

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -70,6 +70,17 @@ DASHBOARD_NAME = "Dashboard 1"
 #: Dashboard zones live in a 100,000 x 100,000 virtual coordinate space.
 ZONE_SPACE = "100000"
 
+#: The root zone's id. Zone ids are sequential integers from 1; with a single zone there is
+#: nothing to count yet.
+ROOT_ZONE_ID = "1"
+
+#: Margin (in the zone coordinate space) on the root zone, as Tableau writes it.
+ROOT_ZONE_MARGIN = "8"
+
+#: Dashboard size when the layout carries no canvas. ``manifest.validate_manifest`` requires
+#: numeric ``canvas.width``/``height``, so this only guards a direct call to the assembler.
+DEFAULT_CANVAS = {"width": 1000, "height": 800}
+
 
 # --- Column types -------------------------------------------------------------
 
@@ -149,14 +160,19 @@ def datasource_id(name: str) -> str:
     return f"federated.{_hashed(f'ds:{name}')}"
 
 
-def connection_id(csv_name: str) -> str:
-    """Return the ``textscan.*`` named-connection id for a CSV filename."""
-    return f"textscan.{_hashed(f'conn:{csv_name}')}"
+def connection_id(datasource_name: str, csv_name: str) -> str:
+    """Return the ``textscan.*`` named-connection id for one datasource's CSV.
+
+    The datasource name is part of the seed, not just the CSV: two datasources may read the
+    same CSV, and ids must stay unique across the whole workbook.
+    """
+    return f"textscan.{_hashed(f'conn:{datasource_name}:{csv_name}')}"
 
 
-def object_id(csv_name: str) -> str:
-    """Return the object-graph object id for a CSV filename."""
-    return f"{csv_name}_{_hashed(f'obj:{csv_name}').upper()}"
+def object_id(datasource_name: str, csv_name: str) -> str:
+    """Return the object-graph object id for one datasource's CSV (see
+    :func:`connection_id` on why the datasource name is in the seed)."""
+    return f"{csv_name}_{_hashed(f'obj:{datasource_name}:{csv_name}').upper()}"
 
 
 def simple_id(kind: str, name: str) -> str:
@@ -193,7 +209,9 @@ def _columns_for(header: list[str], field_types: dict[str, str]) -> list[Column]
     return columns
 
 
-def _render_relation(parent: ET.Element, csv_name: str, columns: list[Column]) -> ET.Element:
+def _render_relation(
+    parent: ET.Element, datasource_name: str, csv_name: str, columns: list[Column]
+) -> ET.Element:
     """Render a live ``<relation>`` over a local CSV, with its physical ``<columns>``.
 
     This is redundancy locations 1 and 3 (``connection > relation`` and
@@ -203,6 +221,7 @@ def _render_relation(parent: ET.Element, csv_name: str, columns: list[Column]) -
 
     Args:
         parent: The element to append the relation to.
+        datasource_name: The owning datasource (part of the connection id's seed).
         csv_name: The CSV filename.
         columns: The physical schema.
 
@@ -211,7 +230,7 @@ def _render_relation(parent: ET.Element, csv_name: str, columns: list[Column]) -
     """
     stem = csv_name.rsplit(".", 1)[0]
     relation = ET.SubElement(parent, "relation", {
-        "connection": connection_id(csv_name),
+        "connection": connection_id(datasource_name, csv_name),
         "name": csv_name,
         "table": f"[{stem}#csv]",
         "type": "table",
@@ -227,12 +246,13 @@ def _render_relation(parent: ET.Element, csv_name: str, columns: list[Column]) -
 
 
 def _render_metadata_records(
-    parent: ET.Element, csv_name: str, columns: list[Column]
+    parent: ET.Element, datasource_name: str, csv_name: str, columns: list[Column]
 ) -> None:
     """Render redundancy location 2: the capability record plus one record per column.
 
     Args:
         parent: The ``<connection class='federated'>`` element.
+        datasource_name: The owning datasource (part of the object id's seed).
         csv_name: The CSV filename (the records' ``parent-name``).
         columns: The physical schema.
     """
@@ -274,7 +294,9 @@ def _render_metadata_records(
             # Tableau rewrites the collation from the system locale on save; the value only
             # has to be a valid one.
             ET.SubElement(record, "collation", {"flag": "0", "name": "LEN_RUS"})
-        ET.SubElement(record, "object-id").text = f"[{object_id(csv_name)}]"
+        ET.SubElement(record, "object-id").text = (
+            f"[{object_id(datasource_name, csv_name)}]"
+        )
 
 
 def _render_datasource(
@@ -299,22 +321,22 @@ def _render_datasource(
     connection = ET.SubElement(datasource, "connection", {"class": "federated"})
     named_connections = ET.SubElement(connection, "named-connections")
     named_connection = ET.SubElement(named_connections, "named-connection", {
-        "caption": name, "name": connection_id(csv_name),
+        "caption": name, "name": connection_id(name, csv_name),
     })
     # directory='.' - the CSV sits beside the .twb inside the .twbx.
     ET.SubElement(named_connection, "connection", {
         "class": "textscan", "directory": ".", "filename": csv_name,
         "password": "", "server": "",
     })
-    _render_relation(connection, csv_name, columns)          # location 1
-    _render_metadata_records(connection, csv_name, columns)  # location 2
+    _render_relation(connection, name, csv_name, columns)          # location 1
+    _render_metadata_records(connection, name, csv_name, columns)  # location 2
 
     ET.SubElement(datasource, "aliases", {"enabled": "yes"})
     # location 4: the UI-level columns, led by the table's internal object-id column.
     ET.SubElement(datasource, "column", {
         "caption": csv_name,
         "datatype": "table",
-        "name": f"[__tableau_internal_object_id__].[{object_id(csv_name)}]",
+        "name": f"[__tableau_internal_object_id__].[{object_id(name, csv_name)}]",
         "role": "measure",
         "type": "quantitative",
     })
@@ -335,10 +357,10 @@ def _render_datasource(
     object_graph = ET.SubElement(datasource, "object-graph")
     objects = ET.SubElement(object_graph, "objects")
     graph_object = ET.SubElement(objects, "object", {
-        "caption": csv_name, "id": object_id(csv_name),
+        "caption": csv_name, "id": object_id(name, csv_name),
     })
     properties = ET.SubElement(graph_object, "properties", {"context": ""})
-    _render_relation(properties, csv_name, columns)          # location 3
+    _render_relation(properties, name, csv_name, columns)          # location 3
 
 
 # --- Worksheets, dashboard, windows --------------------------------------------
@@ -350,6 +372,8 @@ def _render_worksheet(parent: ET.Element, name: str) -> None:
         parent: The ``<worksheets>`` element.
         name: The sheet name, which its window must match exactly.
     """
+    # TODO(next ticket): fill the body from the manifest - datasource-dependencies, the
+    # column-instances, the mark class, and the rows/cols shelf text.
     worksheet = ET.SubElement(parent, "worksheet", {"name": name})
     table = ET.SubElement(worksheet, "table")
     view = ET.SubElement(table, "view")
@@ -392,8 +416,8 @@ def _render_dashboard(parent: ET.Element, canvas: dict, root_zone_id: str) -> No
         "enable-sort-zone-taborder": "true", "name": DASHBOARD_NAME,
     })
     ET.SubElement(dashboard, "style")
-    width = str(int(canvas.get("width", 1000)))
-    height = str(int(canvas.get("height", 800)))
+    width = str(int(canvas.get("width", DEFAULT_CANVAS["width"])))
+    height = str(int(canvas.get("height", DEFAULT_CANVAS["height"])))
     ET.SubElement(dashboard, "size", {
         "maxheight": height, "maxwidth": width, "minheight": height, "minwidth": width,
     })
@@ -402,7 +426,9 @@ def _render_dashboard(parent: ET.Element, canvas: dict, root_zone_id: str) -> No
         "h": ZONE_SPACE, "id": root_zone_id, "type-v2": "layout-basic",
         "w": ZONE_SPACE, "x": "0", "y": "0",
     })
-    _render_zone_style(root_zone, "8")  # zone-style is always the zone's last child
+    # TODO(next ticket): nest the manifest's layout.root tree inside this zone, one child
+    # zone per element id, with each worksheet zone naming its sheet.
+    _render_zone_style(root_zone, ROOT_ZONE_MARGIN)  # zone-style is the zone's last child
     ET.SubElement(dashboard, "simple-id", {"uuid": simple_id("dashboard", DASHBOARD_NAME)})
 
 
@@ -527,9 +553,8 @@ def render_workbook(
 
     layout = manifest_document.get("layout")
     canvas = layout.get("canvas", {}) if isinstance(layout, dict) else {}
-    root_zone_id = "1"  # zone ids are sequential from 1; the tree is the next ticket
-    _render_dashboard(ET.SubElement(workbook, "dashboards"), canvas, root_zone_id)
-    _render_windows(workbook, worksheet_names, root_zone_id)
+    _render_dashboard(ET.SubElement(workbook, "dashboards"), canvas, ROOT_ZONE_ID)
+    _render_windows(workbook, worksheet_names, ROOT_ZONE_ID)
 
     if target == TARGET_2026:
         explain_data = ET.SubElement(workbook, "explain-data", {

--- a/skills/tableau-build/scripts/validate_twb.py
+++ b/skills/tableau-build/scripts/validate_twb.py
@@ -1,0 +1,634 @@
+"""
+TWB XML Validator — Breakage-Only Checks (v1).
+
+Validates Tableau workbook (.twb) XML files for structural errors that would
+cause Tableau Desktop to fail, render blank, or produce incorrect output.
+Style preferences (hex case, attribute order, comments) are NOT checked —
+Tableau normalizes those on save.
+
+Usage:
+    python validate_twb.py <path_to_twb_file>
+    python validate_twb.py <path_to_twb_file> --verbose
+
+Exit codes:
+    0 — all checks passed
+    1 — one or more checks failed
+    2 — file could not be parsed (fatal)
+"""
+
+import argparse
+import logging
+import re
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+# ── Logging setup ────────────────────────────────────────────────────────────
+# Configured in main() only: build.py imports this module, and a library that calls
+# basicConfig at import time reconfigures its caller's logging as a side effect.
+
+logger = logging.getLogger(__name__)
+
+
+# ── Data classes ─────────────────────────────────────────────────────────────
+
+@dataclass
+class CheckResult:
+    """Result of a single validation check."""
+
+    name: str
+    passed: bool
+    details: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ValidationReport:
+    """Aggregated report of all validation checks."""
+
+    file_path: str
+    results: List[CheckResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        """True if every check passed."""
+        return all(r.passed for r in self.results)
+
+    @property
+    def failed_count(self) -> int:
+        """Number of failed checks."""
+        return sum(1 for r in self.results if not r.passed)
+
+    @property
+    def passed_count(self) -> int:
+        """Number of passed checks."""
+        return sum(1 for r in self.results if r.passed)
+
+
+# ── Validator class ──────────────────────────────────────────────────────────
+
+class TwbValidator:
+    """Validates a .twb XML file for structural breakage issues.
+
+    Checks performed (v1 — breakage only):
+        1. Well-formed XML
+        2. Datasource existence (worksheet refs → top-level datasources)
+        3. Column reference integrity (column-instance → column)
+        4. Shelf reference integrity (rows/cols → datasource-dependencies)
+        5. CDATA for field references in <run> elements
+        6. Dashboard datasource declarations (when filter cards exist)
+        7. Filter/slices consistency
+        8. Worksheet name ↔ window name match
+    """
+
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+        self.raw_content: str = ""
+        self.tree: Optional[ET.ElementTree] = None
+        self.root: Optional[ET.Element] = None
+        self.report = ValidationReport(file_path=file_path)
+
+    def validate(self) -> ValidationReport:
+        """Run all validation checks and return the report.
+
+        Returns:
+            ValidationReport with results of all checks.
+        """
+        # Check 1: Well-formed XML (must pass before other checks)
+        if not self._check_well_formed_xml():
+            return self.report
+
+        # Remaining checks require a parsed tree
+        self._check_datasource_existence()
+        self._check_column_reference_integrity()
+        self._check_shelf_reference_integrity()
+        self._check_cdata_field_references()
+        self._check_dashboard_datasource_declarations()
+        self._check_filter_slices_consistency()
+        self._check_worksheet_window_match()
+
+        return self.report
+
+    # ── Check 1: Well-formed XML ─────────────────────────────────────────
+
+    def _check_well_formed_xml(self) -> bool:
+        """Parse the TWB file as XML. If parsing fails, nothing else can run.
+
+        Returns:
+            True if parsing succeeded.
+        """
+        check_name = "Well-formed XML"
+        try:
+            self.raw_content = Path(self.file_path).read_text(encoding="utf-8")
+            self.tree = ET.parse(self.file_path)
+            self.root = self.tree.getroot()
+            self.report.results.append(CheckResult(name=check_name, passed=True))
+            return True
+        except ET.ParseError as e:
+            self.report.results.append(CheckResult(
+                name=check_name,
+                passed=False,
+                details=[f"XML parse error: {e}"],
+            ))
+            return False
+        except Exception as e:
+            self.report.results.append(CheckResult(
+                name=check_name,
+                passed=False,
+                details=[f"File read error: {e}"],
+            ))
+            return False
+
+    # ── Check 2: Datasource existence ────────────────────────────────────
+
+    def _check_datasource_existence(self) -> None:
+        """Verify that every datasource referenced in worksheets exists
+        in the top-level <datasources> block.
+        """
+        check_name = "Datasource existence"
+        errors: List[str] = []
+
+        # Collect top-level datasource names (direct children of <workbook>)
+        top_level_ds_names: Set[str] = set()
+        top_ds_block = self.root.find("datasources")
+        if top_ds_block is not None:
+            for ds in top_ds_block.findall("datasource"):
+                ds_name = ds.get("name", "")
+                if ds_name:
+                    top_level_ds_names.add(ds_name)
+
+        # Check each worksheet's view > datasources references
+        for ws in self.root.findall(".//worksheets/worksheet"):
+            ws_name = ws.get("name", "<unnamed>")
+            for ds_ref in ws.findall(".//view/datasources/datasource"):
+                ref_name = ds_ref.get("name", "")
+                if ref_name and ref_name not in top_level_ds_names:
+                    errors.append(
+                        f"Worksheet '{ws_name}' references datasource "
+                        f"'{ref_name}' which does not exist in top-level "
+                        f"<datasources>"
+                    )
+
+        self.report.results.append(CheckResult(
+            name=check_name,
+            passed=len(errors) == 0,
+            details=errors,
+        ))
+
+    # ── Check 3: Column reference integrity ──────────────────────────────
+
+    def _check_column_reference_integrity(self) -> None:
+        """Verify that every column-instance's 'column' attribute resolves
+        to a declared <column> in the same datasource-dependencies block
+        or in the parent datasource.
+        """
+        check_name = "Column reference integrity"
+        errors: List[str] = []
+
+        # Build a map of columns declared at the top-level datasource
+        ds_columns: Dict[str, Set[str]] = {}
+        for ds in self.root.findall(".//datasources/datasource"):
+            ds_name = ds.get("name", "")
+            columns: Set[str] = set()
+            for col in ds.findall("column"):
+                col_name = col.get("name", "")
+                if col_name:
+                    columns.add(col_name)
+            ds_columns[ds_name] = columns
+
+        # Check each worksheet's datasource-dependencies
+        for ws in self.root.findall(".//worksheets/worksheet"):
+            ws_name = ws.get("name", "<unnamed>")
+            for dep in ws.findall(".//datasource-dependencies"):
+                dep_ds = dep.get("datasource", "")
+
+                # Columns declared in this dependencies block
+                local_columns: Set[str] = set()
+                for col in dep.findall("column"):
+                    col_name = col.get("name", "")
+                    if col_name:
+                        local_columns.add(col_name)
+
+                # Combined: local + top-level datasource columns
+                all_columns = local_columns | ds_columns.get(dep_ds, set())
+
+                # Check each column-instance
+                for ci in dep.findall("column-instance"):
+                    ci_column = ci.get("column", "")
+                    if not ci_column:
+                        continue
+
+                    # Skip built-in Tableau fields
+                    if self._is_builtin_field(ci_column):
+                        continue
+
+                    if ci_column not in all_columns:
+                        ci_name = ci.get("name", ci_column)
+                        errors.append(
+                            f"Worksheet '{ws_name}': column-instance "
+                            f"'{ci_name}' references column '{ci_column}' "
+                            f"which is not declared in datasource-dependencies "
+                            f"or datasource '{dep_ds}'"
+                        )
+
+        self.report.results.append(CheckResult(
+            name=check_name,
+            passed=len(errors) == 0,
+            details=errors,
+        ))
+
+    # ── Check 4: Shelf reference integrity ───────────────────────────────
+
+    def _check_shelf_reference_integrity(self) -> None:
+        """Verify that all field references in <rows> and <cols> match
+        column-instances declared in the worksheet's datasource-dependencies.
+        """
+        check_name = "Shelf reference integrity"
+        errors: List[str] = []
+
+        # Pattern to extract [datasource].[column-instance] refs from shelf text
+        # Matches: [datasource.name].[instance:name:suffix]
+        shelf_ref_pattern = re.compile(
+            r"\[([^\]]+)\]\.\[([^\]]+)\]"
+        )
+
+        for ws in self.root.findall(".//worksheets/worksheet"):
+            ws_name = ws.get("name", "<unnamed>")
+
+            # Collect all column-instance names per datasource in this worksheet
+            ds_instances: Dict[str, Set[str]] = {}
+            for dep in ws.findall(".//datasource-dependencies"):
+                dep_ds = dep.get("datasource", "")
+                instances: Set[str] = set()
+                for ci in dep.findall("column-instance"):
+                    ci_name = ci.get("name", "")
+                    if ci_name:
+                        instances.add(ci_name)
+                ds_instances[dep_ds] = instances
+
+            # Check <rows> and <cols>
+            table = ws.find("table")
+            if table is None:
+                continue
+
+            for shelf_tag in ("rows", "cols"):
+                shelf_el = table.find(shelf_tag)
+                if shelf_el is None:
+                    continue
+
+                shelf_text = shelf_el.text
+                if not shelf_text or not shelf_text.strip():
+                    continue  # Empty shelf (<rows /> or <cols />) is valid
+
+                refs = shelf_ref_pattern.findall(shelf_text)
+                for ds_name, instance_name in refs:
+                    # Skip Tableau built-in generated fields
+                    if self._is_builtin_field_name(instance_name):
+                        continue
+
+                    # Skip Measure Names / Measure Values
+                    if "Measure Names" in instance_name or "Measure Values" in instance_name:
+                        continue
+
+                    known_instances = ds_instances.get(ds_name, set())
+                    # Column-instance names in XML include brackets:
+                    # e.g., [sum:profit:qk], but shelf text strips them
+                    bracketed_name = f"[{instance_name}]"
+                    if (instance_name not in known_instances
+                            and bracketed_name not in known_instances):
+                        errors.append(
+                            f"Worksheet '{ws_name}', <{shelf_tag}>: "
+                            f"references '{ds_name}.{instance_name}' but "
+                            f"'{instance_name}' is not declared as a "
+                            f"column-instance in datasource-dependencies"
+                        )
+
+        self.report.results.append(CheckResult(
+            name=check_name,
+            passed=len(errors) == 0,
+            details=errors,
+        ))
+
+    # ── Check 5: CDATA for field references in <run> elements ────────────
+
+    def _check_cdata_field_references(self) -> None:
+        """Detect <run> elements that use entity-encoded field references
+        (&lt;[...]&gt;) instead of CDATA wrapping. Entity-encoded refs
+        cause Tableau to display literal text instead of the field value.
+        """
+        check_name = "CDATA for field references"
+        errors: List[str] = []
+
+        # Entity-encoded field reference pattern: &lt;[datasource].[field]&gt;
+        entity_pattern = re.compile(r"&lt;\[.*?\]\.\[.*?\]&gt;")
+
+        # Search raw content since ET strips CDATA/entities
+        # Find all <run ...>content</run> segments
+        run_pattern = re.compile(
+            r"<run\b[^>]*>(.*?)</run>",
+            re.DOTALL,
+        )
+
+        for i, line in enumerate(self.raw_content.splitlines(), start=1):
+            # Check for entity-encoded field refs in <run> elements on this line
+            for match in run_pattern.finditer(line):
+                run_content = match.group(1)
+                if entity_pattern.search(run_content):
+                    # Extract a short preview
+                    preview = run_content[:80].strip()
+                    errors.append(
+                        f"Line {i}: <run> element uses entity-encoded field "
+                        f"reference instead of CDATA: '{preview}...'"
+                    )
+
+        self.report.results.append(CheckResult(
+            name=check_name,
+            passed=len(errors) == 0,
+            details=errors,
+        ))
+
+    # ── Check 6: Dashboard datasource declarations ───────────────────────
+
+    def _check_dashboard_datasource_declarations(self) -> None:
+        """When a dashboard contains filter card zones, the <dashboard>
+        element must have its own <datasources> block. Missing this causes
+        filter cards to crash.
+        """
+        check_name = "Dashboard datasource declarations"
+        errors: List[str] = []
+
+        for dashboard in self.root.findall(".//dashboards/dashboard"):
+            db_name = dashboard.get("name", "<unnamed>")
+
+            # Look for filter card zones: zones with type='filter' attribute
+            # or cards with type='filter' in the dashboard zones
+            has_filter_zone = False
+
+            # Method 1: quick filter zones in layout
+            for zone in dashboard.iter("zone"):
+                zone_type = zone.get("type", "")
+                if zone_type == "filter":
+                    has_filter_zone = True
+                    break
+                # Also check for 'mode' attribute which indicates a quick filter
+                if zone.get("mode") in ("checkdropdown", "typeinlist",
+                                         "checkdropdownsingle", "slider"):
+                    has_filter_zone = True
+                    break
+
+            if not has_filter_zone:
+                continue
+
+            # Dashboard has filter zones — check for <datasources>
+            db_datasources = dashboard.find("datasources")
+            if db_datasources is None:
+                errors.append(
+                    f"Dashboard '{db_name}' has filter card zones but no "
+                    f"<datasources> block inside the <dashboard> element. "
+                    f"Filter cards require dashboard-level datasource "
+                    f"declarations."
+                )
+
+        self.report.results.append(CheckResult(
+            name=check_name,
+            passed=len(errors) == 0,
+            details=errors,
+        ))
+
+    # ── Check 7: Filter/slices consistency ───────────────────────────────
+
+    def _check_filter_slices_consistency(self) -> None:
+        """Every field with a <filter> element must also appear in <slices>.
+        Missing slices entries cause filters to be silently ignored.
+        """
+        check_name = "Filter/slices consistency"
+        errors: List[str] = []
+
+        for ws in self.root.findall(".//worksheets/worksheet"):
+            ws_name = ws.get("name", "<unnamed>")
+            view = ws.find(".//view")
+            if view is None:
+                continue
+
+            # Collect filter columns
+            filter_columns: Set[str] = set()
+            for filt in view.findall("filter"):
+                col = filt.get("column", "")
+                if col:
+                    filter_columns.add(col)
+
+            if not filter_columns:
+                continue
+
+            # Collect slices columns
+            slices_columns: Set[str] = set()
+            slices = view.find("slices")
+            if slices is not None:
+                for col_el in slices.findall("column"):
+                    if col_el.text:
+                        slices_columns.add(col_el.text.strip())
+
+            # Check: every filter column should be in slices
+            # Note: action filters (containing "Action" in the column name)
+            # are handled specially by Tableau and DO appear in slices,
+            # so we check them too
+            for fc in filter_columns:
+                if fc not in slices_columns:
+                    # Skip quantitative filters on date ranges — these
+                    # sometimes legitimately lack slices entries in some
+                    # Tableau versions, but it's still best practice
+                    errors.append(
+                        f"Worksheet '{ws_name}': filter on '{fc}' has no "
+                        f"matching entry in <slices>"
+                    )
+
+        self.report.results.append(CheckResult(
+            name=check_name,
+            passed=len(errors) == 0,
+            details=errors,
+        ))
+
+    # ── Check 8: Worksheet name ↔ window name match ─────────────────────
+
+    def _check_worksheet_window_match(self) -> None:
+        """Every <worksheet name='X'> must have a corresponding
+        <window name='X'> in <windows>. Mismatches cause sheets not
+        to display.
+        """
+        check_name = "Worksheet-window name match"
+        errors: List[str] = []
+
+        # Collect worksheet names
+        worksheet_names: Set[str] = set()
+        for ws in self.root.findall(".//worksheets/worksheet"):
+            name = ws.get("name", "")
+            if name:
+                worksheet_names.add(name)
+
+        # Collect window names (only worksheet-class windows)
+        window_names: Set[str] = set()
+        for win in self.root.findall(".//windows/window"):
+            win_class = win.get("class", "")
+            name = win.get("name", "")
+            if name and win_class == "worksheet":
+                window_names.add(name)
+
+        # Also collect dashboard window names (they don't need worksheet match)
+        dashboard_names: Set[str] = set()
+        for db in self.root.findall(".//dashboards/dashboard"):
+            name = db.get("name", "")
+            if name:
+                dashboard_names.add(name)
+
+        # Check: every worksheet should have a window
+        for ws_name in worksheet_names:
+            if ws_name not in window_names:
+                errors.append(
+                    f"Worksheet '{ws_name}' has no matching "
+                    f"<window name='{ws_name}'> in <windows>"
+                )
+
+        # Check reverse: every worksheet-class window should have a worksheet
+        for win_name in window_names:
+            if win_name not in worksheet_names:
+                errors.append(
+                    f"Window '{win_name}' (class='worksheet') has no "
+                    f"matching <worksheet name='{win_name}'>"
+                )
+
+        self.report.results.append(CheckResult(
+            name=check_name,
+            passed=len(errors) == 0,
+            details=errors,
+        ))
+
+    # ── Helpers ──────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _is_builtin_field(column_ref: str) -> bool:
+        """Check if a column reference is a Tableau built-in field.
+
+        Args:
+            column_ref: The column name from a column-instance's column attr.
+
+        Returns:
+            True if this is a built-in field.
+        """
+        builtins = {
+            "[Number of Records]",
+            "[Measure Names]",
+            "[Measure Values]",
+            "[:Measure Names]",
+            "[:Measure Values]",
+        }
+        return column_ref in builtins
+
+    @staticmethod
+    def _is_builtin_field_name(instance_name: str) -> bool:
+        """Check if a column-instance name refers to a built-in/generated field.
+
+        Args:
+            instance_name: The instance name from shelf text.
+
+        Returns:
+            True if this is a built-in or generated field name.
+        """
+        # Tableau-generated geographic fields
+        if "(generated)" in instance_name:
+            return True
+        # Measure Names / Values
+        if "Measure Names" in instance_name or "Measure Values" in instance_name:
+            return True
+        return False
+
+
+# ── Report printing ──────────────────────────────────────────────────────────
+
+def print_report(report: ValidationReport, verbose: bool = False) -> None:
+    """Print a formatted validation report.
+
+    Args:
+        report: The validation report to print.
+        verbose: If True, print details for passed checks too.
+    """
+    logger.info("=" * 60)
+    logger.info("TWB Validation Report")
+    logger.info("=" * 60)
+    logger.info("File: %s", report.file_path)
+    logger.info("")
+
+    for result in report.results:
+        status = "PASS" if result.passed else "FAIL"
+        icon = "[+]" if result.passed else "[X]"
+        logger.info("%s %s: %s", icon, result.name, status)
+
+        if result.details and (not result.passed or verbose):
+            for detail in result.details:
+                logger.info("    - %s", detail)
+
+    logger.info("")
+    logger.info("-" * 60)
+    total = len(report.results)
+    logger.info(
+        "Result: %d/%d checks passed, %d failed",
+        report.passed_count, total, report.failed_count,
+    )
+
+    if report.passed:
+        logger.info("Status: ALL CHECKS PASSED")
+    else:
+        logger.info("Status: VALIDATION FAILED")
+    logger.info("=" * 60)
+
+
+# ── CLI entry point ──────────────────────────────────────────────────────────
+
+def main() -> None:
+    """CLI entry point for the TWB validator.
+
+    Parses arguments, runs validation, prints report, and exits
+    with appropriate code.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    parser = argparse.ArgumentParser(
+        description="Validate a Tableau .twb file for structural errors.",
+    )
+    parser.add_argument(
+        "twb_file",
+        help="Path to the .twb file to validate",
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Show details for passed checks too",
+    )
+    args = parser.parse_args()
+
+    # Validate file exists
+    twb_path = Path(args.twb_file)
+    if not twb_path.exists():
+        logger.error("File not found: %s", args.twb_file)
+        sys.exit(2)
+
+    if not twb_path.suffix.lower() == ".twb":
+        logger.warning("File does not have .twb extension: %s", args.twb_file)
+
+    # Run validation
+    validator = TwbValidator(str(twb_path))
+    report = validator.validate()
+
+    # Print report
+    print_report(report, verbose=args.verbose)
+
+    # Exit code
+    if not report.results:
+        sys.exit(2)  # No checks ran (fatal parse error)
+    elif report.passed:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tableau-build/scripts/validate_twb_xsd.py
+++ b/skills/tableau-build/scripts/validate_twb_xsd.py
@@ -1,0 +1,169 @@
+"""TWB XSD Validator — Structural Checks Against Official Tableau Schema.
+
+Validates a Tableau workbook (.twb) file against the official 2026.1 XSD
+published by Tableau (`tableau/tableau-document-schemas` on GitHub).
+
+This is complementary to `validate_twb.py`:
+    - `validate_twb.py` checks cross-section semantic integrity (datasource
+      references, column-instance refs, filter-slices consistency) — the
+      content the XSD marks as `processContents="skip"`.
+    - This script checks everything outside those skip-zones: element
+      nesting, required attributes, attribute value enums, child ordering.
+
+The XSD targets Tableau 2026.1. When validating a workbook authored for an
+older Tableau version (e.g., 2025.x), expect a small set of known
+"version-shifted" errors that are safe to ignore - chiefly the missing
+`<explain-data>` element, which only exists from 2026.1 on. `build.py build`
+tolerates exactly that one and treats every other schema error as fatal.
+
+Usage:
+    python validate_twb_xsd.py <path_to_twb_file>
+
+Exit codes:
+    0 — XSD validation passed (with no errors)
+    1 — XSD validation failed (one or more errors)
+    2 — file could not be parsed or schema could not be loaded (fatal)
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+try:
+    from lxml import etree
+except ImportError:
+    print("ERROR: lxml is required. Install with: pip install lxml",
+          file=sys.stderr)
+    sys.exit(2)
+
+# Logging setup: configured in main() only - build.py imports this module, and a library
+# that calls basicConfig at import time reconfigures its caller's logging as a side effect.
+logger = logging.getLogger(__name__)
+
+# Schema location — sibling `references/xsd/` directory.
+# Script lives at: <skill-root>/scripts/validate_twb_xsd.py
+# XSD lives at:    <skill-root>/references/xsd/twb_2026.1.0.xsd
+SCRIPT_DIR = Path(__file__).resolve().parent
+XSD_PATH = SCRIPT_DIR.parent / "references" / "xsd" / "twb_2026.1.0.xsd"
+
+
+def load_schema(xsd_path: Path) -> etree.XMLSchema:
+    """Parse and compile the XSD into a usable schema validator.
+
+    Args:
+        xsd_path: Path to the root XSD file. The XSD imports `user.xsd`
+            and `xml.xsd` from the same directory.
+
+    Returns:
+        Compiled XMLSchema validator.
+
+    Raises:
+        FileNotFoundError: If the XSD file does not exist.
+        etree.XMLSchemaParseError: If the XSD itself is malformed or has
+            unresolved imports.
+    """
+    if not xsd_path.exists():
+        raise FileNotFoundError(f"XSD not found at expected path: {xsd_path}")
+    schema_doc = etree.parse(str(xsd_path))
+    return etree.XMLSchema(schema_doc)
+
+
+def validate(twb_path: Path, schema: etree.XMLSchema) -> tuple[bool, list]:
+    """Run the schema against a TWB file.
+
+    Args:
+        twb_path: Path to the .twb file to validate.
+        schema: Compiled XMLSchema validator from `load_schema`.
+
+    Returns:
+        Tuple of (passed, errors). `errors` is a list of
+        lxml `_LogEntry` objects; empty when `passed` is True.
+    """
+    doc = etree.parse(str(twb_path))
+    passed = schema.validate(doc)
+    return passed, list(schema.error_log)
+
+
+def print_report(twb_path: Path, passed: bool, errors: list) -> None:
+    """Print a human-readable validation report.
+
+    Args:
+        twb_path: Path of the file that was validated (for display).
+        passed: True if validation succeeded.
+        errors: List of lxml `_LogEntry` validation errors (may be empty).
+    """
+    logger.info("=" * 60)
+    logger.info("TWB XSD Validation Report")
+    logger.info("=" * 60)
+    logger.info("File:   %s", twb_path)
+    logger.info("Schema: twb_2026.1.0.xsd (Tableau official, version 26.1)")
+    logger.info("")
+
+    if passed:
+        logger.info("[+] XSD validation: PASS")
+        logger.info("Status: ALL CHECKS PASSED")
+        logger.info("=" * 60)
+        return
+
+    logger.info("[X] XSD validation: FAIL (%d errors)", len(errors))
+    logger.info("")
+    for err in errors:
+        logger.info("    Line %d: %s", err.line, err.message)
+    logger.info("")
+    logger.info("-" * 60)
+    logger.info(
+        "Note: when targeting Tableau 2025.x or earlier, a small set of "
+        "errors is expected (e.g., 'missing explain-data', "
+        "'dim-percentage not allowed') - they are version shifts against the "
+        "2026.1 schema, not breakage."
+    )
+    logger.info("=" * 60)
+
+
+def main() -> None:
+    """CLI entry point.
+
+    Parses args, loads the schema, validates the workbook, prints the
+    report, and exits with the appropriate code.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a Tableau .twb file against the official 2026.1 XSD."
+        ),
+    )
+    parser.add_argument(
+        "twb_file",
+        help="Path to the .twb file to validate",
+    )
+    args = parser.parse_args()
+
+    twb_path = Path(args.twb_file)
+    if not twb_path.exists():
+        logger.error("File not found: %s", twb_path)
+        sys.exit(2)
+    if twb_path.suffix.lower() != ".twb":
+        logger.warning("File does not have .twb extension: %s", twb_path)
+
+    try:
+        schema = load_schema(XSD_PATH)
+    except FileNotFoundError as e:
+        logger.error("%s", e)
+        sys.exit(2)
+    except etree.XMLSchemaParseError as e:
+        logger.error("Failed to compile XSD: %s", e)
+        sys.exit(2)
+
+    try:
+        passed, errors = validate(twb_path, schema)
+    except etree.XMLSyntaxError as e:
+        logger.error("File is not well-formed XML: %s", e)
+        sys.exit(2)
+
+    print_report(twb_path, passed, errors)
+    sys.exit(0 if passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,25 +1,34 @@
 """Contract test for tableau-build (CONTRACT.md step 8, §4.1, §4.3).
 
 ``tableau-build`` turns the approved ``IMPLEMENTATION-SPEC.md`` + ``DATA-MODEL.md`` into a
-Tableau workbook. The XML generation is the next ticket; what this test pins is the
-skeleton the builder stands on, split across the two modules:
+Tableau workbook, across three modules:
 
 * :mod:`manifest` (pure core) - the **build manifest**: the machine-readable JSON an agent
   derives from the spec + data model that the deterministic builder consumes. Validation is
   fail-fast and names the offending entry, so a bad spec-to-manifest translation is caught
   before any XML is generated.
+* :mod:`twb` (pure assembler) - manifest -> ``.twb`` XML. What is pinned here is everything
+  Tableau is strict about and an LLM checklist got wrong: the order of ``<workbook>``'s
+  children, unique generated ids, the four places every column must appear, the live-only
+  relation, and the version-dependent ``<explain-data>``.
 * :mod:`build` (orchestration) - the entry gate (§4.1: ``spec`` and ``data`` resolved with
-  their artifacts on disk) and the STATE.md transition (``build`` -> ``approved``, never
-  touching ``current_version``, overwriting in the current ``v_N``, §4.3).
+  their artifacts on disk), the assembly + packaging step, and the STATE.md transition
+  (``build`` -> ``approved``, never touching ``current_version``, overwriting in the
+  current ``v_N``, §4.3).
 """
 
 import json
+import xml.etree.ElementTree as ET
+import zipfile
 from pathlib import Path
+
+import pytest
 
 import build  # the orchestration under test
 import init  # builds a realistic STATE.md the same way a real project would
 import manifest  # the pure manifest-schema core (on sys.path via conftest.py)
 import route  # the router parses/routes the STATE.md build writes
+import twb  # the pure .twb assembler
 
 TARGET_VERSION = "2024.2-2025.x"
 
@@ -119,9 +128,11 @@ def _errors(document=None, **overrides) -> list[str]:
     )
 
 
-def _state_with(project_dir: Path, **status_overrides: str) -> None:
+def _state_with(
+    project_dir: Path, target: str = TARGET_VERSION, **status_overrides: str
+) -> None:
     """Write a canonical STATE.md, optionally overriding some step statuses."""
-    text = init.render_state_md(TARGET_VERSION)
+    text = init.render_state_md(target)
     if status_overrides:
         text = build.apply_status_updates(text, dict(status_overrides))
     (project_dir / "STATE.md").write_text(text, encoding="utf-8")
@@ -143,9 +154,13 @@ def _write_manifest(project_dir: Path, document: dict, version: str = "v_1") -> 
     )
 
 
-def _ready_project(project_dir: Path, **status_overrides: str) -> None:
+def _ready_project(
+    project_dir: Path, target: str = TARGET_VERSION, **status_overrides: str
+) -> None:
     """Open build's entry gate: spec+data resolved with all three artifacts on disk."""
-    _state_with(project_dir, **{"spec": "approved", "data": "approved", **status_overrides})
+    _state_with(
+        project_dir, target, **{"spec": "approved", "data": "approved", **status_overrides}
+    )
     (project_dir / "DATA-MODEL.md").write_text(DATA_MODEL, encoding="utf-8")
     data_dir = project_dir / "data"
     data_dir.mkdir(exist_ok=True)
@@ -153,6 +168,13 @@ def _ready_project(project_dir: Path, **status_overrides: str) -> None:
         "order_date,region,revenue\n2024-01-05,West,1200.5\n", encoding="utf-8"
     )
     _write_spec(project_dir)
+
+
+def _built_project(project_dir: Path, **status_overrides: str) -> build.BuildResult:
+    """A ready project with the manifest authored and the workbook built + packaged."""
+    _ready_project(project_dir, **status_overrides)
+    _write_manifest(project_dir, _manifest())
+    return build.build_workbook(project_dir)
 
 
 # --- Entry gate (CONTRACT.md §4.1) -------------------------------------------
@@ -699,7 +721,367 @@ def test_validate_blocked_gate_reports_the_blocker(tmp_path):
     assert result.ok is False and "tableau-init" in result.errors[0]
 
 
+# --- The .twb assembler (twb.py) ---------------------------------------------
+
+CSV_HEADERS = {"sales_orders.csv": ["order_date", "region", "revenue"]}
+
+
+def _render(document=None, **overrides) -> ET.Element:
+    """Assemble a manifest into a .twb and return the parsed ``<workbook>`` root."""
+    return ET.fromstring(
+        twb.render_workbook(
+            _manifest(**overrides) if document is None else document,
+            DATA_MODEL,
+            CSV_HEADERS,
+        )
+    )
+
+
+def test_minimal_manifest_builds_a_well_formed_twb():
+    """The floor: the assembler emits parseable XML rooted at <workbook> (AC #1)."""
+    root = _render()
+
+    assert root.tag == "workbook"
+    assert root.get("source-build") == twb.SOURCE_BUILD
+
+
+def test_workbook_child_order_is_canonical():
+    """Tableau rejects out-of-order children - the sequence is the XSD's, in code."""
+    assert [child.tag for child in _render()] == [
+        "document-format-change-manifest", "datasources", "worksheets", "dashboards",
+        "windows",
+    ]
+
+
+def test_every_column_appears_in_all_four_locations():
+    """Missing any one of the four causes silent corruption or a load failure (AC #4)."""
+    root = _render()
+    expected = set(CSV_HEADERS["sales_orders.csv"])
+
+    relation = {
+        column.get("name")
+        for column in root.findall(
+            "datasources/datasource/connection/relation/columns/column"
+        )
+    }
+    metadata = {
+        record.findtext("remote-name")
+        for record in root.findall(
+            "datasources/datasource/connection/metadata-records/metadata-record"
+        )
+        if record.get("class") == "column"
+    }
+    object_graph = {
+        column.get("name")
+        for column in root.findall(
+            "datasources/datasource/object-graph/objects/object/properties/relation/"
+            "columns/column"
+        )
+    }
+    ui_columns = {
+        column.get("name").strip("[]")
+        for column in root.findall("datasources/datasource/column")
+        if column.get("datatype") != "table"
+    }
+
+    assert relation == metadata == object_graph == ui_columns == expected
+
+
+def test_the_physical_schema_comes_from_the_csv_not_the_manifest():
+    """The manifest lists only the fields the dashboard uses; a partial relation is a
+    schema mismatch at load, so the CSV header is what the physical schema follows."""
+    document = _manifest()
+    document["datasources"][0]["fields"] = [{"name": "revenue", "type": "real"}]
+    document["worksheets"][1]["encodings"] = {}
+    document["worksheets"][1]["shelves"] = {"rows": ["revenue"]}
+
+    relation = _render(document).findall(
+        "datasources/datasource/connection/relation/columns/column"
+    )
+
+    assert [column.get("name") for column in relation] == CSV_HEADERS["sales_orders.csv"]
+
+
+def test_column_types_come_from_the_data_model():
+    """DATA-MODEL.md is the field authority (§3): type drives datatype, role, remote-type."""
+    root = _render()
+    by_name = {
+        column.get("name"): column
+        for column in root.findall("datasources/datasource/column")
+    }
+
+    assert by_name["[revenue]"].get("datatype") == "real"
+    assert by_name["[revenue]"].get("role") == "measure"
+    assert by_name["[region]"].get("role") == "dimension"
+    assert by_name["[order_date]"].get("datatype") == "date"
+    assert by_name["[revenue]"].get("caption") == "Revenue"
+
+
+def test_generated_ids_are_unique():
+    """Every id in the workbook must be unique or Tableau cross-references the wrong thing."""
+    root = _render()
+    ids = (
+        [element.get("uuid") for element in root.iter("simple-id")]
+        + [element.get("name") for element in root.findall("datasources/datasource")]
+        + [
+            element.get("name")
+            for element in root.iter("named-connection")
+        ]
+    )
+
+    assert len(ids) == len(set(ids))
+
+
+def test_no_snippet_ids_leak():
+    """Ids are generated, never copied from the reference snippets (AC #4)."""
+    xml = twb.render_workbook(_manifest(), DATA_MODEL, CSV_HEADERS)
+
+    for snippet_id in (
+        "1hckotw0bte0i51b8k3sd1ffpnqc",             # scaffold datasource
+        "16xkalt18d1a7p1cjzge51xf66r6",             # scaffold named connection
+        "09EB5EA8C4E1488681646EA8C7C1C3B0",         # scaffold object id
+        "{8ED4AD55-A43F-4C33-B8C1-A6484D0F1985}",   # scaffold worksheet simple-id
+        "{0CB252DB-8C32-4E23-87BF-F5520667C3F4}",   # scaffold dashboard simple-id
+        "{5072827F-AB68-407A-8A5C-209EC187C960}",   # scaffold worksheet window
+        "{3FC88B5F-B055-44CF-B059-FB779136E3D0}",   # scaffold dashboard window
+    ):
+        assert snippet_id not in xml
+
+
+def test_the_same_manifest_rebuilds_byte_identical():
+    """Ids are hash-derived, not random: a re-run is a no-op diff."""
+    first = twb.render_workbook(_manifest(), DATA_MODEL, CSV_HEADERS)
+    second = twb.render_workbook(_manifest(), DATA_MODEL, CSV_HEADERS)
+
+    assert first == second
+
+
+def test_2025_target_omits_explain_data_and_uses_18_1():
+    """The 2024.2-2025.x document format is 18.1 and has no <explain-data> (AC #5)."""
+    root = _render(target_tableau_version="2024.2-2025.x")
+
+    assert root.get("version") == "18.1" and root.get("original-version") == "18.1"
+    assert root.find("explain-data") is None
+
+
+def test_2026_target_emits_explain_data_and_26_1():
+    """Switching STATE.md's target flips both the version attribute and the element (AC #5)."""
+    root = _render(target_tableau_version="2026.1+")
+
+    assert root.get("version") == "26.1" and root.get("original-version") == "26.1"
+    explain_data = root.find("explain-data")
+    assert explain_data is not None
+    assert explain_data.get("enabled-for-viewer") == "false"
+    assert [child.tag for child in root][-1] == "explain-data"  # always the last child
+
+
+def test_relation_is_live_and_local():
+    """Never an extract, and the CSV is read from beside the .twb inside the .twbx."""
+    root = _render()
+    connection = root.find(
+        "datasources/datasource/connection/named-connections/named-connection/connection"
+    )
+
+    assert list(root.iter("extract")) == []
+    assert connection.get("class") == "textscan"
+    assert connection.get("directory") == "."
+    assert connection.get("filename") == "sales_orders.csv"
+    assert root.find("datasources/datasource/connection/relation").get("table") == (
+        "[sales_orders#csv]"
+    )
+
+
+def test_every_viewpoint_has_entire_view_zoom():
+    """A self-closing viewpoint defaults to 'standard' zoom - the sheet then under-fills."""
+    viewpoints = _render().findall("windows/window/viewpoints/viewpoint")
+
+    assert [viewpoint.get("name") for viewpoint in viewpoints] == [
+        "Revenue KPI", "Revenue Trend",
+    ]
+    for viewpoint in viewpoints:
+        assert viewpoint.find("zoom").get("type") == "entire-view"
+
+
+def test_every_worksheet_has_a_matching_hidden_window():
+    """validate_twb's worksheet<->window check is bidirectional; both sides come from here."""
+    root = _render()
+    worksheets = [sheet.get("name") for sheet in root.findall("worksheets/worksheet")]
+    windows = [
+        window.get("name") for window in root.findall("windows/window")
+        if window.get("class") == "worksheet"
+    ]
+
+    assert worksheets == windows == ["Revenue KPI", "Revenue Trend"]
+    assert all(
+        window.get("hidden") == "true" for window in root.findall("windows/window")
+        if window.get("class") == "worksheet"
+    )
+
+
+def test_dashboard_is_sized_from_the_layout_canvas():
+    """The mock's approved canvas is the workbook's dashboard size."""
+    size = _render().find("dashboards/dashboard/size")
+
+    assert size.attrib == {
+        "maxheight": "768", "maxwidth": "1366", "minheight": "768", "minwidth": "1366",
+    }
+
+
+def test_zero_worksheets_omits_the_worksheets_element():
+    """The XSD requires >=1 <worksheet>, so an empty <worksheets> is invalid - omit it."""
+    document = _manifest()
+    document["worksheets"] = []
+    document["objects"] = [
+        {"element_id": "kpi-revenue", "kind": "text"},
+        {"element_id": "chart-trend", "kind": "image"},
+    ]
+
+    root = _render(document)
+
+    assert root.find("worksheets") is None
+    assert [child.tag for child in root] == [
+        "document-format-change-manifest", "datasources", "dashboards", "windows",
+    ]
+
+
+def test_thumbnails_are_never_emitted():
+    """The XSD requires >=1 <thumbnail>; Tableau regenerates them, so omit the element."""
+    assert _render().find("thumbnails") is None
+
+
+def test_worksheets_may_be_empty_when_objects_fill_every_zone():
+    """The manifest relaxation behind the zero-worksheet case: no views is a legal
+    dashboard as long as every leaf zone is still filled."""
+    document = _manifest()
+    document["worksheets"] = []
+    document["objects"] = [
+        {"element_id": "kpi-revenue", "kind": "text"},
+        {"element_id": "chart-trend", "kind": "image"},
+    ]
+
+    assert _errors(document) == []
+
+
+def test_an_unfilled_zone_is_still_rejected_with_no_worksheets():
+    """The relaxation must not open a hole: a zone nothing fills is still an error."""
+    document = _manifest()
+    document["worksheets"] = []
+    document["objects"] = [{"element_id": "kpi-revenue", "kind": "text"}]
+
+    assert any("chart-trend" in error for error in _errors(document))
+
+
+# --- Assembly, validation, packaging (build.build_workbook) -------------------
+
+def test_build_writes_a_validated_twb_and_twbx(tmp_path):
+    """The end-to-end deliverable: a minimal manifest builds both files (AC #1)."""
+    result = _built_project(tmp_path)
+
+    assert result.ok is True, result.errors
+    assert (tmp_path / build.VERSION_DIR / "v_1" / build.TWB_FILENAME).exists()
+    assert (tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME).exists()
+
+
+def test_twbx_contains_the_twb_and_every_csv(tmp_path):
+    """Packaging is flat, so directory='.' resolves each CSV beside the .twb (AC #1)."""
+    _built_project(tmp_path)
+
+    with zipfile.ZipFile(
+        tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME
+    ) as archive:
+        assert sorted(archive.namelist()) == ["dashboard.twb", "sales_orders.csv"]
+
+
+def test_semantic_validator_passes_on_the_generated_twb(tmp_path):
+    """The migrated breakage-only validator is green on what the assembler emits (AC #2)."""
+    import validate_twb  # migrated into the skill by this ticket
+
+    _built_project(tmp_path)
+
+    report = validate_twb.TwbValidator(
+        str(tmp_path / build.VERSION_DIR / "v_1" / build.TWB_FILENAME)
+    ).validate()
+
+    assert report.passed is True, [
+        (result.name, result.details) for result in report.results if not result.passed
+    ]
+
+
+def test_xsd_reports_at_most_the_documented_version_shift(tmp_path):
+    """2026.1 validates clean; 2025.x differs only by the required <explain-data> (AC #2)."""
+    pytest.importorskip("lxml")
+    import validate_twb_xsd  # migrated into the skill by this ticket
+
+    schema = validate_twb_xsd.load_schema(validate_twb_xsd.XSD_PATH)
+
+    _built_project(tmp_path)
+    _, errors_2025 = validate_twb_xsd.validate(
+        tmp_path / build.VERSION_DIR / "v_1" / build.TWB_FILENAME, schema
+    )
+    assert len(errors_2025) <= 1
+    assert all("explain-data" in error.message for error in errors_2025)
+
+    newer = tmp_path / "newer"
+    newer.mkdir()
+    _ready_project(newer, target="2026.1+")
+    _write_manifest(newer, _manifest(target_tableau_version="2026.1+"))
+    assert build.build_workbook(newer).ok is True
+
+    passed, errors_2026 = validate_twb_xsd.validate(
+        newer / build.VERSION_DIR / "v_1" / build.TWB_FILENAME, schema
+    )
+    assert passed is True and errors_2026 == []
+
+
+def test_build_reports_the_version_shift_as_a_warning_not_an_error(tmp_path):
+    """The 2025.x XSD complaint is expected - it must not read as a broken workbook."""
+    pytest.importorskip("lxml")
+
+    result = _built_project(tmp_path)
+
+    assert result.ok is True
+    assert any("explain-data" in warning for warning in result.warnings)
+
+
+def test_build_refuses_an_invalid_manifest(tmp_path):
+    """No XML is generated from a manifest that does not validate."""
+    _ready_project(tmp_path)
+    document = _manifest()
+    document["worksheets"][1]["chart_type"] = "donut"
+    _write_manifest(tmp_path, document)
+
+    result = build.build_workbook(tmp_path)
+
+    assert result.ok is False
+    assert any("donut" in error for error in result.errors)
+    assert not (tmp_path / build.VERSION_DIR / "v_1" / build.TWB_FILENAME).exists()
+
+
+def test_build_refuses_a_csv_that_is_not_on_disk(tmp_path):
+    """A datasource with no CSV would build a workbook bound to nothing."""
+    _ready_project(tmp_path)
+    _write_manifest(tmp_path, _manifest())
+    (tmp_path / "data" / "sales_orders.csv").rename(tmp_path / "data" / "orders.csv")
+
+    result = build.build_workbook(tmp_path)
+
+    assert result.ok is False
+    assert any("sales_orders.csv" in error for error in result.errors)
+
+
 # --- STATE.md transition (CONTRACT.md §4.3) ----------------------------------
+
+def test_commit_refuses_without_a_workbook(tmp_path):
+    """The deliverable is the workbook: a validated manifest alone does not approve it."""
+    _ready_project(tmp_path)
+    _write_manifest(tmp_path, _manifest())
+
+    result = build.commit(tmp_path)
+
+    assert result.ok is False
+    assert build.WORKBOOK_FILENAME in result.message
+    assert route.parse_state(tmp_path / "STATE.md").statuses["build"] == "pending"
+
 
 def test_commit_refuses_without_a_manifest(tmp_path):
     """No manifest => nothing to build; STATE.md is untouched."""
@@ -728,8 +1110,7 @@ def test_commit_refuses_an_invalid_manifest(tmp_path):
 
 def test_commit_approves_and_leaves_current_version_alone(tmp_path):
     """A valid manifest approves build in place - current_version is never bumped (§4.3)."""
-    _ready_project(tmp_path)
-    _write_manifest(tmp_path, _manifest())
+    _built_project(tmp_path)
 
     result = build.commit(tmp_path)
 
@@ -741,8 +1122,7 @@ def test_commit_approves_and_leaves_current_version_alone(tmp_path):
 
 def test_recommit_overwrites_in_place(tmp_path):
     """Re-running build after approval overwrites the same v_N; no new version dir (§4.3)."""
-    _ready_project(tmp_path)
-    _write_manifest(tmp_path, _manifest())
+    _built_project(tmp_path)
     build.commit(tmp_path)
 
     result = build.commit(tmp_path)
@@ -754,8 +1134,7 @@ def test_recommit_overwrites_in_place(tmp_path):
 
 def test_commit_from_stale_reapproves_the_same_version(tmp_path):
     """The realistic re-run: mock bumped and staled build, which rebuilds into that v_N."""
-    _ready_project(tmp_path, build="stale")
-    _write_manifest(tmp_path, _manifest())
+    _built_project(tmp_path, build="stale")
 
     result = build.commit(tmp_path)
 
@@ -765,13 +1144,12 @@ def test_commit_from_stale_reapproves_the_same_version(tmp_path):
 
 def test_router_reports_done_after_build_is_approved(tmp_path):
     """Cross-check through the router: build approved completes the pipeline."""
-    _ready_project(tmp_path, intake="approved", brand="skipped", plan="approved",
+    _built_project(tmp_path, intake="approved", brand="skipped", plan="approved",
                    mock="approved")
     (tmp_path / "DASHBOARD-PLAN.md").write_text("# Plan\n", encoding="utf-8")
     (tmp_path / build.VERSION_DIR / "v_1" / "mock.html").write_text(
         "<html></html>", encoding="utf-8"
     )
-    _write_manifest(tmp_path, _manifest())
 
     assert build.commit(tmp_path).ok is True
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -817,6 +817,59 @@ def test_column_types_come_from_the_data_model():
     assert by_name["[revenue]"].get("caption") == "Revenue"
 
 
+def test_every_documented_type_renders_a_complete_column():
+    """All six DATA-MODEL types must map - datetime and boolean are the least attested,
+    and a type the map misses would silently fall back to string."""
+    data_model = (
+        "# Data Model\n\n## Data source: `types.csv`\n\n"
+        "| Field | Type |\n|---|---|\n"
+        + "".join(f"| f_{name} | {name} |\n" for name in twb.TYPE_FACTS)
+    )
+    document = _manifest(
+        datasources=[{
+            "name": "types", "csv": "types.csv",
+            "fields": [{"name": f"f_{name}", "type": name} for name in twb.TYPE_FACTS],
+        }],
+        worksheets=[],
+        objects=[
+            {"element_id": "kpi-revenue", "kind": "text"},
+            {"element_id": "chart-trend", "kind": "image"},
+        ],
+    )
+    header = [f"f_{name}" for name in twb.TYPE_FACTS]
+
+    root = ET.fromstring(twb.render_workbook(document, data_model, {"types.csv": header}))
+    records = {
+        record.findtext("remote-name"): record
+        for record in root.iter("metadata-record")
+        if record.get("class") == "column"
+    }
+
+    assert set(records) == set(header)
+    for type_name, facts in twb.TYPE_FACTS.items():
+        record = records[f"f_{type_name}"]
+        assert record.findtext("local-type") == type_name
+        assert record.findtext("remote-type") == str(facts.remote_type)
+        assert record.findtext("aggregation") == facts.aggregation
+        # The string trio rides along with text-like types only.
+        assert (record.find("collation") is not None) == facts.text_like
+
+
+def test_an_undocumented_csv_column_still_reaches_the_physical_schema():
+    """A column the data model missed must not vanish: an incomplete relation is a schema
+    mismatch at load. It falls back to string rather than being dropped."""
+    root = ET.fromstring(
+        twb.render_workbook(
+            _manifest(), DATA_MODEL,
+            {"sales_orders.csv": ["order_date", "region", "revenue", "surprise"]},
+        )
+    )
+    columns = root.findall("datasources/datasource/connection/relation/columns/column")
+
+    assert [column.get("name") for column in columns][-1] == "surprise"
+    assert columns[-1].get("datatype") == twb.FALLBACK_TYPE
+
+
 def test_generated_ids_are_unique():
     """Every id in the workbook must be unique or Tableau cross-references the wrong thing."""
     root = _render()
@@ -830,6 +883,25 @@ def test_generated_ids_are_unique():
     )
 
     assert len(ids) == len(set(ids))
+
+
+def test_two_datasources_over_one_csv_still_get_unique_ids():
+    """Ids are seeded from the datasource *and* the csv: sharing a CSV must not collide."""
+    document = _manifest()
+    document["datasources"].append({
+        "name": "sales_orders_secondary",
+        "csv": "sales_orders.csv",
+        "fields": [{"name": "revenue", "type": "real"}],
+    })
+
+    root = _render(document)
+    connections = [
+        element.get("name") for element in root.iter("named-connection")
+    ]
+    objects = [element.get("id") for element in root.iter("object")]
+
+    assert len(connections) == len(set(connections)) == 2
+    assert len(objects) == len(set(objects)) == 2
 
 
 def test_no_snippet_ids_leak():
@@ -982,6 +1054,23 @@ def test_build_writes_a_validated_twb_and_twbx(tmp_path):
     assert (tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME).exists()
 
 
+def test_a_zero_worksheet_manifest_builds_and_packages(tmp_path):
+    """AC #1 literally: one CSV datasource, zero worksheets, one empty dashboard."""
+    _ready_project(tmp_path)
+    document = _manifest()
+    document["worksheets"] = []
+    document["objects"] = [
+        {"element_id": "kpi-revenue", "kind": "text"},
+        {"element_id": "chart-trend", "kind": "image"},
+    ]
+    _write_manifest(tmp_path, document)
+
+    result = build.build_workbook(tmp_path)
+
+    assert result.ok is True, result.errors
+    assert (tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME).exists()
+
+
 def test_twbx_contains_the_twb_and_every_csv(tmp_path):
     """Packaging is flat, so directory='.' resolves each CSV beside the .twb (AC #1)."""
     _built_project(tmp_path)
@@ -1067,6 +1156,31 @@ def test_build_refuses_a_csv_that_is_not_on_disk(tmp_path):
 
     assert result.ok is False
     assert any("sales_orders.csv" in error for error in result.errors)
+
+
+def test_a_failed_build_removes_the_previous_package(tmp_path):
+    """commit approves on the .twbx's existence, so a failed rebuild must not leave the
+    last good package behind for it to approve."""
+    _built_project(tmp_path)
+    (tmp_path / "data" / "sales_orders.csv").rename(tmp_path / "data" / "orders.csv")
+
+    assert build.build_workbook(tmp_path).ok is False
+    assert not (tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME).exists()
+    assert build.commit(tmp_path).ok is False
+
+
+def test_only_the_referenced_csvs_are_packaged(tmp_path):
+    """An unrelated CSV in data/ has no business inside the analyst's deliverable."""
+    _ready_project(tmp_path)
+    (tmp_path / "data" / "unrelated.csv").write_text("a\n1\n", encoding="utf-8")
+    _write_manifest(tmp_path, _manifest())
+
+    assert build.build_workbook(tmp_path).ok is True
+
+    with zipfile.ZipFile(
+        tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME
+    ) as archive:
+        assert "unrelated.csv" not in archive.namelist()
 
 
 # --- STATE.md transition (CONTRACT.md §4.3) ----------------------------------


### PR DESCRIPTION
Closes #34.

The deterministic core of the workbook generator. From a validated build manifest, Python assembles a `.twb` that is **correct by construction** — the rules Tableau is strict about move out of an LLM checklist and into code, which is what kills "Tableau refuses to open the file" at the source.

## What's in it

**`skills/tableau-build/scripts/twb.py`** (new) — pure, stdlib-only, no filesystem, so the tests drive it directly:

- **Child order** taken from the 2026.1 XSD's `WorkbookFile-CT`, not the legacy prose.
- **Deterministic ids** — `federated.*` / `textscan.*` / object-id / `simple-id` uuid5 all hash-derived, so a rebuild is byte-identical and uniqueness is testable. Nothing is copied from the reference snippets.
- **4-way column redundancy** rendered from one `Column` list, so the four locations cannot drift. Physical schema comes from the **CSV header** (an incomplete `relation > columns` is a schema mismatch at load); types come from **`DATA-MODEL.md`** (the field authority, §3), with the role derived from the type.
- **Live connection only** — no `<extract>`, `directory='.'`, CSVs packaged in the `.twbx`.
- **Version targeting** — `18.1` vs `26.1`, and `<explain-data>` emitted for 2026.1+ only.

**`build.py`** — new `build` subcommand between `validate` and `commit`: read the CSV headers → render → run both validators → package a flat `ZIP_DEFLATED` `.twbx`. A validator failure leaves the `.twb` on disk unpackaged and exits 2. `commit` now refuses unless the `.twbx` exists (closes the `TODO` at the old `build.py:558`).

**Migrated** `validate_twb.py`, `validate_twb_xsd.py` and the 3 XSD files from the legacy v1 skill. Their `logging.basicConfig` moved from import time into `main()` — `build.py` imports them, and a library must not reconfigure its caller's logging.

**`manifest.py`** — `documented_field_types` (the type authority the assembler reads); `worksheets: []` is now legal, since the "every leaf zone is filled" check already covered what it guarded.

## Two findings that changed the ticket's shape

1. **`<worksheets>` and `<thumbnails>` are omitted, not emitted empty.** `Workbook-Worksheets-G` and `Workbook-Thumbnails-G` each require ≥1 child, so `step-e-twb-generation.md`'s "always emit `<thumbnails />`" is wrong. Tableau regenerates thumbnails anyway.
2. **`<active id='...'/>` *is* required** — `Window-DashboardWindow-G` (`twb_2026.1.0.xsd:6884`) makes it mandatory, so it is emitted.

## Verification

- **303 tests pass** (+32). `twb.py` is pure, so most drive `render_workbook` directly.
- **Semantic validator**: 8/8 green on generated XML.
- **XSD**: 2026.1+ → **0 errors**. 2024.2-2025.x → exactly **1**, the documented missing-`explain-data` version shift, downgraded to a `[WARN]`. (Its "Expected is one of" list is longer than the ticket quoted, because we also omit `thumbnails`/`datagraph`.)

## Not in this PR (next ticket, per the plan's §1)

Worksheet bodies (shelves/encodings/marks/`datasource-dependencies`), the dashboard zone tree from `layout.root`, actions, parameters, calculated fields, design-token styling. `TODO(next ticket)` markers sit where each lands. The built workbook opens clean and carries the data; the views are empty.

## Review pass

A two-axis review (standards + spec) ran before merge and found three real defects, fixed in 3d43323:

- **Id collision** — `connection_id`/`object_id` seeded only from the CSV, so two datasources over one CSV emitted identical ids (an AC #4 breach both validators missed).
- **Stale `.twbx`** — `commit` approves on the package's existence, so one left behind by a failed rebuild was approvable. `build` now drops it before anything can fail.
- **Unbounded XSD tolerance** — every matching message was downgraded; now at most one, forgiven by position.

Plus `CONTRACT.md` §3/§4.3 now registers `mock-version/v_N/dashboard.twb` as the second build-internal file, and only the CSVs the manifest references are packaged.

## AC #3 is manual and still open

A workbook built from the demo's `sales_orders.csv` needs opening in Tableau Desktop, chiefly to confirm the two unattested `remote-type` codes (135 datetime, 11 boolean). Noted on #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)