### PR TITLE
feat(build): all 15 worksheet chart templates

### DIFF
--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -23,12 +23,31 @@ field, or element id named.
 | **Next step** | None — the pipeline is complete (`tableau-route` confirms). |
 
 The mechanical guarantees live in Python: the entry gate, the manifest schema validation and
-the STATE.md transition in `build.py` / `manifest.py`, and the XML itself in `twb.py` — the
-element order, the generated ids, the four places every column must appear, the live-only
+the STATE.md transition in `build.py` / `manifest.py`, the workbook shell in `twb.py`, and
+every chart template in `worksheet.py` — the element order, the generated ids, the four
+places every column must appear, the mark class and shelves per chart type, the live-only
 connection and the version targeting are **code, not a checklist**, so a validated manifest
 builds a workbook that is correct by construction. Your job is the judgment part: translating
 each spec row into the right manifest entry. Run the script at the points below; do not
 hand-edit `STATE.md` or the generated XML.
+
+## Chart templates
+
+Every chart type is built from manifest fields — nothing is copied from a snippet, so no
+stray field name or datasource id can leak into the analyst's workbook. Pick the
+`chart_type` from `references/BUILD-MANIFEST-TEMPLATE.md`'s table (`bar`, `line`, `area`,
+`pie`, `scatter`, `map`, `text` = KPI card, `table` = text table, `histogram`, `dual-axis`,
+`combo`, plus `heatmap` / `treemap` / `bullet` / `gantt` / `boxplot`).
+
+Four things the spec may ask for are **not** chart types — they are optional keys on any
+worksheet: `sort`, `filters`, `tooltip`, and `axis_titles` / `number_formats`. A *stacked*
+bar is a `bar` with a `color` encoding. Reach for a modifier before reaching for a new
+chart type.
+
+Styling comes from `DESIGN-TOKENS.md` when the analyst ran `tableau-brand`: its font family
+and chart-title size/colour are applied to every worksheet automatically. When it is absent,
+Tableau's own defaults apply and nothing is invented. The manifest never carries fonts or
+colours.
 
 ## The build manifest
 
@@ -115,11 +134,12 @@ invented zone is caught rather than silently built.
   version is created by re-running `tableau-mock` (which bumps and stales spec and build).
 - **Live connection, always.** The workbook never carries an extract: the `.twbx` embeds the
   CSVs, and the analyst points it at the real database with Data → Replace Data Source.
-- **Worksheet bodies are still coming.** Today's assembler emits the datasources, placeholder
-  worksheets, a dashboard sized from the mock's canvas, and the windows. Shelves, encodings,
-  marks and the dashboard's zone tree are the next ticket, so the built workbook opens
-  clean but the views are empty.
+- **The dashboard's zone tree is still coming.** Today's assembler emits the datasources,
+  fully populated worksheets, a dashboard sized from the mock's canvas, and the windows.
+  Nesting the layout tree into dashboard zones is the next ticket, so every view renders but
+  the dashboard itself is still a single container.
 
 > The full `STATE.md` schema and the ordering / staleness / versioning rules live in
 > `CONTRACT.md` at the repo root. This skill restates only its own slice; `build.py`,
-> `manifest.py` and `twb.py` are the executable mirror of the contract it enforces.
+> `manifest.py`, `twb.py` and `worksheet.py` are the executable mirror of the contract it
+> enforces.

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -53,11 +53,11 @@ carrying what the builder must apply: `{"field": "revenue", "aggregation": "sum"
 `{"field": "order_date", "date_part": "month"}`, or `{"field": "revenue", "bin": 500}`.
 Aggregations: `sum`, `avg`, `min`, `max`, `count`, `countd`, `median`, `attr`, `none` — a
 measure with none of them defaults to `SUM`. Date parts: `year`, `quarter`, `month`, `week`,
-`day`, `hour`, `minute`, `date`. Never write an expression like `"SUM([revenue])"` — that is
-the spec's prose, not a field reference.
+`day`, `date`. Never write an expression like `"SUM([revenue])"` — that is the spec's prose,
+not a field reference.
 
 Encodings the builder emits: `color`, `size`, `shape`, `text`, `lod`, `wedge-size`,
-`geometry`, `path`, `tooltip`.
+`geometry`, `tooltip`. Any other name is a validation error, not a silent drop.
 
 ## Optional worksheet keys (the modifiers)
 

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -28,14 +28,53 @@ unfilled zone would build an empty container. A *mapped container* (a node with 
 and `children`, e.g. a DZV panel) is filled by its children and needs no entry of its own.
 Interaction ids (`int-*`) are actions, not zones, and never appear in the tree.
 
-Chart types the builder emits: `bar`, `line`, `area`, `pie`, `scatter`, `map`, `text`,
-`table`, `heatmap`, `histogram`, `treemap`, `bullet`, `gantt`, `boxplot`.
+## Chart types
+
+| `chart_type` | what it emits |
+|--------------|---------------|
+| `bar` | Discrete dimension × aggregated measure. Add a `color` encoding for a **stacked** bar. |
+| `line` | Same shape, but the dimension is a **continuous date** — give it a `date_part`. |
+| `area` | Line with an explicit `Area` mark. |
+| `pie` | Rows/Cols stay empty; everything is encodings (`color`, `wedge-size`, `size`, `text`). |
+| `scatter` | A measure on each axis, a dimension on `lod` (Detail). |
+| `map` | Tableau's generated lat/long; `lod` is the geographic dimension, `color` the measure. Optional `geo_role` (e.g. `"[Country].[ISO3166_2]"`). |
+| `text` | **KPI card** — empty shelves, a single `text` encoding, rendered as a big number. |
+| `table` | **Text table** — a dimension on each axis, the measure on `text`. |
+| `histogram` | A binned dimension: `{"field": "revenue", "bin": 500}` on `columns`, a `count` on `rows`. |
+| `dual-axis` | Exactly **two** measures on `rows`, overlaid on synchronised axes. |
+| `combo` | A dual axis with Bar marks on the first measure and Line on the second. |
+| `heatmap`, `treemap`, `bullet`, `gantt`, `boxplot` | The corresponding mark class. |
+
+Four of the legacy patterns are **modifiers**, not chart types — they apply to any of the
+above via the optional worksheet keys below.
 
 **Shelf and encoding entries** are either a bare field name (`"revenue"`) or an object
-carrying what the builder must apply: `{"field": "revenue", "aggregation": "sum"}` or
-`{"field": "order_date", "date_part": "month"}`. Aggregations: `sum`, `avg`, `min`, `max`,
-`count`, `countd`, `median`, `attr`, `none`. Never write an expression like
-`"SUM([revenue])"` — that is the spec's prose, not a field reference.
+carrying what the builder must apply: `{"field": "revenue", "aggregation": "sum"}`,
+`{"field": "order_date", "date_part": "month"}`, or `{"field": "revenue", "bin": 500}`.
+Aggregations: `sum`, `avg`, `min`, `max`, `count`, `countd`, `median`, `attr`, `none` — a
+measure with none of them defaults to `SUM`. Date parts: `year`, `quarter`, `month`, `week`,
+`day`, `hour`, `minute`, `date`. Never write an expression like `"SUM([revenue])"` — that is
+the spec's prose, not a field reference.
+
+Encodings the builder emits: `color`, `size`, `shape`, `text`, `lod`, `wedge-size`,
+`geometry`, `path`, `tooltip`.
+
+## Optional worksheet keys (the modifiers)
+
+| key | shape | what it does |
+|-----|-------|--------------|
+| `sort` | `{"field": "region", "direction": "DESC", "by": {"field": "revenue", "aggregation": "sum"}}` | Computed sort. Swap `by` for `"order": ["West", "East"]` to sort manually. |
+| `filters` | `[{"field": "region", "values": ["Europe"], "context": true}, {"field": "order_date", "min": "2025-01-01", "max": "2025-06-30"}]` | Categorical (member list) or in-range filter. `context: true` runs it before FIXED LODs. |
+| `tooltip` | `[{"label": "Revenue", "field": "revenue", "aggregation": "sum"}]` | A custom tooltip template, one label/value pair per line. |
+| `axis_titles` | `{"rows": "Revenue per category"}` | Overrides the generated axis title. |
+| `number_formats` | `[{"field": "revenue", "format": "$#,##0"}]` | Cell number format for that field. |
+
+Every modifier's field is resolved as strictly as a shelf field — a filter on a field the
+data model does not document is rejected, not silently dropped.
+
+**Styling comes from `DESIGN-TOKENS.md`, not the manifest.** When it exists, its font family
+and chart-title size/colour are applied to every worksheet; when it does not, Tableau's own
+defaults apply. Nothing in the manifest sets fonts or colours.
 
 **Action targets depend on the type**: `filter` / `highlight` target layout zones, a
 `parameter` action targets a declared parameter by name. The `source` is always a zone.
@@ -58,7 +97,7 @@ carrying what the builder must apply: `{"field": "revenue", "aggregation": "sum"
   ],
   "calculated_fields": [
     {"name": "Revenue per Order", "formula": "SUM([revenue]) / COUNTD([order_id])",
-     "datasource": "sales_orders"}
+     "datasource": "sales_orders", "type": "real"}
   ],
   "worksheets": [
     {
@@ -78,7 +117,11 @@ carrying what the builder must apply: `{"field": "revenue", "aggregation": "sum"
         "columns": [{"field": "order_date", "date_part": "month"}],
         "rows": [{"field": "revenue", "aggregation": "sum"}]
       },
-      "encodings": {"color": "region"}
+      "encodings": {"color": "region"},
+      "filters": [{"field": "region", "values": ["West", "East"], "context": true}],
+      "sort": {"field": "region", "direction": "DESC",
+               "by": {"field": "revenue", "aggregation": "sum"}},
+      "number_formats": [{"field": "revenue", "format": "$#,##0"}]
     }
   ],
   "objects": [

--- a/skills/tableau-build/scripts/build.py
+++ b/skills/tableau-build/scripts/build.py
@@ -55,6 +55,8 @@ logger = logging.getLogger(__name__)
 STATE_FILENAME = "STATE.md"
 DATA_MODEL_FILENAME = "DATA-MODEL.md"
 SPEC_FILENAME = "IMPLEMENTATION-SPEC.md"
+#: Optional read: styling. Absent (branding skipped) means Tableau's own defaults.
+DESIGN_TOKENS_FILENAME = "DESIGN-TOKENS.md"
 #: Build-internal, not a handoff artifact - hence lowercase (CONTRACT.md §3).
 MANIFEST_FILENAME = "build-manifest.json"
 WORKBOOK_FILENAME = "dashboard.twbx"
@@ -702,11 +704,14 @@ def build_workbook(project_dir: Path | str) -> BuildResult:
         )
 
     twb_path = version_dir / TWB_FILENAME
+    tokens_path = project_root / DESIGN_TOKENS_FILENAME
     twb_path.write_text(
         twb.render_workbook(
             document,
             (project_root / DATA_MODEL_FILENAME).read_text(encoding="utf-8-sig"),
             headers,
+            # Optional read (CONTRACT.md §4.1): no branding step, no styling overrides.
+            tokens_path.read_text(encoding="utf-8-sig") if tokens_path.exists() else "",
         ),
         encoding="utf-8",
     )

--- a/skills/tableau-build/scripts/manifest.py
+++ b/skills/tableau-build/scripts/manifest.py
@@ -31,19 +31,19 @@ import re
 from pathlib import Path
 from typing import Optional
 
+# Names, not the module: half the functions below take a parameter called ``worksheet``.
+from worksheet import CHART_SPECS, DATE_PART_DERIVATIONS, ENCODING_ORDER
+
 #: Sections a manifest must carry (actions/parameters may be empty lists, never absent -
 #: "None" must be said explicitly so a forgotten section is not mistaken for "no actions").
 REQUIRED_KEYS: tuple[str, ...] = (
     "target_tableau_version", "datasources", "worksheets", "layout", "actions", "parameters",
 )
 
-#: Mark/chart types the builder knows how to emit. Add a type here only once the builder
-#: has a validated snippet for it - an unknown type must fail loudly, not build blank.
-CHART_TYPES = frozenset({
-    "bar", "line", "area", "pie", "scatter", "map", "text", "table",
-    "heatmap", "histogram", "treemap", "bullet", "gantt", "boxplot",
-    "dual-axis", "combo",
-})
+#: Mark/chart types the builder knows how to emit - read straight off the builder's table,
+#: so a type can never be accepted here and rendered blank there. Add a chart type by adding
+#: a :data:`worksheet.CHART_SPECS` row.
+CHART_TYPES = frozenset(CHART_SPECS)
 
 #: Chart types that overlay two measures on one axis pair - they need exactly two entries on
 #: the rows shelf, or the second axis (and the whole point of the chart) is missing.
@@ -68,10 +68,12 @@ AGGREGATIONS = frozenset({
     "sum", "avg", "min", "max", "count", "countd", "median", "attr", "none",
 })
 
-#: Date parts a shelf/encoding entry may request of a date field.
-DATE_PARTS = frozenset({
-    "year", "quarter", "month", "week", "day", "hour", "minute", "date",
-})
+#: Date parts a shelf/encoding entry may request of a date field, and the encoding names an
+#: ``encodings`` block may use. Both come off the builder's tables for the same reason as
+#: :data:`CHART_TYPES`: an entry this module accepts but the builder has no case for is
+#: dropped silently, and Tableau shows no sign of the missing encoding.
+DATE_PARTS = frozenset(DATE_PART_DERIVATIONS)
+ENCODING_NAMES = frozenset(ENCODING_ORDER)
 
 # A data-source heading in DATA-MODEL.md: "## Data source: `sales.csv`" -> "sales.csv".
 _DATASOURCE_HEADING = re.compile(
@@ -493,6 +495,55 @@ def _validate_reference(
         )
 
 
+def _validate_modifiers(label: str, worksheet: dict, errors: list[str]) -> None:
+    """Reject modifier entries the builder would have to drop.
+
+    A filter with nothing to filter on, a sort with nothing to sort by, or an encoding the
+    builder has no case for is an entry the assembler cannot render - and one Tableau would
+    show no sign of. Naming it here is the difference between "the filter is missing" and
+    "the manifest row is incomplete".
+
+    Args:
+        label: The worksheet's error label.
+        worksheet: One ``worksheets`` entry.
+        errors: Accumulator for validation errors.
+    """
+    encodings = worksheet.get("encodings")
+    if isinstance(encodings, dict):
+        # The field behind each encoding is checked by _validate_reference; only the
+        # encoding *name* is checked here, so a typo'd 'colour' fails instead of vanishing.
+        for name in encodings:
+            if str(name).strip().lower() not in ENCODING_NAMES:
+                errors.append(
+                    f"{label}: unknown encoding '{name}' "
+                    f"(expected one of: {', '.join(sorted(ENCODING_NAMES))})"
+                )
+
+    filters = worksheet.get("filters")
+    if isinstance(filters, list):
+        for index, entry in enumerate(filters):
+            if not isinstance(entry, dict):
+                errors.append(f"{label}: filters[{index}] must be an object with a 'field'")
+                continue
+            values = entry.get("values")
+            if not (isinstance(values, list) and values) and (
+                entry.get("min") is None and entry.get("max") is None
+            ):
+                errors.append(
+                    f"{label}: filters[{index}] has nothing to filter on - give it "
+                    f"'values' (a member list) or 'min'/'max' (a range)"
+                )
+
+    sort = worksheet.get("sort")
+    if isinstance(sort, dict):
+        order = sort.get("order")
+        if sort.get("by") is None and not (isinstance(order, list) and order):
+            errors.append(
+                f"{label}: 'sort' has neither 'by' (the measure to sort on) nor 'order' "
+                f"(an explicit member list) - one of the two is required"
+            )
+
+
 def _validate_worksheets(
     worksheets: object,
     declared_fields: dict[str, set[str]],
@@ -581,43 +632,6 @@ def _validate_worksheets(
             _validate_reference(label, where, entry, available, source, errors)
         _validate_modifiers(label, worksheet, errors)
     return filled
-
-
-def _validate_modifiers(label: str, worksheet: dict, errors: list[str]) -> None:
-    """Reject modifier entries the builder would have to drop.
-
-    A filter with nothing to filter on, or a sort with nothing to sort by, is an entry the
-    assembler cannot render - and one Tableau would show no sign of. Naming it here is the
-    difference between "the filter is missing" and "the manifest row is incomplete".
-
-    Args:
-        label: The worksheet's error label.
-        worksheet: One ``worksheets`` entry.
-        errors: Accumulator for validation errors.
-    """
-    filters = worksheet.get("filters")
-    if isinstance(filters, list):
-        for index, entry in enumerate(filters):
-            if not isinstance(entry, dict):
-                errors.append(f"{label}: filters[{index}] must be an object with a 'field'")
-                continue
-            values = entry.get("values")
-            if not (isinstance(values, list) and values) and (
-                entry.get("min") is None and entry.get("max") is None
-            ):
-                errors.append(
-                    f"{label}: filters[{index}] has nothing to filter on - give it "
-                    f"'values' (a member list) or 'min'/'max' (a range)"
-                )
-
-    sort = worksheet.get("sort")
-    if isinstance(sort, dict):
-        order = sort.get("order")
-        if sort.get("by") is None and not (isinstance(order, list) and order):
-            errors.append(
-                f"{label}: 'sort' has neither 'by' (the measure to sort on) nor 'order' "
-                f"(an explicit member list) - one of the two is required"
-            )
 
 
 def _validate_objects(

--- a/skills/tableau-build/scripts/manifest.py
+++ b/skills/tableau-build/scripts/manifest.py
@@ -42,7 +42,12 @@ REQUIRED_KEYS: tuple[str, ...] = (
 CHART_TYPES = frozenset({
     "bar", "line", "area", "pie", "scatter", "map", "text", "table",
     "heatmap", "histogram", "treemap", "bullet", "gantt", "boxplot",
+    "dual-axis", "combo",
 })
+
+#: Chart types that overlay two measures on one axis pair - they need exactly two entries on
+#: the rows shelf, or the second axis (and the whole point of the chart) is missing.
+DUAL_AXIS_TYPES = frozenset({"dual-axis", "combo"})
 
 #: Dashboard action types (the Tableau constructs behind CONTRACT.md §6's vocabulary).
 ACTION_TYPES = frozenset({"filter", "highlight", "parameter", "set", "url"})
@@ -385,17 +390,20 @@ def _calculated_field_names(
 
 
 def _worksheet_field_references(worksheet: dict) -> list[tuple[str, object]]:
-    """Return the ``(where, entry)`` pairs a worksheet's shelves/encodings reference.
+    """Return the ``(where, entry)`` pairs a worksheet's fields are referenced from.
 
-    Each entry is either a bare field name (``"revenue"``) or an object carrying the
-    aggregation / date part the builder must apply
-    (``{"field": "revenue", "aggregation": "sum"}``).
+    Each entry is either a bare field name (``"revenue"``) or an object carrying what the
+    builder must apply (``{"field": "revenue", "aggregation": "sum"}``). Shelves and
+    encodings place fields on the view; ``filters``, ``sort``, ``tooltip`` and
+    ``number_formats`` are the optional modifiers that any chart type may carry, and their
+    fields have to resolve just as strictly - a filter on a field that does not exist is a
+    filter Tableau silently ignores.
 
     Args:
         worksheet: One ``worksheets`` entry.
 
     Returns:
-        ``(where, entry)`` pairs, where ``where`` is e.g. ``shelves.rows`` / ``encodings.color``.
+        ``(where, entry)`` pairs, where ``where`` is e.g. ``shelves.rows`` / ``sort.by``.
     """
     references: list[tuple[str, object]] = []
     shelves = worksheet.get("shelves")
@@ -407,6 +415,18 @@ def _worksheet_field_references(worksheet: dict) -> list[tuple[str, object]]:
     if isinstance(encodings, dict):
         for encoding, entry in encodings.items():
             references.append((f"encodings.{encoding}", entry))
+
+    for key in ("filters", "tooltip", "number_formats"):
+        entries = worksheet.get(key)
+        if isinstance(entries, list):
+            for index, entry in enumerate(entries):
+                references.append((f"{key}[{index}]", entry))
+
+    sort = worksheet.get("sort")
+    if isinstance(sort, dict):
+        references.append(("sort", sort))
+        if sort.get("by") is not None:
+            references.append(("sort.by", sort["by"]))
     return references
 
 
@@ -425,6 +445,7 @@ def _validate_reference(
         source: The datasource name, for the message.
         errors: Accumulator for validation errors.
     """
+    bin_size: object = None
     if isinstance(entry, dict):
         field_name = _bare_field(entry.get("field"))
         # A JSON null (or any other non-string) means "not specified", same as a missing
@@ -433,6 +454,7 @@ def _validate_reference(
         aggregation = raw_aggregation.strip().lower() if isinstance(raw_aggregation, str) else ""
         raw_date_part = entry.get("date_part", "")
         date_part = raw_date_part.strip().lower() if isinstance(raw_date_part, str) else ""
+        bin_size = entry.get("bin")
     else:
         field_name, aggregation, date_part = _bare_field(entry), "", ""
 
@@ -461,6 +483,13 @@ def _validate_reference(
         errors.append(
             f"{label}: {where} '{field_name}' has unknown date_part '{date_part}' "
             f"(expected one of: {', '.join(sorted(DATE_PARTS))})"
+        )
+    if bin_size is not None and not (
+        isinstance(bin_size, (int, float)) and not isinstance(bin_size, bool) and bin_size > 0
+    ):
+        errors.append(
+            f"{label}: {where} '{field_name}' has a 'bin' of {bin_size!r} - a bin width "
+            f"must be a positive number (e.g. 500 for a histogram of 0-500, 500-1000, ...)"
         )
 
 
@@ -514,6 +543,15 @@ def _validate_worksheets(
                 f"{label}: unknown chart_type '{chart_type}' "
                 f"(expected one of: {', '.join(sorted(CHART_TYPES))})"
             )
+        elif chart_type in DUAL_AXIS_TYPES:
+            shelves = worksheet.get("shelves")
+            rows = shelves.get("rows") if isinstance(shelves, dict) else None
+            if not (isinstance(rows, list) and len(rows) == 2):
+                errors.append(
+                    f"{label}: chart_type '{chart_type}' needs exactly two measures on "
+                    f"'shelves.rows' (the two axes to overlay); got "
+                    f"{len(rows) if isinstance(rows, list) else 0}"
+                )
 
         element_id = str(worksheet.get("element_id", "")).strip()
         if not element_id:
@@ -541,7 +579,45 @@ def _validate_worksheets(
         available = declared_fields[source] | calculated.get(source, set())
         for where, entry in _worksheet_field_references(worksheet):
             _validate_reference(label, where, entry, available, source, errors)
+        _validate_modifiers(label, worksheet, errors)
     return filled
+
+
+def _validate_modifiers(label: str, worksheet: dict, errors: list[str]) -> None:
+    """Reject modifier entries the builder would have to drop.
+
+    A filter with nothing to filter on, or a sort with nothing to sort by, is an entry the
+    assembler cannot render - and one Tableau would show no sign of. Naming it here is the
+    difference between "the filter is missing" and "the manifest row is incomplete".
+
+    Args:
+        label: The worksheet's error label.
+        worksheet: One ``worksheets`` entry.
+        errors: Accumulator for validation errors.
+    """
+    filters = worksheet.get("filters")
+    if isinstance(filters, list):
+        for index, entry in enumerate(filters):
+            if not isinstance(entry, dict):
+                errors.append(f"{label}: filters[{index}] must be an object with a 'field'")
+                continue
+            values = entry.get("values")
+            if not (isinstance(values, list) and values) and (
+                entry.get("min") is None and entry.get("max") is None
+            ):
+                errors.append(
+                    f"{label}: filters[{index}] has nothing to filter on - give it "
+                    f"'values' (a member list) or 'min'/'max' (a range)"
+                )
+
+    sort = worksheet.get("sort")
+    if isinstance(sort, dict):
+        order = sort.get("order")
+        if sort.get("by") is None and not (isinstance(order, list) and order):
+            errors.append(
+                f"{label}: 'sort' has neither 'by' (the measure to sort on) nor 'order' "
+                f"(an explicit member list) - one of the two is required"
+            )
 
 
 def _validate_objects(

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -20,9 +20,9 @@ Two authorities, deliberately kept apart:
 
 The manifest's own ``fields[].type`` is validated but not read here: one authority, no drift.
 
-Scope: datasources, placeholder worksheets, a one-zone dashboard sized from the layout
-canvas, windows, and version targeting. Worksheet bodies (shelves, encodings, marks) and the
-dashboard's zone tree are the next ticket.
+Scope: datasources, worksheet bodies (:mod:`worksheet` owns the shelves, encodings, marks
+and styling), a one-zone dashboard sized from the layout canvas, windows, and version
+targeting. The dashboard's zone tree is the next ticket.
 """
 
 from __future__ import annotations
@@ -32,6 +32,7 @@ import uuid
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 
+import worksheet
 from manifest import documented_field_types
 
 # --- Version targeting (CONTRACT.md §2 values) -------------------------------
@@ -300,7 +301,8 @@ def _render_metadata_records(
 
 
 def _render_datasource(
-    parent: ET.Element, name: str, csv_name: str, columns: list[Column], version: str
+    parent: ET.Element, name: str, csv_name: str, columns: list[Column], version: str,
+    derived: list[worksheet.FieldRef],
 ) -> None:
     """Render one inline, live-connection datasource over a single CSV.
 
@@ -310,6 +312,9 @@ def _render_datasource(
         csv_name: The CSV the datasource reads.
         columns: The physical schema, rendered into all four required locations.
         version: The workbook document version (the datasource carries it too).
+        derived: Calculated and binned columns the worksheets introduce. They are not in
+            the CSV, so they appear only among the UI-level columns - but they must appear
+            *here* as well as in each worksheet, or Tableau drops them on save.
     """
     datasource = ET.SubElement(parent, "datasource", {
         "caption": name,
@@ -349,6 +354,8 @@ def _render_datasource(
             "role": facts.role,
             "type": facts.type_attr,
         })
+    for reference in derived:
+        worksheet.render_column(datasource, reference)
     ET.SubElement(datasource, "layout", {
         "dim-ordering": "alphabetic", "measure-ordering": "alphabetic",
         "show-structure": "true",
@@ -364,32 +371,6 @@ def _render_datasource(
 
 
 # --- Worksheets, dashboard, windows --------------------------------------------
-
-def _render_worksheet(parent: ET.Element, name: str) -> None:
-    """Render a placeholder worksheet body (the shelves/marks are the next ticket).
-
-    Args:
-        parent: The ``<worksheets>`` element.
-        name: The sheet name, which its window must match exactly.
-    """
-    # TODO(next ticket): fill the body from the manifest - datasource-dependencies, the
-    # column-instances, the mark class, and the rows/cols shelf text.
-    worksheet = ET.SubElement(parent, "worksheet", {"name": name})
-    table = ET.SubElement(worksheet, "table")
-    view = ET.SubElement(table, "view")
-    ET.SubElement(view, "datasources")
-    ET.SubElement(view, "aggregation", {"value": "true"})
-    ET.SubElement(table, "style")
-    panes = ET.SubElement(table, "panes")
-    pane = ET.SubElement(
-        panes, "pane", {"selection-relaxation-option": "selection-relaxation-allow"}
-    )
-    ET.SubElement(ET.SubElement(pane, "view"), "breakdown", {"value": "auto"})
-    ET.SubElement(pane, "mark", {"class": "Automatic"})
-    ET.SubElement(table, "rows")
-    ET.SubElement(table, "cols")
-    ET.SubElement(worksheet, "simple-id", {"uuid": simple_id("worksheet", name)})
-
 
 def _render_zone_style(parent: ET.Element, margin: str) -> None:
     """Append the four-format ``<zone-style>`` block Tableau writes on every zone."""
@@ -433,21 +414,22 @@ def _render_dashboard(parent: ET.Element, canvas: dict, root_zone_id: str) -> No
 
 
 def _render_windows(
-    parent: ET.Element, worksheet_names: list[str], root_zone_id: str
+    parent: ET.Element, plans: list[worksheet.WorksheetPlan], root_zone_id: str
 ) -> None:
     """Render one hidden window per worksheet plus the dashboard window.
 
     Args:
         parent: The ``<workbook>`` element.
-        worksheet_names: The sheet names, in manifest order.
+        plans: The resolved worksheets, in manifest order.
         root_zone_id: The zone the dashboard window opens on.
     """
     windows = ET.SubElement(parent, "windows", {"source-height": "30"})
+    worksheet_names = [plan.name for plan in plans]
 
-    for name in worksheet_names:
+    for plan in plans:
         # hidden: these sheets only ever appear embedded in the dashboard.
         window = ET.SubElement(
-            windows, "window", {"class": "worksheet", "hidden": "true", "name": name}
+            windows, "window", {"class": "worksheet", "hidden": "true", "name": plan.name}
         )
         cards = ET.SubElement(window, "cards")
         left = ET.SubElement(cards, "edge", {"name": "left"})
@@ -460,7 +442,17 @@ def _render_windows(
             ET.SubElement(
                 ET.SubElement(top, "strip", {"size": size}), "card", {"type": card_type}
             )
-        ET.SubElement(window, "simple-id", {"uuid": simple_id("window", name)})
+        # A colour- or size-encoded chart with no legend renders, but reads as broken.
+        legends = worksheet.legend_cards(plan)
+        if legends:
+            right_strip = ET.SubElement(
+                ET.SubElement(cards, "edge", {"name": "right"}), "strip", {"size": "160"}
+            )
+            for card_type, column, pane_id in legends:
+                ET.SubElement(right_strip, "card", {
+                    "pane-specification-id": pane_id, "param": column, "type": card_type,
+                })
+        ET.SubElement(window, "simple-id", {"uuid": simple_id("window", plan.name)})
 
     dashboard_window = ET.SubElement(windows, "window", {
         "class": "dashboard", "maximized": "true", "name": DASHBOARD_NAME,
@@ -495,10 +487,114 @@ def workbook_version(target_tableau_version: str) -> str:
     )
 
 
+def _build_resolvers(
+    manifest_document: dict, field_types: dict[str, dict[str, str]]
+) -> dict[str, worksheet.FieldResolver]:
+    """Build one :class:`worksheet.FieldResolver` per declared datasource.
+
+    Args:
+        manifest_document: The parsed build manifest.
+        field_types: ``{csv: {field: type}}`` from ``DATA-MODEL.md``.
+
+    Returns:
+        ``{datasource name: resolver}``. Each resolver knows the datasource's federated id,
+        its CSV's field types, and its calculated fields' formulas.
+    """
+    calculated: dict[str, dict[str, tuple[str, str]]] = {}
+    for entry in manifest_document.get("calculated_fields", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name", "")).strip()
+        source = str(entry.get("datasource", "")).strip()
+        if not (name and source):
+            continue
+        # No 'type' means a numeric result - the overwhelmingly common calculated field.
+        calculated.setdefault(source, {})[name] = (
+            str(entry.get("formula", "")).strip(),
+            str(entry.get("type", "")).strip().lower() or "real",
+        )
+
+    # The resolver only needs the role and the UI type from each DATA-MODEL.md type; passing
+    # a plain mapping keeps :mod:`worksheet` free of an import back into this module.
+    type_facts = {
+        datatype: (facts.role, facts.type_attr) for datatype, facts in TYPE_FACTS.items()
+    }
+    resolvers: dict[str, worksheet.FieldResolver] = {}
+    for entry in manifest_document.get("datasources", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name", "")).strip()
+        csv_name = str(entry.get("csv", "")).strip()
+        resolvers[name] = worksheet.FieldResolver(
+            datasource_id(name),
+            name,
+            field_types.get(csv_name, {}),
+            calculated.get(name, {}),
+            type_facts,
+        )
+    return resolvers
+
+
+def _plan_worksheets(
+    manifest_document: dict, resolvers: dict[str, worksheet.FieldResolver]
+) -> list[tuple[str, worksheet.WorksheetPlan]]:
+    """Resolve every manifest worksheet, paired with its datasource name."""
+    plans: list[tuple[str, worksheet.WorksheetPlan]] = []
+    for entry in manifest_document.get("worksheets", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        source = str(entry.get("datasource", "")).strip()
+        resolver = resolvers.get(source)
+        if resolver is None:  # validate_manifest already named this worksheet
+            continue
+        plans.append((source, worksheet.plan_worksheet(entry, resolver)))
+    return plans
+
+
+def _collect_derived_columns(
+    manifest_document: dict,
+    resolvers: dict[str, worksheet.FieldResolver],
+    plans: list[tuple[str, worksheet.WorksheetPlan]],
+) -> dict[str, list[worksheet.FieldRef]]:
+    """Collect the non-CSV columns each datasource must declare.
+
+    Two kinds: the manifest's ``calculated_fields``, and the binned columns a histogram
+    introduces on a shelf. Both are declared at the datasource level as well as inside each
+    worksheet that uses them - Tableau drops a worksheet-only calculation on save.
+
+    Args:
+        manifest_document: The parsed build manifest.
+        resolvers: The per-datasource resolvers.
+        plans: The resolved worksheets.
+
+    Returns:
+        ``{datasource name: [FieldRef]}``, de-duplicated and in a stable order.
+    """
+    derived: dict[str, dict[str, worksheet.FieldRef]] = {}
+    for entry in manifest_document.get("calculated_fields", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        source = str(entry.get("datasource", "")).strip()
+        resolver = resolvers.get(source)
+        name = str(entry.get("name", "")).strip()
+        if resolver is None or not name:
+            continue
+        reference = resolver.reference(name)
+        if reference is not None:
+            derived.setdefault(source, {}).setdefault(reference.column_name, reference)
+
+    for source, plan in plans:
+        for reference in worksheet.bin_columns(plan):
+            derived.setdefault(source, {}).setdefault(reference.column_name, reference)
+
+    return {source: list(columns.values()) for source, columns in derived.items()}
+
+
 def render_workbook(
     manifest_document: dict,
     data_model_text: str,
     csv_headers: dict[str, list[str]],
+    design_tokens_text: str = "",
 ) -> str:
     """Assemble a validated build manifest into ``.twb`` XML.
 
@@ -511,12 +607,15 @@ def render_workbook(
         manifest_document: The parsed, validated ``build-manifest.json``.
         data_model_text: The contents of ``DATA-MODEL.md`` (the type authority).
         csv_headers: ``{csv filename: header row}`` - the physical schema and its order.
+        design_tokens_text: The contents of ``DESIGN-TOKENS.md``; ``""`` when the analyst
+            skipped branding, in which case Tableau's own defaults apply.
 
     Returns:
         The workbook XML, ready to write as ``dashboard.twb``.
     """
     target = str(manifest_document.get("target_tableau_version", "")).strip()
     version = workbook_version(target)
+    tokens = worksheet.parse_design_tokens(design_tokens_text)
 
     workbook = ET.Element("workbook", {
         "original-version": version,
@@ -531,30 +630,41 @@ def render_workbook(
         ET.SubElement(format_manifest, flag)
 
     field_types = documented_field_types(data_model_text)
+    resolvers = _build_resolvers(manifest_document, field_types)
+    plans = _plan_worksheets(manifest_document, resolvers)
+    derived = _collect_derived_columns(manifest_document, resolvers, plans)
+
     datasources = ET.SubElement(workbook, "datasources")
     for entry in manifest_document.get("datasources", []):
         csv_name = str(entry.get("csv", "")).strip()
+        name = str(entry.get("name", "")).strip()
         _render_datasource(
             datasources,
-            str(entry.get("name", "")).strip(),
+            name,
             csv_name,
             _columns_for(csv_headers.get(csv_name, []), field_types.get(csv_name, {})),
             version,
+            derived.get(name, []),
         )
 
-    worksheet_names = [
-        str(worksheet.get("name", "")).strip()
-        for worksheet in manifest_document.get("worksheets", [])
-    ]
-    if worksheet_names:  # the XSD requires >=1 <worksheet>; omit the element otherwise
+    if any(plan.spec.geographic for _, plan in plans):
+        # A map needs its <mapsources> at *both* levels: the workbook's declares the source,
+        # each map worksheet's view references it. One without the other renders no basemap.
+        ET.SubElement(
+            ET.SubElement(workbook, "mapsources"), "mapsource", {"name": worksheet.MAPSOURCE_NAME}
+        )
+
+    if plans:  # the XSD requires >=1 <worksheet>; omit the element otherwise
         worksheets = ET.SubElement(workbook, "worksheets")
-        for name in worksheet_names:
-            _render_worksheet(worksheets, name)
+        for _, plan in plans:
+            worksheet.render_worksheet(
+                worksheets, plan, tokens, simple_id("worksheet", plan.name)
+            )
 
     layout = manifest_document.get("layout")
     canvas = layout.get("canvas", {}) if isinstance(layout, dict) else {}
     _render_dashboard(ET.SubElement(workbook, "dashboards"), canvas, ROOT_ZONE_ID)
-    _render_windows(workbook, worksheet_names, ROOT_ZONE_ID)
+    _render_windows(workbook, [plan for _, plan in plans], ROOT_ZONE_ID)
 
     if target == TARGET_2026:
         explain_data = ET.SubElement(workbook, "explain-data", {
@@ -563,7 +673,7 @@ def render_workbook(
         ET.SubElement(explain_data, "explanation-types")
 
     ET.indent(workbook, space="  ")
-    return (
+    return worksheet.unwrap_cdata(
         "<?xml version='1.0' encoding='utf-8' ?>\n\n"
         + ET.tostring(workbook, encoding="unicode")
         + "\n"

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -50,7 +50,8 @@ _DEFAULT_WORKBOOK_VERSION = "18.1"
 SOURCE_BUILD = "2025.1.10 (20251.25.1121.1650)"
 
 #: The document-format feature flags, copied verbatim from a Tableau-saved workbook.
-#: Adding or removing one changes Tableau's behaviour - keep the set as-is.
+#: Adding or removing one changes Tableau's behaviour - keep the set as-is. Tableau writes
+#: them alphabetically, which is why :data:`SORT_FORMAT_FLAG` can just be sorted in.
 FORMAT_CHANGE_FLAGS: tuple[str, ...] = (
     "AccessibleZoneTabOrder",
     "AnimationOnByDefault",
@@ -64,6 +65,10 @@ FORMAT_CHANGE_FLAGS: tuple[str, ...] = (
     "WindowsPersistSimpleIdentifiers",
     "ZoneFriendlyName",
 )
+
+#: The extra flag a workbook containing a sorted worksheet carries
+#: (WORKSHEETS.md:512, seen in ``bar-chart-sorted.twb`` and ``custom-tooltip.twb``).
+SORT_FORMAT_FLAG = "SortTagCleanup"
 
 #: The single dashboard this ticket emits (the zone tree from ``layout.root`` is next).
 DASHBOARD_NAME = "Dashboard 1"
@@ -625,8 +630,13 @@ def render_workbook(
         "xmlns:user": "http://www.tableausoftware.com/xml/user",
     })
 
+    worksheet_entries = manifest_document.get("worksheets") or []
+    flags = FORMAT_CHANGE_FLAGS
+    if any(entry.get("sort") for entry in worksheet_entries):
+        flags = tuple(sorted(flags + (SORT_FORMAT_FLAG,)))
+
     format_manifest = ET.SubElement(workbook, "document-format-change-manifest")
-    for flag in FORMAT_CHANGE_FLAGS:
+    for flag in flags:
         ET.SubElement(format_manifest, flag)
 
     field_types = documented_field_types(data_model_text)

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -387,7 +387,7 @@ def _render_zone_style(parent: ET.Element, margin: str) -> None:
         ET.SubElement(zone_style, "format", {"attr": attribute, "value": value})
 
 
-def _render_dashboard(parent: ET.Element, canvas: dict, root_zone_id: str) -> None:
+def _render_dashboard(parent: ET.Element, canvas: dict, root_zone_id: str) -> set[str]:
     """Render the dashboard: its size from the mock's canvas, and one root zone.
 
     The zone *tree* (``layout.root``) is the next ticket; what this pins is the geometry
@@ -397,6 +397,11 @@ def _render_dashboard(parent: ET.Element, canvas: dict, root_zone_id: str) -> No
         parent: The ``<dashboards>`` element.
         canvas: The layout's ``canvas`` object (``width`` / ``height`` in px).
         root_zone_id: The id of the root zone (the dashboard window's ``active`` target).
+
+    Returns:
+        The names of the worksheets this dashboard embeds in a zone - empty until the zone
+        tree lands. :func:`_render_windows` hides exactly these, so a sheet that is embedded
+        nowhere keeps its tab instead of leaving the analyst a blank workbook.
     """
     dashboard = ET.SubElement(parent, "dashboard", {
         "enable-sort-zone-taborder": "true", "name": DASHBOARD_NAME,
@@ -413,29 +418,37 @@ def _render_dashboard(parent: ET.Element, canvas: dict, root_zone_id: str) -> No
         "w": ZONE_SPACE, "x": "0", "y": "0",
     })
     # TODO(next ticket): nest the manifest's layout.root tree inside this zone, one child
-    # zone per element id, with each worksheet zone naming its sheet.
+    # zone per element id, with each worksheet zone naming its sheet - and return those
+    # sheet names here, which is all _render_windows needs to start hiding tabs again.
     _render_zone_style(root_zone, ROOT_ZONE_MARGIN)  # zone-style is the zone's last child
     ET.SubElement(dashboard, "simple-id", {"uuid": simple_id("dashboard", DASHBOARD_NAME)})
+    return set()
 
 
 def _render_windows(
-    parent: ET.Element, plans: list[worksheet.WorksheetPlan], root_zone_id: str
+    parent: ET.Element,
+    plans: list[worksheet.WorksheetPlan],
+    root_zone_id: str,
+    embedded: set[str],
 ) -> None:
-    """Render one hidden window per worksheet plus the dashboard window.
+    """Render one window per worksheet plus the dashboard window.
 
     Args:
         parent: The ``<workbook>`` element.
         plans: The resolved worksheets, in manifest order.
         root_zone_id: The zone the dashboard window opens on.
+        embedded: Names of worksheets the dashboard embeds in a zone; only those get
+            ``hidden='true'``. Hiding a sheet no zone shows makes it unreachable - Tableau
+            renders no tab for it, so the analyst opens a workbook with nothing in it.
     """
     windows = ET.SubElement(parent, "windows", {"source-height": "30"})
     worksheet_names = [plan.name for plan in plans]
 
     for plan in plans:
-        # hidden: these sheets only ever appear embedded in the dashboard.
-        window = ET.SubElement(
-            windows, "window", {"class": "worksheet", "hidden": "true", "name": plan.name}
-        )
+        attributes = {"class": "worksheet", "name": plan.name}
+        if plan.name in embedded:
+            attributes["hidden"] = "true"
+        window = ET.SubElement(windows, "window", dict(sorted(attributes.items())))
         cards = ET.SubElement(window, "cards")
         left = ET.SubElement(cards, "edge", {"name": "left"})
         left_strip = ET.SubElement(left, "strip", {"size": "160"})
@@ -673,8 +686,10 @@ def render_workbook(
 
     layout = manifest_document.get("layout")
     canvas = layout.get("canvas", {}) if isinstance(layout, dict) else {}
-    _render_dashboard(ET.SubElement(workbook, "dashboards"), canvas, ROOT_ZONE_ID)
-    _render_windows(workbook, [plan for _, plan in plans], ROOT_ZONE_ID)
+    embedded = _render_dashboard(
+        ET.SubElement(workbook, "dashboards"), canvas, ROOT_ZONE_ID
+    )
+    _render_windows(workbook, [plan for _, plan in plans], ROOT_ZONE_ID, embedded)
 
     if target == TARGET_2026:
         explain_data = ET.SubElement(workbook, "explain-data", {

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -194,16 +194,17 @@ def is_aggregate_formula(formula: str) -> bool:
     """
     return bool(formula) and _AGGREGATE_CALL.search(formula) is not None
 
+
 #: manifest date_part -> (prefix, derivation). ``date`` is the exact date: no truncation,
-#: but still continuous, which is what makes a line/area chart draw a line.
+#: but still continuous, which is what makes a line/area chart draw a line. Only the levels
+#: WORKSHEETS.md documents from real Tableau output are here - ``manifest.DATE_PARTS`` reads
+#: this table, so an hour/minute request fails validation rather than guessing a prefix.
 DATE_PART_DERIVATIONS: dict[str, tuple[str, str]] = {
     "year": ("tyr", "Year-Trunc"),
     "quarter": ("tqr", "Quarter-Trunc"),
     "month": ("tmn", "Month-Trunc"),
     "week": ("twk", "Week-Trunc"),
     "day": ("tdy", "Day-Trunc"),
-    "hour": ("thr", "Hour-Trunc"),
-    "minute": ("tmi", "Minute-Trunc"),
     "date": ("none", "None"),
 }
 
@@ -809,14 +810,14 @@ def _render_calculation(column: ET.Element, reference: FieldRef) -> None:
             "decimals": BIN_DECIMALS,
             "formula": f"[{reference.bin_source}]",
             "peg": "0",
-            "size": _number(reference.bin_size),
+            "size": _bin_size_text(reference.bin_size),
         })
     elif reference.formula:
         ET.SubElement(column, "calculation", {"class": "tableau", "formula": reference.formula})
 
 
-def _number(value: float) -> str:
-    """Render a manifest number without a trailing ``.0`` (Tableau writes ``500``)."""
+def _bin_size_text(value: float) -> str:
+    """Render a bin size the way Tableau writes it - no trailing ``.0`` (``500``, not ``500.0``)."""
     return str(int(value)) if float(value).is_integer() else str(value)
 
 

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -1049,15 +1049,18 @@ def _render_pane(
 def _render_tooltip(
     parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens
 ) -> None:
-    """Render a ``<customized-tooltip>``: ``label`` / newline / value, one pair per line."""
+    """Render a ``<customized-tooltip>``: one ``label: value`` line per tooltip pair.
+
+    The break goes *between* pairs only - a break after the label pushed every value onto
+    its own line, which is what made the rendered tooltip look double-spaced.
+    """
     formatted = ET.SubElement(
         ET.SubElement(parent, "customized-tooltip"), "formatted-text"
     )
     for index, (label, reference) in enumerate(plan.tooltip):
         if index:  # separate this pair from the previous one
             _render_run(formatted, TOOLTIP_BREAK, tokens, tokens.title_size)
-        _render_run(formatted, f"{label}:", tokens, tokens.title_size, bold=True)
-        _render_run(formatted, TOOLTIP_BREAK, tokens, tokens.title_size)
+        _render_run(formatted, f"{label}: ", tokens, tokens.title_size, bold=True)
         _render_run(
             formatted,
             cdata(f"<{plan.reference_of(reference)}>"),

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -1,0 +1,1155 @@
+"""Worksheet bodies for the tableau-build assembler (CONTRACT.md step 8).
+
+:mod:`twb` owns the workbook shell - datasources, dashboard, windows. This module owns what
+goes *inside* a ``<worksheet>``: the mark class, the shelves, the encodings, the sorts, the
+filters and the design-token styling. Every one of the 15 validated legacy patterns (bar,
+sorted / filtered / styled bar, stacked bar, line, area, pie, scatter, text table, KPI card,
+histogram, map, dual axis, combo, custom tooltip) is produced from manifest fields here -
+nothing is copy-pasted from a snippet, so no snippet's field names, datasource ids or UUIDs
+can leak into an analyst's workbook.
+
+The 15 patterns are **not** 15 chart types. Four of them (sorted, filtered, styled, custom
+tooltip) are modifiers that apply to *any* chart, and "stacked bar" is a bar with a colour
+encoding. So the shape here is a :data:`CHART_SPECS` table of what a chart type changes
+(mark class, pane count, whether the marks carry labels) crossed with modifier renderers that
+each read one optional manifest key. A new chart type is a row in the table, not a function.
+
+Everything is pure and stdlib-only: text in, XML elements out, no filesystem.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from typing import Optional
+
+# --- CDATA -------------------------------------------------------------------
+# ponytail: ElementTree cannot emit CDATA, and Tableau *requires* it around field
+# references in <run> elements (entity-encoded refs render as literal text, which the
+# semantic validator rejects). A sentinel pair plus one regex at serialisation time is far
+# cheaper than a custom serializer.
+
+#: Private-use characters wrapped around text that must serialise as a CDATA section.
+#: Written as escapes, not literals: the source has to survive a cp1252 console.
+CDATA_OPEN = "\ue000"
+CDATA_CLOSE = "\ue001"
+
+_CDATA_SPAN = re.compile(f"{CDATA_OPEN}(.*?){CDATA_CLOSE}", re.DOTALL)
+_ENTITIES = (("&lt;", "<"), ("&gt;", ">"), ("&quot;", '"'), ("&apos;", "'"), ("&amp;", "&"))
+
+
+def unwrap_cdata(xml_text: str) -> str:
+    """Turn every sentinel-marked span in serialised XML into a real CDATA section.
+
+    Args:
+        xml_text: The output of ``ET.tostring``, still carrying the sentinels.
+
+    Returns:
+        The same XML with each span rewritten as ``<![CDATA[...]]>`` and the escaping
+        ElementTree applied inside it undone.
+    """
+    def _restore(match: re.Match) -> str:
+        inner = match.group(1)
+        for entity, character in _ENTITIES:  # &amp; last: it is the escape of the escapes
+            inner = inner.replace(entity, character)
+        return f"<![CDATA[{inner}]]>"
+
+    return _CDATA_SPAN.sub(_restore, xml_text)
+
+
+def cdata(text: str) -> str:
+    """Wrap ``text`` so :func:`unwrap_cdata` emits it as a CDATA section."""
+    return f"{CDATA_OPEN}{text}{CDATA_CLOSE}"
+
+
+# --- Design tokens ------------------------------------------------------------
+
+#: Tableau's own defaults, used for any token DESIGN-TOKENS.md does not carry (and for every
+#: token when the file is absent) - "neutral" means Tableau's look, not an invented one.
+DEFAULT_FONT = "Tableau Book"
+DEFAULT_TITLE_SIZE = 12
+DEFAULT_TITLE_COLOR = "#000000"
+DEFAULT_KPI_SIZE = 22
+
+_HEX = re.compile(r"#[0-9a-fA-F]{3,8}\b")
+_SIZE = re.compile(r"(\d+)\s*px", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class DesignTokens:
+    """The slice of DESIGN-TOKENS.md a worksheet body can actually apply.
+
+    Tableau styles a *worksheet* with a font family, a title run, and cell/axis formats.
+    The palette's series colours are deliberately not mapped onto marks: a colour palette
+    binds hex values to concrete data members (``<map to='#...'><bucket>"West"</bucket>``),
+    and the builder does not know the data's members. Colour therefore stays with Tableau's
+    default palette and the tokens drive type.
+
+    Attributes:
+        font_family: Body font for the whole worksheet.
+        title_size: Chart-title point size.
+        title_color: Chart-title colour, lower-cased hex.
+        kpi_size: Point size for a KPI card's big number.
+        present: Whether a DESIGN-TOKENS.md was actually supplied.
+    """
+
+    font_family: str = DEFAULT_FONT
+    title_size: int = DEFAULT_TITLE_SIZE
+    title_color: str = DEFAULT_TITLE_COLOR
+    kpi_size: int = DEFAULT_KPI_SIZE
+    present: bool = False
+
+
+def parse_design_tokens(tokens_text: str) -> DesignTokens:
+    """Read the typography tokens out of a DESIGN-TOKENS.md.
+
+    The parse is tolerant by design (the file is prose an agent authored from a template):
+    it looks for the ``- **Font family**:`` and ``- **Chart title**:`` bullets and takes the
+    first font name / px size / hex colour on each. Anything it cannot find keeps its
+    Tableau default.
+
+    Args:
+        tokens_text: The contents of a ``DESIGN-TOKENS.md`` (``""`` when absent).
+
+    Returns:
+        The parsed :class:`DesignTokens`; ``present`` is False for empty input.
+    """
+    if not tokens_text.strip():
+        return DesignTokens()
+
+    font, title_size, title_color = DEFAULT_FONT, DEFAULT_TITLE_SIZE, DEFAULT_TITLE_COLOR
+    for raw_line in tokens_text.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("-"):
+            continue
+        label, _, value = line.lstrip("- ").partition(":")
+        label = label.strip().strip("*").lower()
+        value = value.strip()
+        if not value or value.startswith("["):  # an unfilled template placeholder
+            continue
+
+        if label == "font family":
+            font = value.strip("`*")
+        elif label == "chart title":
+            size = _SIZE.search(value)
+            if size:
+                title_size = int(size.group(1))
+            color = _HEX.search(value)
+            if color:
+                title_color = color.group(0).lower()
+
+    return DesignTokens(
+        font_family=font,
+        title_size=title_size,
+        title_color=title_color,
+        kpi_size=max(title_size + 8, DEFAULT_KPI_SIZE),
+        present=True,
+    )
+
+
+# --- Field references ----------------------------------------------------------
+# A shelf/encoding entry names a field; Tableau needs a <column>, a <column-instance>, and a
+# qualified reference for it, all three consistent. These tables are the single place the
+# naming rules live.
+
+#: manifest aggregation -> (column-instance prefix, ``derivation`` attribute).
+AGGREGATION_DERIVATIONS: dict[str, tuple[str, str]] = {
+    "sum": ("sum", "Sum"),
+    "avg": ("avg", "Avg"),
+    "min": ("min", "Min"),
+    "max": ("max", "Max"),
+    "count": ("cnt", "Count"),
+    "countd": ("ctd", "CountD"),
+    "median": ("med", "Median"),
+    "attr": ("attr", "Attribute"),
+    "none": ("none", "None"),
+}
+
+#: Aggregations that turn any field into a continuous measure on the shelf.
+_AGGREGATING = frozenset({"sum", "avg", "min", "max", "count", "countd", "median"})
+
+#: A calculated field that already aggregates cannot be aggregated again - ``SUM()`` of
+#: ``SUM([profit]) / SUM([revenue])`` is an error Tableau refuses at load. Such a field goes
+#: on a shelf as-is, which Tableau records as the ``User`` derivation.
+USER_DERIVATION = ("usr", "User")
+
+_AGGREGATE_CALL = re.compile(
+    r"\b(SUM|AVG|MIN|MAX|COUNT|COUNTD|MEDIAN|ATTR|STDEV|STDEVP|VAR|VARP|PERCENTILE"
+    r"|CORR|COVAR|COVARP|TOTAL|WINDOW_\w+|RUNNING_\w+)\s*\(",
+    re.IGNORECASE,
+)
+
+
+def is_aggregate_formula(formula: str) -> bool:
+    """Return whether a calculated field's formula already aggregates.
+
+    Args:
+        formula: The calculation's Tableau formula.
+
+    Returns:
+        True when the formula calls an aggregate function, so the field must reach a shelf
+        un-aggregated. A row-level formula (``[quantity] * [unit_price]``) returns False and
+        is treated like any other measure.
+    """
+    return bool(formula) and _AGGREGATE_CALL.search(formula) is not None
+
+#: manifest date_part -> (prefix, derivation). ``date`` is the exact date: no truncation,
+#: but still continuous, which is what makes a line/area chart draw a line.
+DATE_PART_DERIVATIONS: dict[str, tuple[str, str]] = {
+    "year": ("tyr", "Year-Trunc"),
+    "quarter": ("tqr", "Quarter-Trunc"),
+    "month": ("tmn", "Month-Trunc"),
+    "week": ("twk", "Week-Trunc"),
+    "day": ("tdy", "Day-Trunc"),
+    "hour": ("thr", "Hour-Trunc"),
+    "minute": ("tmi", "Minute-Trunc"),
+    "date": ("none", "None"),
+}
+
+#: The column-instance name's trailing key, per instance type.
+_TYPE_SUFFIX = {"quantitative": "qk", "nominal": "nk", "ordinal": "ok"}
+
+#: Tableau's built-in pivot fields, referenced qualified but never declared.
+MEASURE_NAMES = "[:Measure Names]"
+
+#: The basemap a map worksheet draws on. Declared at the workbook level *and* in the view.
+MAPSOURCE_NAME = "Tableau"
+
+#: Tableau's generated geographic fields - a map's shelves and geometry encoding.
+GENERATED_LONGITUDE = "[Longitude (generated)]"
+GENERATED_LATITUDE = "[Latitude (generated)]"
+GENERATED_GEOMETRY = "[Geometry (generated)]"
+
+#: What a binned column looks like: always an integer dimension, sliced ordinally.
+BIN_DATATYPE = "integer"
+#: Decimal places Tableau records on a bin calculation.
+BIN_DECIMALS = "2"
+
+
+def caption_for(field_name: str) -> str:
+    """Return the UI caption for a field name (``order_date`` -> ``Order Date``)."""
+    return field_name.replace("_", " ").title()
+
+
+@dataclass(frozen=True)
+class FieldRef:
+    """One resolved shelf/encoding entry: the column, its instance, and how to name both.
+
+    Attributes:
+        field_name: The bare field name from the manifest.
+        datatype: The Tableau datatype of the underlying column.
+        role: ``dimension`` / ``measure``.
+        column_type: The ``type`` attribute of the ``<column>``.
+        instance_type: The ``type`` attribute of the ``<column-instance>``.
+        prefix: The instance-name prefix (``sum``, ``tmn``, ``none``, ...).
+        derivation: The instance's ``derivation`` attribute.
+        formula: A calculated field's formula, else ``""``.
+        bin_size: Bin width when the entry asked for a binned column, else ``None``.
+        bin_source: The measure a bin is computed from, else ``""``.
+    """
+
+    field_name: str
+    datatype: str
+    role: str
+    column_type: str
+    instance_type: str
+    prefix: str
+    derivation: str
+    formula: str = ""
+    bin_size: Optional[float] = None
+    bin_source: str = ""
+
+    @property
+    def column_name(self) -> str:
+        """str: The bracketed column name (``[revenue]``, ``[Revenue (bin)]``)."""
+        return f"[{self.field_name}]"
+
+    @property
+    def instance_name(self) -> str:
+        """str: The bracketed column-instance name (``[sum:revenue:qk]``)."""
+        return f"[{self.prefix}:{self.field_name}:{_TYPE_SUFFIX[self.instance_type]}]"
+
+    @property
+    def caption(self) -> str:
+        """str: The caption Tableau shows for the column.
+
+        A bin's name is already the caption (``Revenue (bin)``); title-casing it would
+        turn the ``(bin)`` marker into ``(Bin)`` and stop matching the column name.
+        """
+        return self.field_name if self.bin_size is not None else caption_for(self.field_name)
+
+
+class FieldResolver:
+    """Turns manifest shelf/encoding entries into :class:`FieldRef`s for one datasource.
+
+    Args:
+        datasource_id: The ``federated.*`` id every reference is qualified with.
+        datasource_caption: The datasource's manifest name, as the view declares it.
+        field_types: ``{field name: DATA-MODEL.md type}`` for the datasource's CSV.
+        calculated: ``{name: (formula, type)}`` for the datasource's calculated fields.
+        type_facts: ``{type: (role, column type)}`` - :mod:`twb`'s type table, passed in so
+            this module stays free of a circular import.
+    """
+
+    def __init__(
+        self,
+        datasource_id: str,
+        datasource_caption: str,
+        field_types: dict[str, str],
+        calculated: dict[str, tuple[str, str]],
+        type_facts: dict[str, tuple[str, str]],
+    ) -> None:
+        self.datasource_id = datasource_id
+        self.datasource_caption = datasource_caption
+        self.field_types = field_types
+        self.calculated = calculated
+        self.type_facts = type_facts
+
+    def qualify(self, name: str) -> str:
+        """Return a bracketed name qualified with the datasource (``[ds].[name]``)."""
+        return f"[{self.datasource_id}].{name}"
+
+    def reference(self, entry: object) -> Optional[FieldRef]:
+        """Resolve one shelf/encoding entry.
+
+        Args:
+            entry: A bare field name, or an object with ``field`` plus any of
+                ``aggregation`` / ``date_part`` / ``bin``.
+
+        Returns:
+            The resolved :class:`FieldRef`, or ``None`` when the entry names no field
+            (``manifest.validate_manifest`` has already rejected that case).
+        """
+        if isinstance(entry, dict):
+            field_name = str(entry.get("field", "")).strip().strip("[]").strip()
+            aggregation = _lower(entry.get("aggregation"))
+            date_part = _lower(entry.get("date_part"))
+            raw_bin = entry.get("bin")
+            bin_size = (
+                raw_bin
+                if isinstance(raw_bin, (int, float)) and not isinstance(raw_bin, bool)
+                else None
+            )
+        else:
+            field_name = str(entry or "").strip().strip("[]").strip()
+            aggregation, date_part, bin_size = "", "", None
+        if not field_name:
+            return None
+
+        formula, declared_type = self.calculated.get(field_name, ("", ""))
+        datatype = declared_type or self.field_types.get(field_name, "string")
+        role, column_type = self.type_facts.get(datatype, ("dimension", "nominal"))
+
+        if bin_size is not None:
+            # A bin is a *new* dimension column computed from the measure, not a derivation
+            # of it - hence its own name, datatype and ordinal slicing.
+            return FieldRef(
+                field_name=f"{caption_for(field_name)} (bin)",
+                datatype=BIN_DATATYPE,
+                role="dimension",
+                column_type="ordinal",
+                instance_type="ordinal",
+                prefix="none",
+                derivation="None",
+                bin_size=float(bin_size),
+                bin_source=field_name,
+            )
+
+        # An unknown aggregation / date part cannot reach here from a validated manifest;
+        # falling back to the un-derived instance keeps a direct call from crashing.
+        if date_part and datatype in {"date", "datetime"}:
+            prefix, derivation = DATE_PART_DERIVATIONS.get(date_part, ("none", "None"))
+            instance_type = "quantitative"
+        elif aggregation:
+            prefix, derivation = AGGREGATION_DERIVATIONS.get(aggregation, ("none", "None"))
+            instance_type = "quantitative" if aggregation in _AGGREGATING else column_type
+        elif is_aggregate_formula(formula):
+            prefix, derivation = USER_DERIVATION
+            instance_type = column_type
+        elif role == "measure":
+            # A measure on a shelf without an explicit aggregation is SUM - Tableau's own
+            # default, and what every spec row means by "revenue on Rows".
+            prefix, derivation, instance_type = "sum", "Sum", "quantitative"
+        else:
+            prefix, derivation, instance_type = "none", "None", column_type
+
+        return FieldRef(
+            field_name=field_name,
+            datatype=datatype,
+            role=role,
+            column_type=column_type,
+            instance_type=instance_type,
+            prefix=prefix,
+            derivation=derivation,
+            formula=formula,
+        )
+
+    def references(self, entries: object) -> list[FieldRef]:
+        """Resolve a shelf's list of entries, dropping any that name no field."""
+        if entries is None:
+            return []
+        raw = entries if isinstance(entries, list) else [entries]
+        return [ref for ref in (self.reference(entry) for entry in raw) if ref is not None]
+
+
+def _lower(value: object) -> str:
+    """Lower-case a manifest string value; anything else (``null``) reads as absent."""
+    return value.strip().lower() if isinstance(value, str) else ""
+
+
+# --- Chart types ---------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ChartSpec:
+    """What a chart type changes about an otherwise identical worksheet body.
+
+    Attributes:
+        mark_class: The ``<mark class='...'>`` for the single pane.
+        label_marks: Show mark labels (a text table's numbers, a pie's slice values).
+        kpi_card: Centre the cell text and render the text encoding as one big
+            number - the KPI card treatment.
+        dual: Two measures share one axis pair: 3 panes and an axis-sync style rule.
+        pane_marks: Per-pane mark classes for a dual chart (a combo's Bar then Line);
+            empty means every pane keeps ``mark_class``.
+        geographic: Shelves are Tableau's generated lat/long and the marks carry geometry.
+        empty_shelves: The chart puts nothing on Rows/Cols (pie, KPI card).
+    """
+
+    mark_class: str = "Automatic"
+    label_marks: bool = False
+    kpi_card: bool = False
+    dual: bool = False
+    pane_marks: tuple[str, ...] = ()
+    geographic: bool = False
+    empty_shelves: bool = False
+
+
+#: Every chart type the builder emits, and what it changes. The four legacy "chart types"
+#: that are really modifiers - sorted, filtered, styled, custom tooltip - are the optional
+#: ``sort`` / ``filters`` / design tokens / ``tooltip`` manifest keys, applicable to any row
+#: here; a stacked bar is ``bar`` with a ``color`` encoding.
+CHART_SPECS: dict[str, ChartSpec] = {
+    "bar": ChartSpec(),
+    "line": ChartSpec(),
+    "area": ChartSpec(mark_class="Area"),
+    "pie": ChartSpec(mark_class="Pie", label_marks=True, empty_shelves=True),
+    "scatter": ChartSpec(),
+    "map": ChartSpec(geographic=True),
+    "text": ChartSpec(label_marks=True, kpi_card=True, empty_shelves=True),
+    "table": ChartSpec(label_marks=True),
+    "heatmap": ChartSpec(mark_class="Square"),
+    "histogram": ChartSpec(),
+    "treemap": ChartSpec(mark_class="Square", label_marks=True),
+    "bullet": ChartSpec(mark_class="Bar"),
+    "gantt": ChartSpec(mark_class="Gantt"),
+    "boxplot": ChartSpec(mark_class="Circle"),
+    "dual-axis": ChartSpec(dual=True),
+    "combo": ChartSpec(dual=True, pane_marks=("Bar", "Line")),
+}
+
+#: Encoding names the builder emits, in the order Tableau writes them. An encoding the
+#: manifest names but this list does not is ignored rather than emitted blind.
+ENCODING_ORDER: tuple[str, ...] = (
+    "color", "size", "shape", "text", "lod", "wedge-size", "geometry", "tooltip",
+)
+
+#: Encodings that need a legend card on the window's right edge.
+LEGEND_ENCODINGS: tuple[str, ...] = ("color", "size", "shape")
+
+#: The pane attribute every snippet carries.
+PANE_RELAXATION = {"selection-relaxation-option": "selection-relaxation-allow"}
+
+#: Tableau's line break inside a formatted-text run: AE ligature + tab. Not ``\n``.
+TOOLTIP_BREAK = "\u00c6\t"
+
+
+# --- Worksheet parts ------------------------------------------------------------
+
+@dataclass(frozen=True)
+class FilterPlan:
+    """One resolved filter: the field, the members or bounds, and whether it is a context
+    filter (which runs before FIXED LODs and every other filter).
+
+    Attributes:
+        reference: The filtered field.
+        members: Explicit members for a categorical filter; empty for a range filter.
+        minimum: Lower bound of a range filter, or ``None``.
+        maximum: Upper bound of a range filter, or ``None``.
+        context: Whether Tableau evaluates it first.
+    """
+
+    reference: FieldRef
+    members: tuple[str, ...] = ()
+    minimum: Optional[str] = None
+    maximum: Optional[str] = None
+    context: bool = False
+
+
+@dataclass(frozen=True)
+class SortPlan:
+    """One resolved sort: computed (``by`` a measure) or manual (an explicit ``order``).
+
+    Attributes:
+        reference: The dimension being sorted.
+        by: The measure that determines the order, for a computed sort.
+        order: The explicit member order, for a manual sort.
+        direction: ``ASC`` or ``DESC``.
+    """
+
+    reference: FieldRef
+    by: Optional[FieldRef] = None
+    order: tuple[str, ...] = ()
+    direction: str = "DESC"
+
+
+@dataclass
+class WorksheetPlan:
+    """Everything one worksheet needs, resolved once and rendered from twice.
+
+    :func:`render_worksheet` writes the body; :func:`legend_cards` and :func:`bin_columns`
+    read the same plan for the window's legends and the datasource's derived columns. Every
+    field reference - including the ones behind filters, sorts and tooltips - is resolved
+    here, because :attr:`all_refs` is what declares them in ``<datasource-dependencies>``,
+    and a field Tableau finds referenced but not declared is a broken worksheet.
+
+    Attributes:
+        name: The Tableau sheet name.
+        spec: The chart type's :class:`ChartSpec`.
+        resolver: The datasource's :class:`FieldResolver`.
+        columns: Resolved Cols shelf entries.
+        rows: Resolved Rows shelf entries.
+        encodings: ``{encoding name: FieldRef}``.
+        filters: Resolved filters, in manifest order.
+        sort: The resolved sort, if any.
+        tooltip: ``(label, field)`` pairs for a custom tooltip template.
+        number_formats: ``(field, format pattern)`` pairs for the cell style rule.
+        axis_titles: ``{"rows"|"columns": title}`` overrides.
+        geo_role: A map's geographic semantic role, or ``""``.
+    """
+
+    name: str
+    spec: ChartSpec
+    resolver: FieldResolver
+    columns: list[FieldRef] = field(default_factory=list)
+    rows: list[FieldRef] = field(default_factory=list)
+    encodings: dict[str, FieldRef] = field(default_factory=dict)
+    filters: list[FilterPlan] = field(default_factory=list)
+    sort: Optional[SortPlan] = None
+    tooltip: list[tuple[str, FieldRef]] = field(default_factory=list)
+    number_formats: list[tuple[FieldRef, str]] = field(default_factory=list)
+    axis_titles: dict[str, str] = field(default_factory=dict)
+    geo_role: str = ""
+
+    def qualify(self, name: str) -> str:
+        """Return a bracketed name qualified with this worksheet's datasource."""
+        return self.resolver.qualify(name)
+
+    def reference_of(self, reference: FieldRef) -> str:
+        """Return the qualified column-instance reference for a resolved field."""
+        return self.resolver.qualify(reference.instance_name)
+
+    @property
+    def all_refs(self) -> list[FieldRef]:
+        """list[FieldRef]: Every field the worksheet references, from any of its parts."""
+        references = [*self.columns, *self.rows, *self.encodings.values()]
+        references += [entry.reference for entry in self.filters]
+        if self.sort is not None:
+            references.append(self.sort.reference)
+            if self.sort.by is not None:
+                references.append(self.sort.by)
+        references += [reference for _, reference in self.tooltip]
+        references += [reference for reference, _ in self.number_formats]
+        return references
+
+
+def plan_worksheet(entry: dict, resolver: FieldResolver) -> WorksheetPlan:
+    """Resolve one manifest worksheet into a :class:`WorksheetPlan`.
+
+    Args:
+        entry: One ``worksheets`` entry from the build manifest.
+        resolver: The :class:`FieldResolver` for the worksheet's datasource.
+
+    Returns:
+        The plan; an unknown chart type falls back to the plain ``bar`` spec, which
+        ``manifest.validate_manifest`` has already rejected before the assembler runs.
+    """
+    spec = CHART_SPECS.get(str(entry.get("chart_type", "")).strip().lower(), ChartSpec())
+    shelves = entry.get("shelves") if isinstance(entry.get("shelves"), dict) else {}
+    raw_encodings = entry.get("encodings") if isinstance(entry.get("encodings"), dict) else {}
+    axis_titles = entry.get("axis_titles") if isinstance(entry.get("axis_titles"), dict) else {}
+
+    encodings: dict[str, FieldRef] = {}
+    for name in ENCODING_ORDER:
+        if name not in raw_encodings:
+            continue
+        reference = resolver.reference(raw_encodings[name])
+        if reference is not None:
+            encodings[name] = reference
+
+    return WorksheetPlan(
+        name=str(entry.get("name", "")).strip(),
+        spec=spec,
+        resolver=resolver,
+        columns=resolver.references(shelves.get("columns")),
+        rows=resolver.references(shelves.get("rows")),
+        encodings=encodings,
+        filters=_plan_filters(entry.get("filters"), resolver),
+        sort=_plan_sort(entry.get("sort"), resolver),
+        tooltip=_plan_tooltip(entry.get("tooltip"), resolver),
+        number_formats=_plan_number_formats(entry.get("number_formats"), resolver),
+        axis_titles={
+            shelf: str(title).strip()
+            for shelf, title in axis_titles.items()
+            if isinstance(title, str) and title.strip()
+        },
+        geo_role=str(entry.get("geo_role", "")).strip() if spec.geographic else "",
+    )
+
+
+def _plan_filters(entries: object, resolver: FieldResolver) -> list[FilterPlan]:
+    """Resolve the ``filters`` list into :class:`FilterPlan`s, dropping empty entries."""
+    if not isinstance(entries, list):
+        return []
+    plans: list[FilterPlan] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        values = entry.get("values")
+        members = tuple(str(value) for value in values) if isinstance(values, list) else ()
+        minimum, maximum = entry.get("min"), entry.get("max")
+        if not members and minimum is None and maximum is None:
+            continue  # nothing to filter on
+
+        # A range filter needs the *continuous* instance of a date: the discrete one has no
+        # min/max to compare against, and Tableau ignores the filter.
+        request = dict(entry)
+        if not members and not request.get("date_part"):
+            request["date_part"] = "date"
+        reference = resolver.reference(request)
+        if reference is None:
+            continue
+        plans.append(FilterPlan(
+            reference=reference,
+            members=members,
+            minimum=None if minimum is None else _bound(minimum, reference.datatype),
+            maximum=None if maximum is None else _bound(maximum, reference.datatype),
+            context=entry.get("context") is True,
+        ))
+    return plans
+
+
+def _plan_sort(entry: object, resolver: FieldResolver) -> Optional[SortPlan]:
+    """Resolve the ``sort`` object into a :class:`SortPlan`, or ``None`` when absent."""
+    if not isinstance(entry, dict):
+        return None
+    reference = resolver.reference(entry)
+    if reference is None:
+        return None
+    order = entry.get("order")
+    by = resolver.reference(entry["by"]) if entry.get("by") is not None else None
+    if by is None and not (isinstance(order, list) and order):
+        return None  # a sort naming neither a measure nor an order sorts by nothing
+    return SortPlan(
+        reference=reference,
+        by=by,
+        order=tuple(str(member) for member in order) if isinstance(order, list) else (),
+        direction=str(entry.get("direction", "DESC")).strip().upper() or "DESC",
+    )
+
+
+def _plan_tooltip(entries: object, resolver: FieldResolver) -> list[tuple[str, FieldRef]]:
+    """Resolve the ``tooltip`` list into ``(label, field)`` pairs."""
+    if not isinstance(entries, list):
+        return []
+    pairs: list[tuple[str, FieldRef]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        reference = resolver.reference(entry)
+        if reference is not None:
+            pairs.append((str(entry.get("label", reference.caption)).strip(), reference))
+    return pairs
+
+
+def _plan_number_formats(
+    entries: object, resolver: FieldResolver
+) -> list[tuple[FieldRef, str]]:
+    """Resolve the ``number_formats`` list into ``(field, format pattern)`` pairs."""
+    if not isinstance(entries, list):
+        return []
+    formats: list[tuple[FieldRef, str]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        pattern = str(entry.get("format", "")).strip()
+        reference = resolver.reference(entry)
+        if reference is not None and pattern:
+            formats.append((reference, pattern))
+    return formats
+
+
+def bin_columns(plan: WorksheetPlan) -> list[FieldRef]:
+    """Return the binned columns a worksheet introduces (histogram support).
+
+    A bin is a real column on the datasource, not a worksheet-local derivation, so
+    :mod:`twb` collects these across worksheets and declares them once per datasource.
+    """
+    return [reference for reference in plan.all_refs if reference.bin_size is not None]
+
+
+def legend_cards(plan: WorksheetPlan) -> list[tuple[str, str, str]]:
+    """Return the ``(card type, qualified field, pane id)`` triples for the right edge.
+
+    Without a legend card a colour- or size-encoded chart renders, but the analyst has no
+    key for it - which reads as a broken dashboard. A dual-axis / combo chart is coloured by
+    the built-in Measure Names rather than by anything the manifest named, and its legend
+    belongs to the first *measure* pane, not the shared pane 0.
+    """
+    if plan.spec.dual:
+        return [("color", plan.qualify(MEASURE_NAMES), "1")]
+    return [
+        (name, plan.qualify(plan.encodings[name].instance_name), "0")
+        for name in LEGEND_ENCODINGS
+        if name in plan.encodings
+    ]
+
+
+# --- Rendering ------------------------------------------------------------------
+
+def _render_run(parent: ET.Element, text: str, tokens: DesignTokens, size: int,
+                color: str = "", bold: bool = False) -> None:
+    """Append one styled ``<run>`` to a formatted-text block."""
+    attributes = {"fontname": tokens.font_family, "fontsize": str(size)}
+    if bold:
+        attributes["bold"] = "true"
+    if color:
+        attributes["fontcolor"] = color.lower()
+    ET.SubElement(parent, "run", dict(sorted(attributes.items()))).text = text
+
+
+def _render_title(parent: ET.Element, tokens: DesignTokens) -> None:
+    """Render the worksheet's title styling from the design tokens.
+
+    ``<Sheet Name>`` is Tableau's placeholder: the run styles the title without hard-coding
+    the sheet's name into it.
+    """
+    layout_options = ET.SubElement(parent, "layout-options")
+    title = ET.SubElement(layout_options, "title")
+    formatted = ET.SubElement(title, "formatted-text")
+    _render_run(formatted, "<Sheet Name>", tokens, tokens.title_size, tokens.title_color)
+
+
+def _render_dependencies(parent: ET.Element, plan: WorksheetPlan) -> None:
+    """Declare every column and column-instance the worksheet references.
+
+    Both are emitted in name order so the same manifest always produces byte-identical XML;
+    the schema accepts them in any order.
+    """
+    dependencies = ET.SubElement(
+        parent, "datasource-dependencies", {"datasource": plan.resolver.datasource_id}
+    )
+    by_column: dict[str, FieldRef] = {}
+    by_instance: dict[str, FieldRef] = {}
+    for reference in plan.all_refs:
+        by_column.setdefault(reference.column_name, reference)
+        by_instance.setdefault(reference.instance_name, reference)
+
+    # A map's geographic dimension must say which geography it is, or Tableau plots nothing.
+    geo_column = (
+        plan.encodings["lod"].column_name
+        if plan.geo_role and "lod" in plan.encodings else ""
+    )
+
+    for name in sorted(by_column):
+        render_column(
+            dependencies, by_column[name], plan.geo_role if name == geo_column else ""
+        )
+
+    for name in sorted(by_instance):
+        reference = by_instance[name]
+        ET.SubElement(dependencies, "column-instance", {
+            "column": reference.column_name,
+            "derivation": reference.derivation,
+            "name": name,
+            "pivot": "key",
+            "type": reference.instance_type,
+        })
+
+
+def render_column(parent: ET.Element, reference: FieldRef, semantic_role: str = "") -> None:
+    """Render one ``<column>`` - the field definition, plus any calculation behind it.
+
+    Used both inside a worksheet's ``<datasource-dependencies>`` and at the datasource
+    level (where the calculated and binned columns must also be declared).
+
+    Args:
+        parent: The element to append the column to.
+        reference: The resolved field.
+        semantic_role: A geographic role (``[Country].[ISO3166_2]``), or ``""``.
+    """
+    attributes = {
+        "caption": reference.caption,
+        "datatype": reference.datatype,
+        "name": reference.column_name,
+        "role": reference.role,
+        "type": reference.column_type,
+    }
+    if semantic_role:
+        attributes["semantic-role"] = semantic_role
+    column = ET.SubElement(parent, "column", dict(sorted(attributes.items())))
+    _render_calculation(column, reference)
+
+
+def _render_calculation(column: ET.Element, reference: FieldRef) -> None:
+    """Append the ``<calculation>`` child a bin or a calculated field carries."""
+    if reference.bin_size is not None:
+        ET.SubElement(column, "calculation", {
+            "class": "bin",
+            "decimals": BIN_DECIMALS,
+            "formula": f"[{reference.bin_source}]",
+            "peg": "0",
+            "size": _number(reference.bin_size),
+        })
+    elif reference.formula:
+        ET.SubElement(column, "calculation", {"class": "tableau", "formula": reference.formula})
+
+
+def _number(value: float) -> str:
+    """Render a manifest number without a trailing ``.0`` (Tableau writes ``500``)."""
+    return str(int(value)) if float(value).is_integer() else str(value)
+
+
+def _render_filters(parent: ET.Element, plan: WorksheetPlan) -> list[str]:
+    """Render the worksheet's filters and return the columns ``<slices>`` must list.
+
+    Two shapes, both from the legacy patterns: a categorical filter over an explicit member
+    list, and a quantitative in-range filter (a date or numeric window).
+
+    Args:
+        parent: The ``<view>`` element.
+        plan: The worksheet plan.
+
+    Returns:
+        The qualified column names that were filtered, in manifest order.
+    """
+    filtered: list[str] = []
+    for entry in plan.filters:
+        qualified = plan.reference_of(entry.reference)
+        attributes = {"column": qualified}
+        if entry.context:
+            # A context filter runs before FIXED LODs and every other filter.
+            attributes["context"] = "true"
+
+        if entry.members:
+            _render_categorical(
+                ET.SubElement(
+                    parent, "filter",
+                    dict(sorted({"class": "categorical", **attributes}.items())),
+                ),
+                entry.reference.instance_name,
+                list(entry.members),
+            )
+        else:
+            range_filter = ET.SubElement(parent, "filter", dict(sorted({
+                "class": "quantitative", "included-values": "in-range", **attributes,
+            }.items())))
+            for tag, bound in (("min", entry.minimum), ("max", entry.maximum)):
+                if bound is not None:
+                    ET.SubElement(range_filter, tag).text = bound
+        filtered.append(qualified)
+    return filtered
+
+
+def _render_categorical(parent: ET.Element, level: str, members: list[str]) -> None:
+    """Render a categorical filter's members, wrapping >1 of them in a union."""
+    ui_attributes = {
+        "user:ui-domain": "database",
+        "user:ui-enumeration": "inclusive",
+        "user:ui-marker": "enumerate",
+    }
+    if len(members) == 1:
+        ET.SubElement(parent, "groupfilter", {
+            "function": "member", "level": level, "member": f'"{members[0]}"', **ui_attributes,
+        })
+        return
+    union = ET.SubElement(parent, "groupfilter", {"function": "union", **ui_attributes})
+    for member in members:
+        ET.SubElement(union, "groupfilter", {
+            "function": "member", "level": level, "member": f'"{member}"',
+        })
+
+
+def _bound(value: object, datatype: str) -> str:
+    """Render a filter bound: dates take Tableau's ``#...#`` literal delimiters."""
+    text = str(value).strip()
+    if datatype in {"date", "datetime"} and not text.startswith("#"):
+        return f"#{text}#"
+    return text
+
+
+def _render_sort(parent: ET.Element, plan: WorksheetPlan) -> None:
+    """Render the worksheet's sort: computed (by a measure) or manual (an explicit order)."""
+    if plan.sort is None:
+        return
+    column = plan.reference_of(plan.sort.reference)
+
+    if plan.sort.order:
+        manual = ET.SubElement(
+            parent, "sort", {"column": column, "direction": plan.sort.direction}
+        )
+        dictionary = ET.SubElement(manual, "dictionary")
+        for member in plan.sort.order:
+            ET.SubElement(dictionary, "bucket").text = f'"{member}"'
+        return
+
+    ET.SubElement(parent, "computed-sort", {
+        "column": column,
+        "direction": plan.sort.direction,
+        "using": plan.reference_of(plan.sort.by),
+    })
+
+
+def _render_style(parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens) -> None:
+    """Render the worksheet's ``<style>``, one style-rule per element, alphabetically.
+
+    Tableau Desktop rewrites style rules into alphabetical order on save; emitting them any
+    other way produces a diff on first open. Rules are collected into a dict keyed by
+    element and then sorted, so a new rule cannot be added in the wrong place.
+    """
+    rules: dict[str, list[tuple[str, dict]]] = {}
+
+    def add(element: str, tag: str, attributes: dict) -> None:
+        rules.setdefault(element, []).append((tag, attributes))
+
+    if tokens.present:
+        add("worksheet", "format", {"attr": "font-family", "value": tokens.font_family})
+
+    for shelf, scope, references in (
+        ("rows", "rows", plan.rows), ("columns", "cols", plan.columns)
+    ):
+        title = plan.axis_titles.get(shelf)
+        if not (title and references):
+            continue
+        add("axis", "format", {
+            "attr": "title", "class": "0",
+            "field": plan.reference_of(references[0]),
+            "scope": scope, "value": title,
+        })
+
+    for reference, pattern in plan.number_formats:
+        add("cell", "format", {
+            "attr": "text-format",
+            "field": plan.reference_of(reference),
+            "value": pattern,
+        })
+
+    if plan.spec.kpi_card:
+        add("cell", "format", {"attr": "text-align", "value": "center"})
+        add("cell", "format", {"attr": "vertical-align", "value": "center"})
+
+    if plan.spec.geographic:
+        add("map", "format", {"attr": "washout", "value": "0.0"})
+
+    if plan.spec.dual and len(plan.rows) > 1:
+        # Sync the two axes and hide the second one's labels: without this the chart draws
+        # two independent scales and reads as two unrelated series.
+        second = plan.reference_of(plan.rows[1])
+        add("axis", "encoding", {
+            "attr": "space", "class": "0", "field": second, "field-type": "quantitative",
+            "fold": "true", "scope": "rows", "synchronized": "true", "type": "space",
+        })
+        add("axis", "format", {
+            "attr": "display", "class": "0", "field": second, "scope": "rows",
+            "value": "false",
+        })
+
+    style = ET.SubElement(parent, "style")
+    for element in sorted(rules):
+        rule = ET.SubElement(style, "style-rule", {"element": element})
+        for tag, attributes in rules[element]:
+            ET.SubElement(rule, tag, attributes)
+
+
+def _render_panes(parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens) -> None:
+    """Render the worksheet's panes: one, or three for a dual-axis / combo chart."""
+    panes = ET.SubElement(parent, "panes")
+    if plan.spec.dual and len(plan.rows) > 1:
+        # Pane 0 is the shared default; panes 1..n each own one measure's axis, in the same
+        # order the measures sit on Rows.
+        _render_pane(panes, plan, tokens, {}, plan.spec.mark_class)
+        for index, reference in enumerate(plan.rows):
+            mark = (
+                plan.spec.pane_marks[index]
+                if index < len(plan.spec.pane_marks) else plan.spec.mark_class
+            )
+            _render_pane(
+                panes, plan, tokens,
+                {
+                    "id": str(index + 1),
+                    "y-axis-name": plan.reference_of(reference),
+                },
+                mark,
+            )
+        return
+    _render_pane(panes, plan, tokens, {}, plan.spec.mark_class)
+
+
+def _render_pane(
+    parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens,
+    attributes: dict, mark_class: str,
+) -> None:
+    """Render one pane: its mark class, encodings, tooltip, label and mark style.
+
+    The child order is the XSD's ``PaneSpecification-G`` sequence - view, mark, encodings,
+    customized-tooltip, customized-label, style - not the order they were decided in.
+    """
+    pane = ET.SubElement(
+        parent, "pane", dict(sorted({**attributes, **PANE_RELAXATION}.items()))
+    )
+    ET.SubElement(ET.SubElement(pane, "view"), "breakdown", {"value": "auto"})
+    ET.SubElement(pane, "mark", {"class": mark_class})
+
+    # {encoding: qualified column}. Two encodings are built-ins the manifest never names:
+    # a dual chart colours its two measures apart with Measure Names, and a map needs the
+    # generated geometry to draw its polygons.
+    columns = {
+        name: plan.reference_of(reference)
+        for name, reference in plan.encodings.items()
+    }
+    if plan.spec.dual:
+        columns["color"] = plan.qualify(MEASURE_NAMES)
+    if plan.spec.geographic:
+        columns["geometry"] = plan.qualify(GENERATED_GEOMETRY)
+
+    if columns or plan.tooltip:
+        block = ET.SubElement(pane, "encodings")
+        for name in ENCODING_ORDER:
+            if name in columns:
+                ET.SubElement(block, name, {"column": columns[name]})
+        # Every field the tooltip template names must also be registered as an encoding,
+        # or Tableau has no value to substitute into it.
+        for _, reference in plan.tooltip:
+            ET.SubElement(block, "tooltip", {
+                "column": plan.reference_of(reference)
+            })
+
+    if plan.tooltip:
+        _render_tooltip(pane, plan, tokens)
+    if plan.spec.kpi_card and "text" in plan.encodings:
+        _render_big_number(pane, plan, tokens)
+    if plan.spec.label_marks:
+        style = ET.SubElement(pane, "style")
+        rule = ET.SubElement(style, "style-rule", {"element": "mark"})
+        for attribute in ("mark-labels-show", "mark-labels-cull"):
+            ET.SubElement(rule, "format", {"attr": attribute, "value": "true"})
+
+
+def _render_tooltip(
+    parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens
+) -> None:
+    """Render a ``<customized-tooltip>``: ``label`` / newline / value, one pair per line."""
+    formatted = ET.SubElement(
+        ET.SubElement(parent, "customized-tooltip"), "formatted-text"
+    )
+    for index, (label, reference) in enumerate(plan.tooltip):
+        if index:  # separate this pair from the previous one
+            _render_run(formatted, TOOLTIP_BREAK, tokens, tokens.title_size)
+        _render_run(formatted, f"{label}:", tokens, tokens.title_size, bold=True)
+        _render_run(formatted, TOOLTIP_BREAK, tokens, tokens.title_size)
+        _render_run(
+            formatted,
+            cdata(f"<{plan.reference_of(reference)}>"),
+            tokens, tokens.title_size, bold=True,
+        )
+
+
+def _render_big_number(parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens) -> None:
+    """Render a KPI card's ``<customized-label>`` - the text encoding, set large."""
+    formatted = ET.SubElement(
+        ET.SubElement(parent, "customized-label"), "formatted-text"
+    )
+    _render_run(
+        formatted,
+        cdata(f"<{plan.reference_of(plan.encodings['text'])}>"),
+        tokens, tokens.kpi_size, tokens.title_color, bold=True,
+    )
+
+
+def _shelf_text(plan: WorksheetPlan, references: list[FieldRef], generated: str) -> str:
+    """Render one shelf's text from its resolved fields.
+
+    Args:
+        plan: The worksheet plan.
+        references: The shelf's fields, in manifest order.
+        generated: The Tableau-generated field this shelf carries on a map.
+
+    Returns:
+        The shelf string: empty for a pie/KPI card, ``(a + b)`` for a dual axis, ``(a / b)``
+        for nested dimensions, and the single qualified reference otherwise.
+    """
+    if plan.spec.geographic:
+        return plan.qualify(generated)
+    if plan.spec.empty_shelves or not references:
+        return ""
+    qualified = [plan.reference_of(reference) for reference in references]
+    if len(qualified) == 1:
+        return qualified[0]
+    # '+' overlays measures on one axis pair (dual axis / combo); '/' nests dimensions.
+    separator = " + " if plan.spec.dual else " / "
+    return "(" + separator.join(qualified) + ")"
+
+
+def render_worksheet(parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens,
+                     simple_id: str) -> None:
+    """Render one complete ``<worksheet>`` from its plan.
+
+    Args:
+        parent: The ``<worksheets>`` element.
+        plan: The resolved worksheet.
+        tokens: The design tokens (Tableau defaults when the file was absent).
+        simple_id: The braced UUID for the sheet's ``<simple-id>``.
+    """
+    element = ET.SubElement(parent, "worksheet", {"name": plan.name})
+    if tokens.present:
+        _render_title(element, tokens)
+
+    table = ET.SubElement(element, "table")
+    view = ET.SubElement(table, "view")
+    datasources = ET.SubElement(view, "datasources")
+    ET.SubElement(datasources, "datasource", {
+        "caption": plan.resolver.datasource_caption,
+        "name": plan.resolver.datasource_id,
+    })
+    if plan.spec.geographic:
+        ET.SubElement(
+            ET.SubElement(view, "mapsources"), "mapsource", {"name": MAPSOURCE_NAME}
+        )
+    _render_dependencies(view, plan)
+    filtered = _render_filters(view, plan)
+    _render_sort(view, plan)
+    if filtered:
+        # Every filtered field must appear here or Tableau silently drops the filter.
+        slices = ET.SubElement(view, "slices")
+        for column in filtered:
+            ET.SubElement(slices, "column").text = column
+    ET.SubElement(view, "aggregation", {"value": "true"})
+
+    _render_style(table, plan, tokens)
+    _render_panes(table, plan, tokens)
+    ET.SubElement(table, "rows").text = _shelf_text(plan, plan.rows, GENERATED_LATITUDE)
+    ET.SubElement(table, "cols").text = _shelf_text(plan, plan.columns, GENERATED_LONGITUDE)
+
+    # Both of these come after the shelves in the XSD's <table> sequence.
+    bins = bin_columns(plan)
+    if bins:
+        # Show every bin range, including the empty ones - a histogram with gaps silently
+        # dropped misreads as a different distribution.
+        full_range = ET.SubElement(table, "show-full-range")
+        for reference in bins:
+            ET.SubElement(full_range, "column").text = plan.qualify(reference.column_name)
+    if plan.spec.kpi_card:
+        # A KPI card is a single number, not a mark worth hovering.
+        ET.SubElement(table, "tooltip-style", {"tooltip-mode": "none"})
+
+    ET.SubElement(element, "simple-id", {"uuid": simple_id})

--- a/tests/fixtures/charts/area.xml
+++ b/tests/fixtures/charts/area.xml
@@ -1,0 +1,39 @@
+<worksheet name="Area">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Order Date" datatype="date" name="[order_date]" role="dimension" type="ordinal" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+            <column-instance column="[order_date]" derivation="Week-Trunc" name="[twk:order_date:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Area" />
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[twk:order_date:qk]</cols>
+      </table>
+      <simple-id uuid="{712D3D45-4746-5DA8-B676-ADC3CBB0AAEC}" />
+    </worksheet>

--- a/tests/fixtures/charts/bar-filtered.xml
+++ b/tests/fixtures/charts/bar-filtered.xml
@@ -1,0 +1,57 @@
+<worksheet name="Bar Filtered">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Order Date" datatype="date" name="[order_date]" role="dimension" type="ordinal" />
+            <column caption="Product Category" datatype="string" name="[product_category]" role="dimension" type="nominal" />
+            <column caption="Region" datatype="string" name="[region]" role="dimension" type="nominal" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[order_date]" derivation="None" name="[none:order_date:qk]" pivot="key" type="quantitative" />
+            <column-instance column="[product_category]" derivation="None" name="[none:product_category:nk]" pivot="key" type="nominal" />
+            <column-instance column="[region]" derivation="None" name="[none:region:nk]" pivot="key" type="nominal" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <filter class="categorical" column="[federated.b2993893834e8f0306a282d0a717d7a9].[none:region:nk]" context="true">
+            <groupfilter function="union" user:ui-domain="database" user:ui-enumeration="inclusive" user:ui-marker="enumerate">
+              <groupfilter function="member" level="[none:region:nk]" member="&quot;Europe&quot;" />
+              <groupfilter function="member" level="[none:region:nk]" member="&quot;Asia&quot;" />
+            </groupfilter>
+          </filter>
+          <filter class="quantitative" column="[federated.b2993893834e8f0306a282d0a717d7a9].[none:order_date:qk]" included-values="in-range">
+            <min>#2025-03-03#</min>
+            <max>#2025-04-22#</max>
+          </filter>
+          <slices>
+            <column>[federated.b2993893834e8f0306a282d0a717d7a9].[none:region:nk]</column>
+            <column>[federated.b2993893834e8f0306a282d0a717d7a9].[none:order_date:qk]</column>
+          </slices>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]</cols>
+      </table>
+      <simple-id uuid="{B5082F3E-A7F0-5857-9888-2C0DCF34552D}" />
+    </worksheet>

--- a/tests/fixtures/charts/bar-sorted.xml
+++ b/tests/fixtures/charts/bar-sorted.xml
@@ -1,0 +1,40 @@
+<worksheet name="Bar Sorted">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Product Category" datatype="string" name="[product_category]" role="dimension" type="nominal" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[product_category]" derivation="None" name="[none:product_category:nk]" pivot="key" type="nominal" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <computed-sort column="[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]" direction="DESC" using="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]</cols>
+      </table>
+      <simple-id uuid="{54DE9D6E-A43F-59FB-A684-1B50B806F89E}" />
+    </worksheet>

--- a/tests/fixtures/charts/bar-stacked.xml
+++ b/tests/fixtures/charts/bar-stacked.xml
@@ -1,0 +1,44 @@
+<worksheet name="Bar Stacked">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Product Category" datatype="string" name="[product_category]" role="dimension" type="nominal" />
+            <column caption="Region" datatype="string" name="[region]" role="dimension" type="nominal" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[product_category]" derivation="None" name="[none:product_category:nk]" pivot="key" type="nominal" />
+            <column-instance column="[region]" derivation="None" name="[none:region:nk]" pivot="key" type="nominal" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+            <encodings>
+              <color column="[federated.b2993893834e8f0306a282d0a717d7a9].[none:region:nk]" />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]</cols>
+      </table>
+      <simple-id uuid="{3147158C-7A21-567E-A666-6F828C7F875C}" />
+    </worksheet>

--- a/tests/fixtures/charts/bar-styled.xml
+++ b/tests/fixtures/charts/bar-styled.xml
@@ -1,0 +1,45 @@
+<worksheet name="Bar Styled">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Product Category" datatype="string" name="[product_category]" role="dimension" type="nominal" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[product_category]" derivation="None" name="[none:product_category:nk]" pivot="key" type="nominal" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="axis">
+            <format attr="title" class="0" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" scope="rows" value="Revenue per category" />
+          </style-rule>
+          <style-rule element="cell">
+            <format attr="text-format" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" value="$#,##0" />
+          </style-rule>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]</cols>
+      </table>
+      <simple-id uuid="{4C143BA0-9C68-5E19-84E3-DAB1F107B494}" />
+    </worksheet>

--- a/tests/fixtures/charts/bar.xml
+++ b/tests/fixtures/charts/bar.xml
@@ -1,0 +1,39 @@
+<worksheet name="Bar">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Product Category" datatype="string" name="[product_category]" role="dimension" type="nominal" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[product_category]" derivation="None" name="[none:product_category:nk]" pivot="key" type="nominal" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]</cols>
+      </table>
+      <simple-id uuid="{9D0BC46C-A756-5165-AC47-419710BE0558}" />
+    </worksheet>

--- a/tests/fixtures/charts/calculated-field.xml
+++ b/tests/fixtures/charts/calculated-field.xml
@@ -1,0 +1,41 @@
+<worksheet name="Calculated Field">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Margin Pct" datatype="real" name="[Margin Pct]" role="measure" type="quantitative">
+              <calculation class="tableau" formula="SUM([profit]) / SUM([revenue])" />
+            </column>
+            <column caption="Region" datatype="string" name="[region]" role="dimension" type="nominal" />
+            <column-instance column="[region]" derivation="None" name="[none:region:nk]" pivot="key" type="nominal" />
+            <column-instance column="[Margin Pct]" derivation="User" name="[usr:Margin Pct:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[usr:Margin Pct:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[none:region:nk]</cols>
+      </table>
+      <simple-id uuid="{7152EE60-EEAB-561C-8A77-09D70D36B673}" />
+    </worksheet>

--- a/tests/fixtures/charts/combo.xml
+++ b/tests/fixtures/charts/combo.xml
@@ -1,0 +1,66 @@
+<worksheet name="Combo">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Order Date" datatype="date" name="[order_date]" role="dimension" type="ordinal" />
+            <column caption="Profit" datatype="real" name="[profit]" role="measure" type="quantitative" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[profit]" derivation="Sum" name="[sum:profit:qk]" pivot="key" type="quantitative" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+            <column-instance column="[order_date]" derivation="Month-Trunc" name="[tmn:order_date:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="axis">
+            <encoding attr="space" class="0" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]" field-type="quantitative" fold="true" scope="rows" synchronized="true" type="space" />
+            <format attr="display" class="0" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]" scope="rows" value="false" />
+          </style-rule>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+            <encodings>
+              <color column="[federated.b2993893834e8f0306a282d0a717d7a9].[:Measure Names]" />
+            </encodings>
+          </pane>
+          <pane id="1" selection-relaxation-option="selection-relaxation-allow" y-axis-name="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Bar" />
+            <encodings>
+              <color column="[federated.b2993893834e8f0306a282d0a717d7a9].[:Measure Names]" />
+            </encodings>
+          </pane>
+          <pane id="2" selection-relaxation-option="selection-relaxation-allow" y-axis-name="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Line" />
+            <encodings>
+              <color column="[federated.b2993893834e8f0306a282d0a717d7a9].[:Measure Names]" />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>([federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk] + [federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk])</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[tmn:order_date:qk]</cols>
+      </table>
+      <simple-id uuid="{91C0AB6D-D2D6-5F71-AB0C-C7794F2B3528}" />
+    </worksheet>

--- a/tests/fixtures/charts/custom-tooltip.xml
+++ b/tests/fixtures/charts/custom-tooltip.xml
@@ -1,0 +1,55 @@
+<worksheet name="Custom Tooltip">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Product Category" datatype="string" name="[product_category]" role="dimension" type="nominal" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[product_category]" derivation="Attribute" name="[attr:product_category:nk]" pivot="key" type="nominal" />
+            <column-instance column="[product_category]" derivation="None" name="[none:product_category:nk]" pivot="key" type="nominal" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+            <encodings>
+              <tooltip column="[federated.b2993893834e8f0306a282d0a717d7a9].[attr:product_category:nk]" />
+              <tooltip column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
+            </encodings>
+            <customized-tooltip>
+              <formatted-text>
+                <run bold="true" fontname="Open Sans" fontsize="14">Category:</run>
+                <run fontname="Open Sans" fontsize="14">Æ	</run>
+                <run bold="true" fontname="Open Sans" fontsize="14"><![CDATA[<[federated.b2993893834e8f0306a282d0a717d7a9].[attr:product_category:nk]>]]></run>
+                <run fontname="Open Sans" fontsize="14">Æ	</run>
+                <run bold="true" fontname="Open Sans" fontsize="14">Revenue:</run>
+                <run fontname="Open Sans" fontsize="14">Æ	</run>
+                <run bold="true" fontname="Open Sans" fontsize="14"><![CDATA[<[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]>]]></run>
+              </formatted-text>
+            </customized-tooltip>
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]</cols>
+      </table>
+      <simple-id uuid="{922EA0A4-5363-5163-99BA-C67EA843EE2D}" />
+    </worksheet>

--- a/tests/fixtures/charts/custom-tooltip.xml
+++ b/tests/fixtures/charts/custom-tooltip.xml
@@ -37,12 +37,10 @@
             </encodings>
             <customized-tooltip>
               <formatted-text>
-                <run bold="true" fontname="Open Sans" fontsize="14">Category:</run>
-                <run fontname="Open Sans" fontsize="14">Æ	</run>
+                <run bold="true" fontname="Open Sans" fontsize="14">Category: </run>
                 <run bold="true" fontname="Open Sans" fontsize="14"><![CDATA[<[federated.b2993893834e8f0306a282d0a717d7a9].[attr:product_category:nk]>]]></run>
                 <run fontname="Open Sans" fontsize="14">Æ	</run>
-                <run bold="true" fontname="Open Sans" fontsize="14">Revenue:</run>
-                <run fontname="Open Sans" fontsize="14">Æ	</run>
+                <run bold="true" fontname="Open Sans" fontsize="14">Revenue: </run>
                 <run bold="true" fontname="Open Sans" fontsize="14"><![CDATA[<[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]>]]></run>
               </formatted-text>
             </customized-tooltip>

--- a/tests/fixtures/charts/dual-axis.xml
+++ b/tests/fixtures/charts/dual-axis.xml
@@ -1,0 +1,66 @@
+<worksheet name="Dual Axis">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Order Date" datatype="date" name="[order_date]" role="dimension" type="ordinal" />
+            <column caption="Profit" datatype="real" name="[profit]" role="measure" type="quantitative" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[profit]" derivation="Sum" name="[sum:profit:qk]" pivot="key" type="quantitative" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+            <column-instance column="[order_date]" derivation="Month-Trunc" name="[tmn:order_date:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="axis">
+            <encoding attr="space" class="0" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]" field-type="quantitative" fold="true" scope="rows" synchronized="true" type="space" />
+            <format attr="display" class="0" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]" scope="rows" value="false" />
+          </style-rule>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+            <encodings>
+              <color column="[federated.b2993893834e8f0306a282d0a717d7a9].[:Measure Names]" />
+            </encodings>
+          </pane>
+          <pane id="1" selection-relaxation-option="selection-relaxation-allow" y-axis-name="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+            <encodings>
+              <color column="[federated.b2993893834e8f0306a282d0a717d7a9].[:Measure Names]" />
+            </encodings>
+          </pane>
+          <pane id="2" selection-relaxation-option="selection-relaxation-allow" y-axis-name="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+            <encodings>
+              <color column="[federated.b2993893834e8f0306a282d0a717d7a9].[:Measure Names]" />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>([federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk] + [federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk])</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[tmn:order_date:qk]</cols>
+      </table>
+      <simple-id uuid="{CEDEAAA5-EA1B-53A6-A4D9-BCD7DB3A9669}" />
+    </worksheet>

--- a/tests/fixtures/charts/histogram.xml
+++ b/tests/fixtures/charts/histogram.xml
@@ -1,0 +1,44 @@
+<worksheet name="Histogram">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Revenue (bin)" datatype="integer" name="[Revenue (bin)]" role="dimension" type="ordinal">
+              <calculation class="bin" decimals="2" formula="[revenue]" peg="0" size="500" />
+            </column>
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[revenue]" derivation="Count" name="[cnt:revenue:qk]" pivot="key" type="quantitative" />
+            <column-instance column="[Revenue (bin)]" derivation="None" name="[none:Revenue (bin):ok]" pivot="key" type="ordinal" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[cnt:revenue:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[none:Revenue (bin):ok]</cols>
+        <show-full-range>
+          <column>[federated.b2993893834e8f0306a282d0a717d7a9].[Revenue (bin)]</column>
+        </show-full-range>
+      </table>
+      <simple-id uuid="{BCAC38AF-B8B7-579D-A3C4-C181F1F859D4}" />
+    </worksheet>

--- a/tests/fixtures/charts/kpi-card.xml
+++ b/tests/fixtures/charts/kpi-card.xml
@@ -1,0 +1,56 @@
+<worksheet name="Kpi Card">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="cell">
+            <format attr="text-align" value="center" />
+            <format attr="vertical-align" value="center" />
+          </style-rule>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+            <encodings>
+              <text column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
+            </encodings>
+            <customized-label>
+              <formatted-text>
+                <run bold="true" fontcolor="#7f56d9" fontname="Open Sans" fontsize="22"><![CDATA[<[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]>]]></run>
+              </formatted-text>
+            </customized-label>
+            <style>
+              <style-rule element="mark">
+                <format attr="mark-labels-show" value="true" />
+                <format attr="mark-labels-cull" value="true" />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows />
+        <cols />
+        <tooltip-style tooltip-mode="none" />
+      </table>
+      <simple-id uuid="{130C3890-07C5-5581-8DA4-6927A8DEB5DB}" />
+    </worksheet>

--- a/tests/fixtures/charts/line.xml
+++ b/tests/fixtures/charts/line.xml
@@ -1,0 +1,39 @@
+<worksheet name="Line">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Order Date" datatype="date" name="[order_date]" role="dimension" type="ordinal" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+            <column-instance column="[order_date]" derivation="Month-Trunc" name="[tmn:order_date:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[tmn:order_date:qk]</cols>
+      </table>
+      <simple-id uuid="{805AE770-C568-59BF-92B5-686C15C0E30B}" />
+    </worksheet>

--- a/tests/fixtures/charts/map.xml
+++ b/tests/fixtures/charts/map.xml
@@ -1,0 +1,50 @@
+<worksheet name="Map">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <mapsources>
+            <mapsource name="Tableau" />
+          </mapsources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Country" datatype="string" name="[country]" role="dimension" semantic-role="[Country].[ISO3166_2]" type="nominal" />
+            <column caption="Profit" datatype="real" name="[profit]" role="measure" type="quantitative" />
+            <column-instance column="[country]" derivation="None" name="[none:country:nk]" pivot="key" type="nominal" />
+            <column-instance column="[profit]" derivation="Sum" name="[sum:profit:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="map">
+            <format attr="washout" value="0.0" />
+          </style-rule>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+            <encodings>
+              <color column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]" />
+              <lod column="[federated.b2993893834e8f0306a282d0a717d7a9].[none:country:nk]" />
+              <geometry column="[federated.b2993893834e8f0306a282d0a717d7a9].[Geometry (generated)]" />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[Latitude (generated)]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[Longitude (generated)]</cols>
+      </table>
+      <simple-id uuid="{123BC0E8-35ED-585D-A4A9-CA9EB2844CEA}" />
+    </worksheet>

--- a/tests/fixtures/charts/pie.xml
+++ b/tests/fixtures/charts/pie.xml
@@ -1,0 +1,51 @@
+<worksheet name="Pie">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Product Category" datatype="string" name="[product_category]" role="dimension" type="nominal" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[product_category]" derivation="None" name="[none:product_category:nk]" pivot="key" type="nominal" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Pie" />
+            <encodings>
+              <color column="[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]" />
+              <size column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
+              <text column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
+              <wedge-size column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
+            </encodings>
+            <style>
+              <style-rule element="mark">
+                <format attr="mark-labels-show" value="true" />
+                <format attr="mark-labels-cull" value="true" />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows />
+        <cols />
+      </table>
+      <simple-id uuid="{A9839A3B-54AA-55D6-9FD6-0CA1784A553F}" />
+    </worksheet>

--- a/tests/fixtures/charts/scatter.xml
+++ b/tests/fixtures/charts/scatter.xml
@@ -1,0 +1,44 @@
+<worksheet name="Scatter">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Product Category" datatype="string" name="[product_category]" role="dimension" type="nominal" />
+            <column caption="Profit" datatype="real" name="[profit]" role="measure" type="quantitative" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[product_category]" derivation="None" name="[none:product_category:nk]" pivot="key" type="nominal" />
+            <column-instance column="[profit]" derivation="Sum" name="[sum:profit:qk]" pivot="key" type="quantitative" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+            <encodings>
+              <lod column="[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]" />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]</cols>
+      </table>
+      <simple-id uuid="{F57AF686-E199-5786-A95F-4C3EE3050502}" />
+    </worksheet>

--- a/tests/fixtures/charts/text-table.xml
+++ b/tests/fixtures/charts/text-table.xml
@@ -1,0 +1,50 @@
+<worksheet name="Text Table">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Product Category" datatype="string" name="[product_category]" role="dimension" type="nominal" />
+            <column caption="Region" datatype="string" name="[region]" role="dimension" type="nominal" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[product_category]" derivation="None" name="[none:product_category:nk]" pivot="key" type="nominal" />
+            <column-instance column="[region]" derivation="None" name="[none:region:nk]" pivot="key" type="nominal" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="Automatic" />
+            <encodings>
+              <text column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
+            </encodings>
+            <style>
+              <style-rule element="mark">
+                <format attr="mark-labels-show" value="true" />
+                <format attr="mark-labels-cull" value="true" />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[none:region:nk]</cols>
+      </table>
+      <simple-id uuid="{D4D12C98-B6EB-5585-B5FE-AC86A7C14B59}" />
+    </worksheet>

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -974,8 +974,12 @@ def test_every_viewpoint_has_entire_view_zoom():
         assert viewpoint.find("zoom").get("type") == "entire-view"
 
 
-def test_every_worksheet_has_a_matching_hidden_window():
-    """validate_twb's worksheet<->window check is bidirectional; both sides come from here."""
+def test_every_worksheet_has_a_matching_visible_window():
+    """validate_twb's worksheet<->window check is bidirectional; both sides come from here.
+
+    The windows are *visible*: a sheet is hidden only once a dashboard zone embeds it, and
+    the zone tree is the next ticket. Hiding a sheet nothing shows leaves Tableau with no tab
+    to render it on, which is a workbook the analyst cannot see into at all."""
     root = _render()
     worksheets = [sheet.get("name") for sheet in root.findall("worksheets/worksheet")]
     windows = [
@@ -984,10 +988,10 @@ def test_every_worksheet_has_a_matching_hidden_window():
     ]
 
     assert worksheets == windows == ["Revenue KPI", "Revenue Trend"]
-    assert all(
-        window.get("hidden") == "true" for window in root.findall("windows/window")
-        if window.get("class") == "worksheet"
-    )
+    assert not [
+        window.get("name") for window in root.findall("windows/window")
+        if window.get("class") == "worksheet" and window.get("hidden") == "true"
+    ]
 
 
 def test_dashboard_is_sized_from_the_layout_canvas():

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1,0 +1,871 @@
+"""Golden-output contract test for tableau-build's 15 worksheet chart templates (issue #35).
+
+Every chart pattern the legacy skill shipped as a hand-written ``.twb`` snippet is produced
+here from manifest fields alone. Two things are being protected:
+
+* **No snippet leakage.** The old workflow copy-pasted a snippet and search-replaced the
+  field names; anything it missed - a datasource hash, a UUID, a leftover ``profit`` -
+  shipped to the analyst. :func:`test_no_snippet_values_leak` fails if any of those appear.
+* **No silent template regression.** Each pattern's rendered ``<worksheet>`` is pinned to a
+  golden file under ``fixtures/charts/``, so a change to the builder shows up as a diff on
+  the exact chart types it affects rather than as a workbook that opens blank in Tableau.
+
+Regenerate the goldens after an *intended* template change with::
+
+    UPDATE_CHART_GOLDENS=1 python -m pytest tests/test_charts.py -q
+
+and read the resulting diff before committing it - that diff is the review.
+
+The 15 patterns are not 15 chart types: sorted / filtered / styled / custom-tooltip are
+modifiers that apply to any chart, and a stacked bar is a bar with a colour encoding. The
+cases below therefore cover all 15 *patterns* across 12 ``chart_type`` values plus the
+modifier keys.
+"""
+
+import os
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+import build
+import manifest
+import twb
+import worksheet
+
+GOLDEN_DIR = Path(__file__).parent / "fixtures" / "charts"
+UPDATE_GOLDENS = os.environ.get("UPDATE_CHART_GOLDENS") == "1"
+
+TARGET_VERSION = "2026.1+"
+
+DATA_MODEL = """# Data Model
+
+## Data source: `sales_orders.csv`
+
+| Field | Type | Role | Sample values | Description |
+|-------|------|------|---------------|-------------|
+| order_date | date | dimension | 2024-01-05 | Order date |
+| region | string | dimension | West | Sales region |
+| country | string | dimension | France | Billing country |
+| product_category | string | dimension | Technology | Product category |
+| revenue | real | measure | 1200.5 | Order revenue |
+| profit | real | measure | 120.5 | Order profit |
+"""
+
+CSV_HEADERS = {
+    "sales_orders.csv": [
+        "order_date", "region", "country", "product_category", "revenue", "profit",
+    ]
+}
+
+DESIGN_TOKENS = """# Design Tokens
+
+## Typography
+
+- **Font family**: Open Sans
+- **Chart title**: 14px, 600, #7F56D9
+"""
+
+
+def _sheet(name: str, chart_type: str, **extra) -> dict:
+    """Build one manifest worksheet entry, filling in the boilerplate."""
+    entry = {
+        "name": name,
+        "element_id": f"zone-{name.lower().replace(' ', '-')}",
+        "chart_type": chart_type,
+        "datasource": "sales_orders",
+    }
+    entry.update(extra)
+    return entry
+
+
+#: One case per legacy pattern: ``(golden slug, manifest worksheet)``. The sheet name is the
+#: slug title-cased, which is what the golden filename and the element id are derived from.
+CHART_CASES: list[tuple[str, dict]] = [
+    ("bar", _sheet("Bar", "bar",
+                   shelves={"columns": ["product_category"], "rows": ["revenue"]})),
+    ("bar-sorted", _sheet(
+        "Bar Sorted", "bar",
+        shelves={"columns": ["product_category"], "rows": ["revenue"]},
+        sort={"field": "product_category", "direction": "DESC",
+              "by": {"field": "revenue", "aggregation": "sum"}},
+    )),
+    ("bar-filtered", _sheet(
+        "Bar Filtered", "bar",
+        shelves={"columns": ["product_category"], "rows": ["revenue"]},
+        filters=[
+            {"field": "region", "values": ["Europe", "Asia"], "context": True},
+            {"field": "order_date", "min": "2025-03-03", "max": "2025-04-22"},
+        ],
+    )),
+    ("bar-styled", _sheet(
+        "Bar Styled", "bar",
+        shelves={"columns": ["product_category"], "rows": ["revenue"]},
+        axis_titles={"rows": "Revenue per category"},
+        number_formats=[{"field": "revenue", "format": "$#,##0"}],
+    )),
+    ("bar-stacked", _sheet(
+        "Bar Stacked", "bar",
+        shelves={"columns": ["product_category"], "rows": ["revenue"]},
+        encodings={"color": "region"},
+    )),
+    ("line", _sheet("Line", "line", shelves={
+        "columns": [{"field": "order_date", "date_part": "month"}], "rows": ["revenue"],
+    })),
+    ("area", _sheet("Area", "area", shelves={
+        "columns": [{"field": "order_date", "date_part": "week"}], "rows": ["revenue"],
+    })),
+    ("pie", _sheet("Pie", "pie", encodings={
+        "color": "product_category", "wedge-size": "revenue", "size": "revenue",
+        "text": "revenue",
+    })),
+    ("scatter", _sheet(
+        "Scatter", "scatter",
+        shelves={"columns": ["profit"], "rows": ["revenue"]},
+        encodings={"lod": "product_category"},
+    )),
+    ("text-table", _sheet(
+        "Text Table", "table",
+        shelves={"columns": ["region"], "rows": ["product_category"]},
+        encodings={"text": "revenue"},
+    )),
+    ("kpi-card", _sheet("Kpi Card", "text", encodings={"text": "revenue"})),
+    ("histogram", _sheet("Histogram", "histogram", shelves={
+        "columns": [{"field": "revenue", "bin": 500}],
+        "rows": [{"field": "revenue", "aggregation": "count"}],
+    })),
+    ("map", _sheet(
+        "Map", "map",
+        encodings={"lod": "country", "color": "profit"},
+        geo_role="[Country].[ISO3166_2]",
+    )),
+    ("dual-axis", _sheet("Dual Axis", "dual-axis", shelves={
+        "columns": [{"field": "order_date", "date_part": "month"}],
+        "rows": ["revenue", "profit"],
+    })),
+    ("combo", _sheet("Combo", "combo", shelves={
+        "columns": [{"field": "order_date", "date_part": "month"}],
+        "rows": ["revenue", "profit"],
+    })),
+    ("custom-tooltip", _sheet(
+        "Custom Tooltip", "bar",
+        shelves={"columns": ["product_category"], "rows": ["revenue"]},
+        tooltip=[
+            {"label": "Category", "field": "product_category", "aggregation": "attr"},
+            {"label": "Revenue", "field": "revenue", "aggregation": "sum"},
+        ],
+    )),
+    ("calculated-field", _sheet(
+        "Calculated Field", "bar",
+        shelves={"columns": ["region"], "rows": ["Margin Pct"]},
+    )),
+]
+
+SHEET_NAMES = [entry["name"] for _, entry in CHART_CASES]
+
+
+def _manifest(worksheets=None, **overrides) -> dict:
+    """A manifest whose layout places one zone per worksheet."""
+    entries = list(worksheets if worksheets is not None else [e for _, e in CHART_CASES])
+    document = {
+        "target_tableau_version": TARGET_VERSION,
+        "datasources": [{
+            "name": "sales_orders",
+            "csv": "sales_orders.csv",
+            "fields": [
+                {"name": "order_date", "type": "date"},
+                {"name": "region", "type": "string"},
+                {"name": "country", "type": "string"},
+                {"name": "product_category", "type": "string"},
+                {"name": "revenue", "type": "real"},
+                {"name": "profit", "type": "real"},
+            ],
+        }],
+        "calculated_fields": [{
+            "name": "Margin Pct",
+            "formula": "SUM([profit]) / SUM([revenue])",
+            "datasource": "sales_orders",
+            "type": "real",
+        }],
+        "worksheets": entries,
+        "layout": {
+            "canvas": {"width": 1366, "height": 768},
+            "root": {
+                "type": "vert",
+                "children": [{"id": entry["element_id"]} for entry in entries],
+            },
+        },
+        "actions": [],
+        "parameters": [],
+    }
+    document.update(overrides)
+    return document
+
+
+def _render(document=None, tokens: str = DESIGN_TOKENS) -> str:
+    """Render a manifest to .twb XML."""
+    return twb.render_workbook(
+        document if document is not None else _manifest(), DATA_MODEL, CSV_HEADERS, tokens
+    )
+
+
+ALL_CHARTS_XML = _render()
+ALL_CHARTS_ROOT = ET.fromstring(ALL_CHARTS_XML)
+
+
+def _worksheet_element(name: str, root: ET.Element = ALL_CHARTS_ROOT) -> ET.Element:
+    """Return the ``<worksheet>`` with the given name."""
+    for element in root.findall("worksheets/worksheet"):
+        if element.get("name") == name:
+            return element
+    raise AssertionError(f"no worksheet named {name!r} in the rendered workbook")
+
+
+def _worksheet_xml(name: str, xml_text: str = ALL_CHARTS_XML) -> str:
+    """Return one worksheet's raw serialised XML, sliced out of the workbook text.
+
+    Sliced rather than re-serialised from the parsed tree on purpose: ``ET`` turns a CDATA
+    section back into entity-escaped text, which is exactly the mistake the golden has to
+    be able to catch (Tableau prints an entity-escaped field reference as literal text).
+    """
+    start = xml_text.index(f'<worksheet name="{name}">')
+    end = xml_text.index("</worksheet>", start) + len("</worksheet>")
+    return xml_text[start:end]
+
+
+# --- Golden output (AC #4) ----------------------------------------------------
+
+@pytest.mark.parametrize("slug,entry", CHART_CASES, ids=[slug for slug, _ in CHART_CASES])
+def test_chart_template_matches_its_golden(slug, entry):
+    """Each pattern's rendered worksheet is byte-identical to its golden file.
+
+    This is the regression net the ticket asks for: change a mark class, a shelf, an
+    encoding or a style rule and exactly the affected chart types fail, with the diff
+    naming what moved.
+    """
+    rendered = _worksheet_xml(entry["name"])
+    golden = GOLDEN_DIR / f"{slug}.xml"
+
+    if UPDATE_GOLDENS:
+        GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+        golden.write_text(rendered + "\n", encoding="utf-8")
+
+    assert golden.exists(), (
+        f"missing golden {golden.relative_to(GOLDEN_DIR.parents[2])} - regenerate with "
+        f"UPDATE_CHART_GOLDENS=1"
+    )
+    assert rendered == golden.read_text(encoding="utf-8").strip()
+
+
+#: The ticket's parity list, as ``slug -> what makes that pattern that pattern``. A golden
+#: set that drops one of these has stopped covering a legacy chart.
+REQUIRED_PATTERNS: dict[str, str] = {
+    "bar": "chart_type",
+    "bar-sorted": "sort",
+    "bar-filtered": "filters",
+    "bar-styled": "axis_titles",
+    "bar-stacked": "encodings",
+    "line": "chart_type",
+    "area": "chart_type",
+    "pie": "chart_type",
+    "scatter": "chart_type",
+    "text-table": "chart_type",
+    "kpi-card": "chart_type",
+    "histogram": "chart_type",
+    "map": "chart_type",
+    "dual-axis": "chart_type",
+    "combo": "chart_type",
+    "custom-tooltip": "tooltip",
+}
+
+
+def test_every_legacy_pattern_has_a_case():
+    """All 15 legacy patterns are covered, and each really exercises what defines it.
+
+    A bare count would pass with fifteen bar charts; this checks each named pattern is
+    present *and* that its distinguishing manifest key is actually set.
+    """
+    cases = dict(CHART_CASES)
+    assert len(cases) == len(CHART_CASES), "duplicate golden slug"
+    missing = sorted(set(REQUIRED_PATTERNS) - set(cases))
+    assert not missing, f"legacy pattern(s) with no golden case: {missing}"
+
+    chart_types = set()
+    for slug, key in REQUIRED_PATTERNS.items():
+        assert key in cases[slug], f"{slug} does not exercise its '{key}'"
+        chart_types.add(cases[slug]["chart_type"])
+
+    # The 15 patterns span 12 distinct chart types; the rest are modifiers.
+    assert chart_types == {
+        "bar", "line", "area", "pie", "scatter", "table", "text", "histogram", "map",
+        "dual-axis", "combo",
+    }
+
+
+def test_every_chart_type_is_buildable():
+    """Every type manifest.CHART_TYPES accepts has a spec - otherwise validate lets through
+    a chart the assembler renders as a bare Automatic mark."""
+    assert manifest.CHART_TYPES <= set(worksheet.CHART_SPECS)
+
+
+# --- Parameterisation, not copy-paste (AC #1) ---------------------------------
+
+#: Values that only exist in the legacy snippets. Any of them in generated XML means a
+#: template was copied rather than built.
+SNIPPET_LEAKS = (
+    "federated.1hckotw0bte0i51b8k3sd1ffpnqc",
+    "federated.0oycml11kgsls31h6pvlk0w4f5yj",
+    "8ED4AD55-A43F-4C33-B8C1-A6484D0F1985",
+    "Calculation_1923881515222933504",
+    "product_name",
+    "[cost]",
+)
+
+
+def test_no_snippet_values_leak():
+    """No snippet's datasource hash, UUID, calculation id or field name reaches the output."""
+    for leak in SNIPPET_LEAKS:
+        assert leak not in ALL_CHARTS_XML, f"snippet value {leak!r} leaked into the workbook"
+
+
+def test_the_same_manifest_rebuilds_byte_identical():
+    """Ids are hash-derived, so a re-run is diff-free (and the goldens are stable)."""
+    assert _render() == ALL_CHARTS_XML
+
+
+# --- Mark classes and shelves --------------------------------------------------
+
+@pytest.mark.parametrize("sheet_name,mark_class", [
+    ("Bar", "Automatic"),
+    ("Line", "Automatic"),
+    ("Area", "Area"),
+    ("Pie", "Pie"),
+    ("Scatter", "Automatic"),
+    ("Text Table", "Automatic"),
+    ("Kpi Card", "Automatic"),
+    ("Histogram", "Automatic"),
+    ("Map", "Automatic"),
+])
+def test_mark_class_per_chart_type(sheet_name, mark_class):
+    """The mark class is what makes Tableau draw the right shape; Area and Pie must be
+    explicit or Tableau falls back to a line."""
+    pane = _worksheet_element(sheet_name).find("table/panes/pane")
+    assert pane.find("mark").get("class") == mark_class
+
+
+def test_pie_and_kpi_put_everything_on_encodings():
+    """Both charts carry empty shelves - all their data flows through encodings."""
+    for sheet_name in ("Pie", "Kpi Card"):
+        table = _worksheet_element(sheet_name).find("table")
+        assert not (table.findtext("rows") or "").strip()
+        assert not (table.findtext("cols") or "").strip()
+
+
+def test_pie_has_a_wedge_size_encoding():
+    """wedge-size is what gives each slice its angle; without it the pie is one wedge."""
+    encodings = _worksheet_element("Pie").find("table/panes/pane/encodings")
+    assert encodings.find("wedge-size") is not None
+
+
+def test_line_uses_a_continuous_truncated_date():
+    """A discrete date draws bars; the Month-Trunc continuous instance is what makes a line."""
+    element = _worksheet_element("Line")
+    instance = element.find(
+        "table/view/datasource-dependencies/"
+        "column-instance[@name='[tmn:order_date:qk]']"
+    )
+    assert instance is not None
+    assert instance.get("derivation") == "Month-Trunc"
+    assert instance.get("type") == "quantitative"
+    assert "[tmn:order_date:qk]" in element.findtext("table/cols")
+
+
+def test_scatter_puts_measures_on_both_axes_and_a_dimension_on_detail():
+    """Two continuous measures are what turn a view into a scatter plot."""
+    element = _worksheet_element("Scatter")
+    assert "[sum:profit:qk]" in element.findtext("table/cols")
+    assert "[sum:revenue:qk]" in element.findtext("table/rows")
+    assert element.find("table/panes/pane/encodings/lod") is not None
+
+
+def test_text_table_puts_dimensions_on_both_axes_and_the_measure_on_text():
+    """The measure appears only as a label - that is what makes it a table, not a chart."""
+    element = _worksheet_element("Text Table")
+    assert "[none:region:nk]" in element.findtext("table/cols")
+    assert "[none:product_category:nk]" in element.findtext("table/rows")
+    assert element.find("table/panes/pane/encodings/text") is not None
+
+
+def test_labelled_charts_show_their_mark_labels():
+    """A text table or pie whose labels are off renders as blank cells / unlabelled wedges."""
+    for sheet_name in ("Text Table", "Pie", "Kpi Card"):
+        rule = _worksheet_element(sheet_name).find(
+            "table/panes/pane/style/style-rule[@element='mark']"
+        )
+        shown = {fmt.get("attr"): fmt.get("value") for fmt in rule.findall("format")}
+        assert shown["mark-labels-show"] == "true"
+
+
+def test_kpi_card_renders_its_value_as_a_big_cdata_label():
+    """The KPI's number comes from a customized-label; the field reference must be CDATA,
+    or Tableau prints the reference as literal text."""
+    element = _worksheet_element("Kpi Card")
+    run = element.find("table/panes/pane/customized-label/formatted-text/run")
+    assert run.get("bold") == "true"
+    assert int(run.get("fontsize")) >= 22
+    assert "[sum:revenue:qk]" in run.text
+    assert "<![CDATA[<[federated." in ALL_CHARTS_XML
+
+
+def test_histogram_declares_a_bin_column_and_slices_it_ordinally():
+    """A histogram's x axis is a bin *column* with its own calculation, not a derivation."""
+    element = _worksheet_element("Histogram")
+    column = element.find(
+        "table/view/datasource-dependencies/column[@name='[Revenue (bin)]']"
+    )
+    assert column.get("role") == "dimension"
+    calculation = column.find("calculation")
+    assert calculation.get("class") == "bin"
+    assert calculation.get("formula") == "[revenue]"
+    assert calculation.get("size") == "500"
+    assert "[none:Revenue (bin):ok]" in element.findtext("table/cols")
+
+
+def test_a_bin_column_is_also_declared_on_the_datasource():
+    """Tableau drops a calculation that exists only inside a worksheet when it saves."""
+    column = ALL_CHARTS_ROOT.find(
+        "datasources/datasource/column[@name='[Revenue (bin)]']"
+    )
+    assert column is not None and column.find("calculation") is not None
+
+
+def test_a_calculated_field_reaches_the_datasource_and_the_shelf():
+    """A shelf can only reference a calculated field the datasource actually declares."""
+    column = ALL_CHARTS_ROOT.find(
+        "datasources/datasource/column[@name='[Margin Pct]']"
+    )
+    assert column.find("calculation").get("formula") == "SUM([profit]) / SUM([revenue])"
+    assert "[usr:Margin Pct:qk]" in _worksheet_element("Calculated Field").findtext(
+        "table/rows"
+    )
+
+
+def test_an_already_aggregated_calculation_is_not_aggregated_again():
+    """SUM(SUM([profit]) / SUM([revenue])) is an error Tableau refuses - an aggregate calc
+    goes on the shelf as-is, which Tableau records as the 'User' derivation."""
+    instance = _worksheet_element("Calculated Field").find(
+        "table/view/datasource-dependencies/column-instance[@column='[Margin Pct]']"
+    )
+    assert instance.get("derivation") == "User"
+    assert instance.get("name") == "[usr:Margin Pct:qk]"
+
+
+def test_a_row_level_calculation_still_gets_the_default_sum():
+    """Only *aggregate* formulas skip the default aggregation; a row-level calc is an
+    ordinary measure and must still be summed."""
+    document = _manifest(
+        [_sheet("Line Total", "bar",
+                shelves={"columns": ["region"], "rows": ["Line Total"]})],
+        calculated_fields=[{
+            "name": "Line Total", "formula": "[revenue] - [profit]",
+            "datasource": "sales_orders", "type": "real",
+        }],
+    )
+    element = _worksheet_element("Line Total", ET.fromstring(_render(document)))
+    instance = element.find(
+        "table/view/datasource-dependencies/column-instance[@column='[Line Total]']"
+    )
+    assert instance.get("derivation") == "Sum"
+
+
+@pytest.mark.parametrize("formula,aggregate", [
+    ("SUM([profit]) / SUM([revenue])", True),
+    ("COUNTD([order_id])", True),
+    ("WINDOW_AVG(SUM([revenue]))", True),
+    ("[revenue] - [profit]", False),
+    ("IF [revenue] > 0 THEN 1 ELSE 0 END", False),
+])
+def test_aggregate_formula_detection(formula, aggregate):
+    """The rule that decides it, pinned directly."""
+    assert worksheet.is_aggregate_formula(formula) is aggregate
+
+
+def test_map_uses_the_generated_geographic_fields():
+    """A map plots Tableau's generated lat/long, with the real dimension on Detail."""
+    element = _worksheet_element("Map")
+    assert "[Longitude (generated)]" in element.findtext("table/cols")
+    assert "[Latitude (generated)]" in element.findtext("table/rows")
+    assert element.find("table/view/mapsources/mapsource") is not None
+    assert element.find("table/panes/pane/encodings/geometry") is not None
+    column = element.find("table/view/datasource-dependencies/column[@name='[country]']")
+    assert column.get("semantic-role") == "[Country].[ISO3166_2]"
+
+
+def test_a_map_declares_its_basemap_at_the_workbook_level_too():
+    """The <mapsources> in the view references a source the workbook must declare; one
+    without the other renders no basemap."""
+    assert ALL_CHARTS_ROOT.findtext("mapsources/mapsource") is not None or (
+        ALL_CHARTS_ROOT.find("mapsources/mapsource") is not None
+    )
+    assert ALL_CHARTS_ROOT.find("mapsources/mapsource").get("name") == "Tableau"
+
+
+def test_no_map_means_no_workbook_mapsources():
+    """A workbook with no map has no basemap to declare."""
+    document = _manifest([_sheet(
+        "Bar", "bar", shelves={"columns": ["region"], "rows": ["revenue"]},
+    )])
+    assert ET.fromstring(_render(document)).find("mapsources") is None
+
+
+def test_a_kpi_card_suppresses_its_tooltip():
+    """A KPI card is one number, not a mark worth hovering."""
+    style = _worksheet_element("Kpi Card").find("table/tooltip-style")
+    assert style.get("tooltip-mode") == "none"
+    assert _worksheet_element("Bar").find("table/tooltip-style") is None
+
+
+def test_a_histogram_shows_its_empty_bins():
+    """Without show-full-range an empty bin vanishes and the distribution misreads."""
+    element = _worksheet_element("Histogram")
+    columns = element.findall("table/show-full-range/column")
+    assert [column.text.rsplit(".", 1)[-1] for column in columns] == ["[Revenue (bin)]"]
+    assert _worksheet_element("Bar").find("table/show-full-range") is None
+
+
+def test_dual_axis_overlays_two_measures_across_three_panes():
+    """Pane 0 is shared; panes 1 and 2 each own one measure's axis, in shelf order."""
+    element = _worksheet_element("Dual Axis")
+    assert element.findtext("table/rows") == (
+        "([{ds}].[sum:revenue:qk] + [{ds}].[sum:profit:qk])".format(
+            ds=twb.datasource_id("sales_orders")
+        )
+    )
+    panes = element.findall("table/panes/pane")
+    assert len(panes) == 3
+    assert [pane.get("id") for pane in panes] == [None, "1", "2"]
+    assert panes[1].get("y-axis-name").endswith("[sum:revenue:qk]")
+    assert panes[2].get("y-axis-name").endswith("[sum:profit:qk]")
+
+
+def test_dual_axis_synchronises_and_hides_the_second_axis():
+    """Unsynchronised axes make two unrelated scales look like one chart."""
+    rule = _worksheet_element("Dual Axis").find("table/style/style-rule[@element='axis']")
+    assert rule.find("encoding").get("synchronized") == "true"
+    assert rule.find("format").get("value") == "false"
+
+
+def test_combo_overrides_the_mark_class_per_pane():
+    """The only structural difference from a dual axis: Bar on one axis, Line on the other."""
+    panes = _worksheet_element("Combo").findall("table/panes/pane")
+    assert [pane.find("mark").get("class") for pane in panes] == [
+        "Automatic", "Bar", "Line",
+    ]
+
+
+def test_dual_charts_colour_their_measures_apart():
+    """Without Measure Names on colour, both series draw in one colour."""
+    for sheet_name in ("Dual Axis", "Combo"):
+        for pane in _worksheet_element(sheet_name).findall("table/panes/pane"):
+            assert pane.find("encodings/color").get("column").endswith("[:Measure Names]")
+
+
+# --- Modifiers: sort, filters, tooltip ----------------------------------------
+
+def test_computed_sort_names_the_dimension_and_the_measure():
+    """A sorted bar orders its dimension *by* a measure - both references must resolve."""
+    sort = _worksheet_element("Bar Sorted").find("table/view/computed-sort")
+    assert sort.get("column").endswith("[none:product_category:nk]")
+    assert sort.get("using").endswith("[sum:revenue:qk]")
+    assert sort.get("direction") == "DESC"
+
+
+def test_a_manual_sort_writes_the_member_order():
+    """An explicit order becomes a <dictionary> of quoted buckets."""
+    document = _manifest([_sheet(
+        "Manual", "bar",
+        shelves={"columns": ["region"], "rows": ["revenue"]},
+        sort={"field": "region", "direction": "ASC", "order": ["West", "East"]},
+    )])
+    element = _worksheet_element("Manual", ET.fromstring(_render(document)))
+    buckets = element.findall("table/view/sort/dictionary/bucket")
+    assert [bucket.text for bucket in buckets] == ['"West"', '"East"']
+
+
+def test_a_multi_value_filter_wraps_its_members_in_a_union():
+    """One member is a bare groupfilter; several need a union, or only the last applies."""
+    element = _worksheet_element("Bar Filtered")
+    categorical = element.find("table/view/filter[@class='categorical']")
+    assert categorical.get("context") == "true"
+    union = categorical.find("groupfilter")
+    assert union.get("function") == "union"
+    assert [member.get("member") for member in union.findall("groupfilter")] == [
+        '"Europe"', '"Asia"',
+    ]
+
+
+def test_a_date_range_filter_uses_hash_delimited_bounds_and_a_continuous_instance():
+    """Tableau needs #...# literals, and a range needs the continuous date instance."""
+    element = _worksheet_element("Bar Filtered")
+    quantitative = element.find("table/view/filter[@class='quantitative']")
+    assert quantitative.get("column").endswith("[none:order_date:qk]")
+    assert quantitative.findtext("min") == "#2025-03-03#"
+    assert quantitative.findtext("max") == "#2025-04-22#"
+
+
+def test_every_filtered_field_is_declared_and_sliced():
+    """A filter on an undeclared field, or one missing from <slices>, is silently ignored."""
+    element = _worksheet_element("Bar Filtered")
+    declared = {
+        instance.get("name")
+        for instance in element.findall("table/view/datasource-dependencies/column-instance")
+    }
+    for filter_element in element.findall("table/view/filter"):
+        column = filter_element.get("column")
+        assert column.rsplit(".", 1)[-1] in declared
+    sliced = {column.text for column in element.findall("table/view/slices/column")}
+    assert sliced == {
+        filter_element.get("column")
+        for filter_element in element.findall("table/view/filter")
+    }
+
+
+def test_a_custom_tooltip_registers_every_field_it_names():
+    """The three-part chain: declared instance, tooltip encoding, template run."""
+    element = _worksheet_element("Custom Tooltip")
+    pane = element.find("table/panes/pane")
+    registered = {
+        tooltip.get("column").rsplit(".", 1)[-1]
+        for tooltip in pane.findall("encodings/tooltip")
+    }
+    assert registered == {"[attr:product_category:nk]", "[sum:revenue:qk]"}
+
+    runs = pane.findall("customized-tooltip/formatted-text/run")
+    assert runs[0].text == "Category:"
+    assert "[attr:product_category:nk]" in runs[2].text
+    # The value runs must be CDATA - entity-escaped, Tableau prints the reference verbatim.
+    assert "<![CDATA[<[federated" in _worksheet_xml("Custom Tooltip")
+
+
+def test_a_tooltip_field_reaches_the_dependencies():
+    """A tooltip-only field still has to be declared, or the tooltip renders empty."""
+    declared = {
+        instance.get("name")
+        for instance in _worksheet_element("Custom Tooltip").findall(
+            "table/view/datasource-dependencies/column-instance"
+        )
+    }
+    assert "[attr:product_category:nk]" in declared
+
+
+# --- Design tokens (AC #3) -----------------------------------------------------
+
+def test_tokens_set_the_body_font_and_the_title_run():
+    """Font family and title styling are the tokens a worksheet can genuinely carry."""
+    element = _worksheet_element("Bar")
+    run = element.find("layout-options/title/formatted-text/run")
+    assert run.get("fontname") == "Open Sans"
+    assert run.get("fontsize") == "14"
+    assert run.get("fontcolor") == "#7f56d9"
+
+    rule = element.find("table/style/style-rule[@element='worksheet']")
+    assert rule.find("format").get("value") == "Open Sans"
+
+
+def test_token_hex_colours_are_lower_cased():
+    """DESIGN-TOKENS.md writes #7F56D9; Tableau writes lower case, so a save would diff."""
+    assert "#7F56D9" not in ALL_CHARTS_XML
+
+
+def test_without_tokens_no_styling_is_invented():
+    """No branding step means Tableau's own defaults - not a made-up font or colour."""
+    root = ET.fromstring(_render(tokens=""))
+    element = _worksheet_element("Bar", root)
+    assert element.find("layout-options") is None
+    assert element.find("table/style/style-rule[@element='worksheet']") is None
+
+
+def test_an_unfilled_token_template_is_ignored():
+    """A DESIGN-TOKENS.md still carrying '[font]' placeholders must not style anything
+    with the literal placeholder text."""
+    tokens = worksheet.parse_design_tokens(
+        "## Typography\n\n- **Font family**: [font]\n- **Chart title**: [size]px\n"
+    )
+    assert tokens.font_family == worksheet.DEFAULT_FONT
+
+
+def test_style_rules_are_alphabetical_by_element():
+    """Tableau Desktop rewrites them alphabetically on save; emitting any other order
+    produces a diff the analyst did not make."""
+    for element in ALL_CHARTS_ROOT.findall("worksheets/worksheet"):
+        for style in element.findall(".//style"):
+            elements = [rule.get("element") for rule in style.findall("style-rule")]
+            assert elements == sorted(elements), element.get("name")
+
+
+# --- Legends -------------------------------------------------------------------
+
+def _worksheet_windows() -> dict:
+    """``{sheet name: <window>}`` for the worksheet-class windows."""
+    return {
+        window.get("name"): window
+        for window in ALL_CHARTS_ROOT.findall("windows/window")
+        if window.get("class") == "worksheet"
+    }
+
+
+def test_colour_and_size_encoded_charts_get_legend_cards():
+    """A chart encoded by colour with no legend renders, but reads as broken."""
+    windows = _worksheet_windows()
+    pie_cards = windows["Pie"].findall("cards/edge[@name='right']/strip/card")
+    assert [card.get("type") for card in pie_cards] == ["color", "size"]
+    assert all(card.get("param") for card in pie_cards)
+    assert all(card.get("pane-specification-id") == "0" for card in pie_cards)
+
+    assert windows["Bar"].find("cards/edge[@name='right']") is None
+
+
+@pytest.mark.parametrize("sheet_name", ["Dual Axis", "Combo"])
+def test_dual_charts_get_a_measure_names_legend_on_their_first_measure_pane(sheet_name):
+    """Their colour comes from the built-in Measure Names, which the manifest never names -
+    so the legend has to be derived from the chart type, and it belongs to pane 1."""
+    card = _worksheet_windows()[sheet_name].find(
+        "cards/edge[@name='right']/strip/card"
+    )
+    assert card.get("type") == "color"
+    assert card.get("param").endswith("[:Measure Names]")
+    assert card.get("pane-specification-id") == "1"
+
+
+# --- The whole workbook still validates ----------------------------------------
+
+def test_the_all_charts_workbook_passes_the_semantic_validator(tmp_path):
+    """Every migrated breakage check, over a workbook holding every chart type (AC #2)."""
+    import validate_twb
+
+    twb_path = tmp_path / "all-charts.twb"
+    twb_path.write_text(ALL_CHARTS_XML, encoding="utf-8")
+    report = validate_twb.TwbValidator(str(twb_path)).validate()
+    failures = [
+        f"{result.name}: {result.details}" for result in report.results if not result.passed
+    ]
+    assert not failures
+
+
+def test_the_all_charts_workbook_passes_the_xsd(tmp_path):
+    """Schema-valid against the 2026.1 XSD - the element order inside a worksheet is not
+    something the assembler may get 'nearly' right."""
+    lxml = pytest.importorskip("lxml")  # noqa: F841 - the validator imports it itself
+    import validate_twb_xsd
+
+    twb_path = tmp_path / "all-charts.twb"
+    twb_path.write_text(ALL_CHARTS_XML, encoding="utf-8")
+    _, errors = validate_twb_xsd.validate(
+        twb_path, validate_twb_xsd.load_schema(validate_twb_xsd.XSD_PATH)
+    )
+    assert not [f"line {error.line}: {error.message}" for error in errors]
+
+
+def test_an_all_charts_manifest_validates(tmp_path):
+    """The schema accepts every chart type and modifier key the templates support - a
+    manifest the builder can render must not be one validate rejects."""
+    assert manifest.validate_manifest(_manifest(), DATA_MODEL, TARGET_VERSION) == []
+
+
+def test_a_dual_axis_without_two_measures_is_rejected():
+    """One measure on rows means no second axis - the chart type is the wrong choice."""
+    document = _manifest([_sheet("Dual", "dual-axis", shelves={
+        "columns": ["region"], "rows": ["revenue"],
+    })])
+    errors = manifest.validate_manifest(document, DATA_MODEL, TARGET_VERSION)
+    assert any("exactly two measures" in error for error in errors)
+
+
+def test_a_negative_bin_width_is_rejected():
+    """A bin of 0 or less would divide the axis into nothing."""
+    document = _manifest([_sheet("Hist", "histogram", shelves={
+        "columns": [{"field": "revenue", "bin": 0}], "rows": ["revenue"],
+    })])
+    errors = manifest.validate_manifest(document, DATA_MODEL, TARGET_VERSION)
+    assert any("bin width must be a positive number" in error for error in errors)
+
+
+def test_a_filter_with_nothing_to_filter_on_is_rejected():
+    """The builder would drop it and Tableau would show no sign - name the row instead."""
+    document = _manifest([_sheet(
+        "Empty Filter", "bar",
+        shelves={"columns": ["region"], "rows": ["revenue"]},
+        filters=[{"field": "region", "context": True}],
+    )])
+    errors = manifest.validate_manifest(document, DATA_MODEL, TARGET_VERSION)
+    assert any("nothing to filter on" in error for error in errors)
+
+
+def test_a_sort_with_neither_by_nor_order_is_rejected():
+    """Same failure mode: an incomplete sort silently does nothing."""
+    document = _manifest([_sheet(
+        "Empty Sort", "bar",
+        shelves={"columns": ["region"], "rows": ["revenue"]},
+        sort={"field": "region", "direction": "ASC"},
+    )])
+    errors = manifest.validate_manifest(document, DATA_MODEL, TARGET_VERSION)
+    assert any("neither 'by'" in error for error in errors)
+
+
+def test_a_filter_on_an_undocumented_field_is_rejected():
+    """Modifier fields are resolved as strictly as shelf fields."""
+    document = _manifest([_sheet(
+        "Bad Filter", "bar",
+        shelves={"columns": ["region"], "rows": ["revenue"]},
+        filters=[{"field": "no_such_field", "values": ["x"]}],
+    )])
+    errors = manifest.validate_manifest(document, DATA_MODEL, TARGET_VERSION)
+    assert any("no_such_field" in error for error in errors)
+
+
+# --- End to end through build.py -----------------------------------------------
+
+def test_build_packages_a_workbook_holding_every_chart_type(tmp_path):
+    """The ticket's headline: a workbook with one sheet per chart type builds, passes both
+    validators, and is packaged (AC #2 - the Tableau Desktop open is manual)."""
+    import init
+    import json
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "STATE.md").write_text(
+        build.apply_status_updates(
+            init.render_state_md(TARGET_VERSION),
+            {"data": "approved", "spec": "approved"},
+        ),
+        encoding="utf-8",
+    )
+    (project / "DATA-MODEL.md").write_text(DATA_MODEL, encoding="utf-8")
+    (project / "DESIGN-TOKENS.md").write_text(DESIGN_TOKENS, encoding="utf-8")
+    data_dir = project / "data"
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / "sales_orders.csv").write_text(
+        ",".join(CSV_HEADERS["sales_orders.csv"]) + "\n", encoding="utf-8"
+    )
+
+    document = _manifest()
+    version_dir = project / "mock-version" / "v_1"
+    version_dir.mkdir(parents=True, exist_ok=True)
+    (version_dir / "IMPLEMENTATION-SPEC.md").write_text(
+        "# Spec\n\n## Layout\n\n```json\n"
+        + json.dumps(document["layout"], indent=2)
+        + "\n```\n",
+        encoding="utf-8",
+    )
+    (version_dir / "build-manifest.json").write_text(
+        json.dumps(document, indent=2), encoding="utf-8"
+    )
+
+    result = build.build_workbook(project)
+    assert result.ok, result.errors
+    assert (project / result.twbx_path).exists()
+    assert len(
+        ET.fromstring(
+            (project / result.twb_path).read_text(encoding="utf-8")
+        ).findall("worksheets/worksheet")
+    ) == len(CHART_CASES)

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -518,6 +518,26 @@ def test_no_map_means_no_workbook_mapsources():
     assert ET.fromstring(_render(document)).find("mapsources") is None
 
 
+def test_a_sorted_workbook_carries_the_sort_format_flag():
+    """WORKSHEETS.md:512 - a workbook holding a sorted worksheet adds <SortTagCleanup/> to
+    the format-change manifest, and Tableau writes those flags alphabetically."""
+    flags = [
+        element.tag
+        for element in ALL_CHARTS_ROOT.find("document-format-change-manifest")
+    ]
+    assert "SortTagCleanup" in flags
+    assert flags == sorted(flags)
+
+    unsorted_document = _manifest([_sheet(
+        "Bar", "bar", shelves={"columns": ["region"], "rows": ["revenue"]},
+    )])
+    unsorted_root = ET.fromstring(_render(unsorted_document))
+    unsorted_flags = [
+        element.tag for element in unsorted_root.find("document-format-change-manifest")
+    ]
+    assert "SortTagCleanup" not in unsorted_flags
+
+
 def test_a_kpi_card_suppresses_its_tooltip():
     """A KPI card is one number, not a mark worth hovering."""
     style = _worksheet_element("Kpi Card").find("table/tooltip-style")
@@ -799,6 +819,18 @@ def test_a_filter_with_nothing_to_filter_on_is_rejected():
     )])
     errors = manifest.validate_manifest(document, DATA_MODEL, TARGET_VERSION)
     assert any("nothing to filter on" in error for error in errors)
+
+
+def test_an_unknown_encoding_name_is_rejected():
+    """The builder only emits ENCODING_ORDER, so a typo'd 'colour' would vanish - the field
+    behind it validates fine, which is exactly what makes the name worth checking."""
+    document = _manifest([_sheet(
+        "Typo", "bar",
+        shelves={"columns": ["region"], "rows": ["revenue"]},
+        encodings={"colour": "product_category"},
+    )])
+    errors = manifest.validate_manifest(document, DATA_MODEL, TARGET_VERSION)
+    assert any("unknown encoding 'colour'" in error for error in errors)
 
 
 def test_a_sort_with_neither_by_nor_order_is_rejected():

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -676,8 +676,11 @@ def test_a_custom_tooltip_registers_every_field_it_names():
     assert registered == {"[attr:product_category:nk]", "[sum:revenue:qk]"}
 
     runs = pane.findall("customized-tooltip/formatted-text/run")
-    assert runs[0].text == "Category:"
-    assert "[attr:product_category:nk]" in runs[2].text
+    # Label and value share a line: no break between them, one break between pairs.
+    assert runs[0].text == "Category: "
+    assert "[attr:product_category:nk]" in runs[1].text
+    assert runs[2].text == worksheet.TOOLTIP_BREAK
+    assert runs[3].text == "Revenue: "
     # The value runs must be CDATA - entity-escaped, Tableau prints the reference verbatim.
     assert "<![CDATA[<[federated" in _worksheet_xml("Custom Tooltip")
 

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -518,6 +518,21 @@ def test_no_map_means_no_workbook_mapsources():
     assert ET.fromstring(_render(document)).find("mapsources") is None
 
 
+def test_a_sheet_no_dashboard_zone_shows_keeps_its_tab():
+    """Tableau renders no tab for hidden='true', so hiding a sheet the dashboard does not
+    embed makes it unreachable - the workbook opens with nothing in it. Until the zone tree
+    lands, no sheet is embedded, so no sheet may be hidden."""
+    hidden = [
+        window.get("name")
+        for window in ALL_CHARTS_ROOT.find("windows")
+        if window.get("class") == "worksheet" and window.get("hidden") == "true"
+    ]
+    assert hidden == []
+
+    zones = ALL_CHARTS_ROOT.findall("dashboards/dashboard/zones//zone")
+    assert not [zone.get("name") for zone in zones if zone.get("name")]
+
+
 def test_a_sorted_workbook_carries_the_sort_format_flag():
     """WORKSHEETS.md:512 - a workbook holding a sorted worksheet adds <SortTagCleanup/> to
     the format-change manifest, and Tableau writes those flags alphabetically."""


### PR DESCRIPTION
Closes #35. Also closes #43 (tooltip line-break bug found reviewing this branch's output in Tableau Desktop).

## What this does

Every one of the 15 chart patterns the legacy skill shipped as a hand-written `.twb` snippet is now **generated from manifest fields**. The old workflow copy-pasted a snippet and search-replaced field names; anything it missed — a stale datasource hash, a UUID, a leftover `profit` — shipped to the analyst. Nothing is copied any more.

The 15 patterns are not 15 chart types. `sorted` / `filtered` / `styled` / `custom tooltip` are **modifiers** (the `sort` / `filters` / `axis_titles`+`number_formats` / `tooltip` manifest keys) that apply to any chart, and a stacked bar is a bar with a colour encoding. So the implementation is 12 `chart_type` values plus the modifier keys, covering all 15.

New module `skills/tableau-build/scripts/worksheet.py` (~1150 lines) owns the whole worksheet: field resolution, shelves, encodings, marks, panes, filters, sorts, tooltips, legend cards, bins and calculated fields. `manifest.py` and `twb.py` grew the plumbing to reach it.

## Review protection

Each pattern's rendered `<worksheet>` is pinned to a golden under `tests/fixtures/charts/`, so a template change surfaces as a diff on the exact chart types it affects rather than as a workbook that opens blank in Tableau. Regenerate with `UPDATE_CHART_GOLDENS=1 python -m pytest tests/test_charts.py -q` — and read that diff, because the diff *is* the review. A separate test fails if any snippet-era literal leaks into the output.

## Commits

- `1b56f2a` the 15 templates and their goldens
- `8118368` second-review findings
- `965a2ab` stop hiding every sheet — `_render_windows` assumed the dashboard embedded the worksheets it was hiding, which no dashboard on this branch does yet, so Desktop opened with no visible tabs
- `861773a` custom tooltip put a line break between a label and its value (#43)

## Verified

- `python -m pytest -q` — 386 passed
- The all-charts workbook opens in Tableau Desktop and all 15 sheets render (manual verification, findings below)

## Known gaps, tracked not fixed

Human review of the built workbook in Desktop turned up formatting gaps that are **out of scope here** and tracked in #44 (which now precedes #38 and #39): no fit attribute is emitted so every sheet defaults to Standard rather than Entire View; colour palettes are never applied (a palette binds hex to concrete data members the manifest doesn't carry — see the note at `worksheet.py:84-87`); measures on the text mark are only exercised on KPI/table; and borders / lines / shading / alignment aren't expressible at all. #44 also carries the histogram bin-size default and the combo-vs-dual-axis overlap.

One demo-data quirk left deliberately alone: the `bar-filtered` golden filters a date window the sample CSV has no rows in, so that sheet renders empty in the review workbook. The filter itself is correct — including `region` as a context filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)