### PR TITLE
feat(build): dashboard layout engine - fixed-size zones from the layout JSON

### DIFF
--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -134,10 +134,18 @@ invented zone is caught rather than silently built.
   version is created by re-running `tableau-mock` (which bumps and stales spec and build).
 - **Live connection, always.** The workbook never carries an extract: the `.twbx` embeds the
   CSVs, and the analyst points it at the real database with Data → Replace Data Source.
-- **The dashboard's zone tree is still coming.** Today's assembler emits the datasources,
-  fully populated worksheets, a dashboard sized from the mock's canvas, and the windows.
-  Nesting the layout tree into dashboard zones is the next ticket, so every view renders but
-  the dashboard itself is still a single container.
+- **The dashboard is fixed-size and its zones are computed.** The `layout` tree becomes the
+  dashboard's zone hierarchy one-to-one: sibling `size` values are proportions of the parent
+  along its flow axis, mapped into Tableau's 0–100000 space at the canvas dimensions. A
+  worksheet's optional `title` becomes a text zone above its sheet zone (and suppresses the
+  sheet's own title); a colour-encoded chart gets a legend zone below it. Both stack *inside*
+  the element's own box, so they never disturb its siblings.
+- **A filter / parameter / image / button / legend object reserves its box, empty.** Each of
+  those zone types needs a reference the manifest does not carry yet (a field plus the
+  dashboard's own `<datasource-dependencies>`, a parameter, a filename, an action, a sheet +
+  colour field), and Tableau does not treat those as optional — so the layout keeps the
+  geometry and the features-and-actions ticket turns each into its real zone. `text` and
+  `blank` objects render fully today.
 
 > The full `STATE.md` schema and the ordering / staleness / versioning rules live in
 > `CONTRACT.md` at the repo root. This skill restates only its own slice; `build.py`,

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -134,12 +134,20 @@ invented zone is caught rather than silently built.
   version is created by re-running `tableau-mock` (which bumps and stales spec and build).
 - **Live connection, always.** The workbook never carries an extract: the `.twbx` embeds the
   CSVs, and the analyst points it at the real database with Data → Replace Data Source.
-- **The dashboard is fixed-size and its zones are computed.** The `layout` tree becomes the
-  dashboard's zone hierarchy one-to-one: sibling `size` values are proportions of the parent
-  along its flow axis, mapped into Tableau's 0–100000 space at the canvas dimensions. A
-  worksheet's optional `title` becomes a text zone above its sheet zone (and suppresses the
-  sheet's own title); a colour-encoded chart gets a legend zone below it. Both stack *inside*
-  the element's own box, so they never disturb its siblings.
+- **The zones are computed and the canvas is the dashboard's minimum size.** The `layout`
+  tree becomes the dashboard's zone hierarchy one-to-one: sibling `size` values are
+  proportions of the parent along its flow axis, mapped into Tableau's 0–100000 space at the
+  canvas dimensions. Because that space is normalised, the approved proportions hold at any
+  window size, so the dashboard is `sizing-mode='range'` with the canvas as `minwidth` /
+  `minheight` and **no maximum** — the analyst can lower the minimum in Desktop.
+- **Every view zone's header is a text object.** A sheet's *own* title is always off: Tableau
+  draws it inside the zone out of the sheet's own height, so a short zone (a KPI card) loses
+  its number to it. Give every `worksheets[]` entry a `title` — it becomes a text zone above
+  the sheet zone — or have the layout place a `text` object beside it; a view with neither
+  gets no header at all. A colour-encoded chart also gets a legend zone below it. Both
+  generated zones stack *inside* the element's own box, so they never disturb its siblings.
+- **Field labels are off on every sheet.** They repeat what the zone's header already says
+  and cost the chart a whole band of the sheet.
 - **A filter / parameter / image / button / legend object reserves its box, empty.** Each of
   those zone types needs a reference the manifest does not carry yet (a field plus the
   dashboard's own `<datasource-dependencies>`, a parameter, a filename, an action, a sheet +

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -134,12 +134,13 @@ invented zone is caught rather than silently built.
   version is created by re-running `tableau-mock` (which bumps and stales spec and build).
 - **Live connection, always.** The workbook never carries an extract: the `.twbx` embeds the
   CSVs, and the analyst points it at the real database with Data → Replace Data Source.
-- **The zones are computed and the canvas is the dashboard's minimum size.** The `layout`
-  tree becomes the dashboard's zone hierarchy one-to-one: sibling `size` values are
-  proportions of the parent along its flow axis, mapped into Tableau's 0–100000 space at the
-  canvas dimensions. Because that space is normalised, the approved proportions hold at any
-  window size, so the dashboard is `sizing-mode='range'` with the canvas as `minwidth` /
-  `minheight` and **no maximum** — the analyst can lower the minimum in Desktop.
+- **The zones are computed and the dashboard is range-sized.** The `layout` tree becomes the
+  dashboard's zone hierarchy one-to-one: sibling `size` values are proportions of the parent
+  along its flow axis, mapped into Tableau's 0–100000 space at the canvas dimensions. Because
+  that space is normalised, the approved proportions hold at any window size, so the dashboard
+  is `sizing-mode='range'` at a fixed **1100 × 800** minimum with **no maximum**. The canvas
+  is the design surface the tree was laid out against, not the size the analyst is stuck
+  with — who can change either bound in Desktop.
 - **Every view zone's header is a text object.** A sheet's *own* title is always off: Tableau
   draws it inside the zone out of the sheet's own height, so a short zone (a KPI card) loses
   its number to it. Give every `worksheets[]` entry a `title` — it becomes a text zone above

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -17,11 +17,14 @@ a bad spec-to-manifest translation is fixed row-by-row before any XML is generat
 | `layout` | yes | The spec's `## Layout` container tree, copied as-is (canvas + nested `vert`/`horz` + id leaves with `%` sizes). |
 | `actions` | yes (`[]` if none) | Dashboard actions; `type` from `filter`/`highlight`/`parameter`/`set`/`url`. `source` is always a zone; a target is a zone for `filter`/`highlight`, a declared parameter for `parameter` (see below). |
 | `parameters` | yes (`[]` if none) | Each needs a `name` and a `data_type`. |
-| `objects` | optional | Layout zones no view fills — a filter card, title text, a logo, a legend. `kind` from `filter`/`parameter`/`text`/`image`/`legend`/`button`/`blank`. |
+| `objects` | optional | Layout zones no view fills — a filter card, title text, a logo, a legend. `kind` from `filter`/`parameter`/`text`/`image`/`legend`/`button`/`blank`. `text` and `blank` render today; the rest reserve their box as an empty zone until the wiring they need lands. |
 | `calculated_fields` | optional | Fields that legitimately are not in the data model; declaring one makes it usable on a shelf of its `datasource`. |
 
 **Copy the `layout` tree from the spec verbatim** — `validate` diffs the two and rejects any
 zone the manifest drops or invents, so the workbook cannot disagree with the approved mock.
+The tree *is* the dashboard's zone hierarchy: each node becomes one zone, sibling `size`
+values are proportions of the parent along its flow axis, and the dashboard is fixed at
+`canvas` px. A child with no `size` shares whatever its siblings leave.
 
 **Every leaf zone must be filled** by exactly one worksheet or one `objects` entry — an
 unfilled zone would build an empty container. A *mapped container* (a node with both an `id`
@@ -68,6 +71,10 @@ Encodings the builder emits: `color`, `size`, `shape`, `text`, `lod`, `wedge-siz
 | `tooltip` | `[{"label": "Revenue", "field": "revenue", "aggregation": "sum"}]` | A custom tooltip template, one label/value pair per line. |
 | `axis_titles` | `{"rows": "Revenue per category"}` | Overrides the generated axis title. |
 | `number_formats` | `[{"field": "revenue", "format": "$#,##0"}]` | Cell number format for that field. |
+| `title` | `"Revenue by region"` | Puts a styled text zone above the sheet's zone in the dashboard and suppresses the sheet's own title. Omit to keep Tableau's sheet title. |
+
+An `objects` entry of `kind: "text"` takes its content the same way: `{"element_id":
+"txt-title", "kind": "text", "text": "Sales Performance"}`.
 
 Every modifier's field is resolved as strictly as a shelf field — a filter on a field the
 data model does not document is rejected, not silently dropped.
@@ -113,6 +120,7 @@ defaults apply. Nothing in the manifest sets fonts or colours.
       "element_id": "chart-trend",
       "chart_type": "line",
       "datasource": "sales_orders",
+      "title": "Revenue over time",
       "shelves": {
         "columns": [{"field": "order_date", "date_part": "month"}],
         "rows": [{"field": "revenue", "aggregation": "sum"}]

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -23,9 +23,10 @@ a bad spec-to-manifest translation is fixed row-by-row before any XML is generat
 **Copy the `layout` tree from the spec verbatim** — `validate` diffs the two and rejects any
 zone the manifest drops or invents, so the workbook cannot disagree with the approved mock.
 The tree *is* the dashboard's zone hierarchy: each node becomes one zone, sibling `size`
-values are proportions of the parent along its flow axis, and `canvas` px becomes the
-dashboard's *minimum* size (`sizing-mode='range'`, no maximum). A child with no `size` shares
-whatever its siblings leave.
+values are proportions of the parent along its flow axis, and `canvas` px is what those
+proportions are computed against — not the dashboard's size, which is `sizing-mode='range'` at
+a 1100 × 800 minimum with no maximum. A child with no `size` shares whatever its siblings
+leave.
 
 **Give every view element a header.** A sheet's own title never renders on the dashboard, so
 a `worksheets[]` entry without a `title` (or a `text` object placed beside it in the tree)

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -23,8 +23,13 @@ a bad spec-to-manifest translation is fixed row-by-row before any XML is generat
 **Copy the `layout` tree from the spec verbatim** — `validate` diffs the two and rejects any
 zone the manifest drops or invents, so the workbook cannot disagree with the approved mock.
 The tree *is* the dashboard's zone hierarchy: each node becomes one zone, sibling `size`
-values are proportions of the parent along its flow axis, and the dashboard is fixed at
-`canvas` px. A child with no `size` shares whatever its siblings leave.
+values are proportions of the parent along its flow axis, and `canvas` px becomes the
+dashboard's *minimum* size (`sizing-mode='range'`, no maximum). A child with no `size` shares
+whatever its siblings leave.
+
+**Give every view element a header.** A sheet's own title never renders on the dashboard, so
+a `worksheets[]` entry without a `title` (or a `text` object placed beside it in the tree)
+shows up with no header at all.
 
 **Every leaf zone must be filled** by exactly one worksheet or one `objects` entry — an
 unfilled zone would build an empty container. A *mapped container* (a node with both an `id`

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -31,6 +31,7 @@ import hashlib
 import uuid
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
+from typing import NamedTuple
 
 import worksheet
 import zones
@@ -369,7 +370,7 @@ def _render_datasource(
 # --- Worksheets, dashboard, windows --------------------------------------------
 
 def _dashboard_leaves(
-    plans: list[tuple[str, dict, worksheet.WorksheetPlan]], objects: object
+    plans: list[PlannedWorksheet], objects: object
 ) -> dict[str, zones.Leaf]:
     """Map every layout element id to what fills its zone.
 
@@ -378,7 +379,7 @@ def _dashboard_leaves(
     the views and the non-view objects.
 
     Args:
-        plans: The resolved worksheets, as ``(datasource, manifest entry, plan)``.
+        plans: The resolved worksheets.
         objects: The manifest's optional ``objects`` list.
 
     Returns:
@@ -392,10 +393,10 @@ def _dashboard_leaves(
         # Only the colour legend is placed in the dashboard; size/shape keys stay on the
         # worksheet's own right edge, where they do not compete for the element's box.
         legend = next(
-            ((reference, pane_id)
+            (zones.Legend(reference, pane_id)
              for card_type, reference, pane_id in worksheet.legend_cards(plan)
              if card_type == "color"),
-            (),
+            None,
         )
         # First claimant wins: two views on one zone is a manifest bug, and picking the
         # later one would silently move the analyst's chart.
@@ -590,16 +591,30 @@ def _build_resolvers(
     return resolvers
 
 
+class PlannedWorksheet(NamedTuple):
+    """One resolved worksheet and the two things about it the plan does not carry.
+
+    The manifest entry travels alongside the plan because the *dashboard* needs what a
+    :class:`worksheet.WorksheetPlan` deliberately knows nothing about - the ``element_id`` the
+    sheet fills and its title - while the datasource name is what the derived-column pass
+    groups by.
+
+    Attributes:
+        datasource: The datasource name the worksheet reads.
+        entry: The raw ``worksheets`` entry from the manifest.
+        plan: The resolved plan the worksheet body is rendered from.
+    """
+
+    datasource: str
+    entry: dict
+    plan: worksheet.WorksheetPlan
+
+
 def _plan_worksheets(
     manifest_document: dict, resolvers: dict[str, worksheet.FieldResolver]
-) -> list[tuple[str, dict, worksheet.WorksheetPlan]]:
-    """Resolve every manifest worksheet into ``(datasource, manifest entry, plan)``.
-
-    The entry travels with the plan because the *dashboard* needs what the plan deliberately
-    does not carry - the ``element_id`` the sheet fills and its title - while the datasource
-    name is what the derived-column pass groups by.
-    """
-    plans: list[tuple[str, dict, worksheet.WorksheetPlan]] = []
+) -> list[PlannedWorksheet]:
+    """Resolve every manifest worksheet into a :class:`PlannedWorksheet`."""
+    plans: list[PlannedWorksheet] = []
     for entry in manifest_document.get("worksheets", []) or []:
         if not isinstance(entry, dict):
             continue
@@ -607,14 +622,16 @@ def _plan_worksheets(
         resolver = resolvers.get(source)
         if resolver is None:  # validate_manifest already named this worksheet
             continue
-        plans.append((source, entry, worksheet.plan_worksheet(entry, resolver)))
+        plans.append(
+            PlannedWorksheet(source, entry, worksheet.plan_worksheet(entry, resolver))
+        )
     return plans
 
 
 def _collect_derived_columns(
     manifest_document: dict,
     resolvers: dict[str, worksheet.FieldResolver],
-    plans: list[tuple[str, dict, worksheet.WorksheetPlan]],
+    plans: list[PlannedWorksheet],
 ) -> dict[str, list[worksheet.FieldRef]]:
     """Collect the non-CSV columns each datasource must declare.
 
@@ -643,9 +660,11 @@ def _collect_derived_columns(
         if reference is not None:
             derived.setdefault(source, {}).setdefault(reference.column_name, reference)
 
-    for source, _, plan in plans:
-        for reference in worksheet.bin_columns(plan):
-            derived.setdefault(source, {}).setdefault(reference.column_name, reference)
+    for planned in plans:
+        for reference in worksheet.bin_columns(planned.plan):
+            derived.setdefault(planned.datasource, {}).setdefault(
+                reference.column_name, reference
+            )
 
     return {source: list(columns.values()) for source, columns in derived.items()}
 
@@ -712,7 +731,7 @@ def render_workbook(
             derived.get(name, []),
         )
 
-    if any(plan.spec.geographic for _, _, plan in plans):
+    if any(planned.plan.spec.geographic for planned in plans):
         # A map needs its <mapsources> at *both* levels: the workbook's declares the source,
         # each map worksheet's view references it. One without the other renders no basemap.
         ET.SubElement(
@@ -721,12 +740,15 @@ def render_workbook(
 
     if plans:  # the XSD requires >=1 <worksheet>; omit the element otherwise
         worksheets = ET.SubElement(workbook, "worksheets")
-        for _, _, plan in plans:
+        for planned in plans:
             worksheet.render_worksheet(
-                worksheets, plan, tokens, simple_id("worksheet", plan.name)
+                worksheets, planned.plan, tokens,
+                simple_id("worksheet", planned.plan.name),
             )
 
-    layout = manifest_document.get("layout") if isinstance(manifest_document.get("layout"), dict) else {}
+    layout = manifest_document.get("layout")
+    if not isinstance(layout, dict):
+        layout = {}
     root_zone_id, embedded = _render_dashboard(
         ET.SubElement(workbook, "dashboards"),
         layout.get("canvas", {}),
@@ -735,7 +757,7 @@ def render_workbook(
         tokens,
     )
     _render_windows(
-        workbook, [plan for _, _, plan in plans], root_zone_id, embedded
+        workbook, [planned.plan for planned in plans], root_zone_id, embedded
     )
 
     if target == TARGET_2026:

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -427,7 +427,7 @@ def _render_dashboard(
     leaves: dict[str, zones.Leaf],
     tokens: worksheet.DesignTokens,
 ) -> tuple[str, set[str]]:
-    """Render the dashboard: fixed-size at the mock's canvas, with the spec's zone tree.
+    """Render the dashboard: range-sized from the mock's canvas, with the spec's zone tree.
 
     Args:
         parent: The ``<dashboards>`` element.
@@ -447,10 +447,12 @@ def _render_dashboard(
     ET.SubElement(dashboard, "style")
     width = str(int(canvas.get("width", DEFAULT_CANVAS["width"])))
     height = str(int(canvas.get("height", DEFAULT_CANVAS["height"])))
-    # A fixed-size dashboard is what makes the mock's geometry hold: with sizing-mode
-    # 'automatic' Tableau re-flows the zones to the viewer's window instead.
+    # Range-sized at the mock's canvas as the floor, with no maximum: zone geometry is in a
+    # normalised 100,000-unit space, so the proportions the analyst approved hold at any
+    # window size, while a hard maximum (a fixed size) only forces the viewer to scroll a
+    # wide screen's worth of empty margin. The analyst can lower the minimum in Desktop.
     ET.SubElement(dashboard, "size", {
-        "maxheight": height, "maxwidth": width, "minheight": height, "minwidth": width,
+        "minheight": height, "minwidth": width, "sizing-mode": "range",
     })
     root_zone_id, embedded = zones.render_zones(
         ET.SubElement(dashboard, "zones"),

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -79,6 +79,12 @@ DASHBOARD_NAME = "Dashboard 1"
 #: numeric ``canvas.width``/``height``, so this only guards a direct call to the assembler.
 DEFAULT_CANVAS = {"width": 1000, "height": 800}
 
+#: The dashboard's minimum size in px, whatever the mock's canvas: the smallest window a
+#: business dashboard still reads on. The canvas drives the zone *proportions*, not this floor
+#: - see :func:`_render_dashboard`.
+MIN_DASHBOARD_WIDTH = 1100
+MIN_DASHBOARD_HEIGHT = 800
+
 
 # --- Column types -------------------------------------------------------------
 
@@ -427,11 +433,12 @@ def _render_dashboard(
     leaves: dict[str, zones.Leaf],
     tokens: worksheet.DesignTokens,
 ) -> tuple[str, set[str]]:
-    """Render the dashboard: range-sized from the mock's canvas, with the spec's zone tree.
+    """Render the dashboard: range-sized above a fixed floor, with the spec's zone tree.
 
     Args:
         parent: The ``<dashboards>`` element.
-        canvas: The layout's ``canvas`` object (``width`` / ``height`` in px).
+        canvas: The layout's ``canvas`` object (``width`` / ``height`` in px) - what px
+            measures inside the tree are scaled against, not the dashboard's size.
         root: The layout tree's ``root`` node.
         leaves: ``{element id: Leaf}`` - what fills each leaf zone.
         tokens: The design tokens, for the generated title zones.
@@ -447,12 +454,14 @@ def _render_dashboard(
     ET.SubElement(dashboard, "style")
     width = str(int(canvas.get("width", DEFAULT_CANVAS["width"])))
     height = str(int(canvas.get("height", DEFAULT_CANVAS["height"])))
-    # Range-sized at the mock's canvas as the floor, with no maximum: zone geometry is in a
-    # normalised 100,000-unit space, so the proportions the analyst approved hold at any
-    # window size, while a hard maximum (a fixed size) only forces the viewer to scroll a
-    # wide screen's worth of empty margin. The analyst can lower the minimum in Desktop.
+    # Range-sized, no maximum: zone geometry is in a normalised 100,000-unit space, so the
+    # proportions the analyst approved hold at any window size, while a hard maximum (a fixed
+    # size) only forces the viewer to scroll a wide screen's worth of empty margin. The floor
+    # is the standard minimum, not the mock's canvas - the canvas is a design surface, and
+    # pinning the minimum to it would make a wide mock unopenable on a laptop.
     ET.SubElement(dashboard, "size", {
-        "minheight": height, "minwidth": width, "sizing-mode": "range",
+        "minheight": str(MIN_DASHBOARD_HEIGHT), "minwidth": str(MIN_DASHBOARD_WIDTH),
+        "sizing-mode": "range",
     })
     root_zone_id, embedded = zones.render_zones(
         ET.SubElement(dashboard, "zones"),

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -21,8 +21,8 @@ Two authorities, deliberately kept apart:
 The manifest's own ``fields[].type`` is validated but not read here: one authority, no drift.
 
 Scope: datasources, worksheet bodies (:mod:`worksheet` owns the shelves, encodings, marks
-and styling), a one-zone dashboard sized from the layout canvas, windows, and version
-targeting. The dashboard's zone tree is the next ticket.
+and styling), the dashboard's size and zone tree (:mod:`zones` owns the geometry), windows,
+and version targeting.
 """
 
 from __future__ import annotations
@@ -33,6 +33,7 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 
 import worksheet
+import zones
 from manifest import documented_field_types
 
 # --- Version targeting (CONTRACT.md §2 values) -------------------------------
@@ -70,18 +71,8 @@ FORMAT_CHANGE_FLAGS: tuple[str, ...] = (
 #: (WORKSHEETS.md:512, seen in ``bar-chart-sorted.twb`` and ``custom-tooltip.twb``).
 SORT_FORMAT_FLAG = "SortTagCleanup"
 
-#: The single dashboard this ticket emits (the zone tree from ``layout.root`` is next).
+#: The single dashboard the builder emits.
 DASHBOARD_NAME = "Dashboard 1"
-
-#: Dashboard zones live in a 100,000 x 100,000 virtual coordinate space.
-ZONE_SPACE = "100000"
-
-#: The root zone's id. Zone ids are sequential integers from 1; with a single zone there is
-#: nothing to count yet.
-ROOT_ZONE_ID = "1"
-
-#: Margin (in the zone coordinate space) on the root zone, as Tableau writes it.
-ROOT_ZONE_MARGIN = "8"
 
 #: Dashboard size when the layout carries no canvas. ``manifest.validate_manifest`` requires
 #: numeric ``canvas.width``/``height``, so this only guards a direct call to the assembler.
@@ -377,31 +368,77 @@ def _render_datasource(
 
 # --- Worksheets, dashboard, windows --------------------------------------------
 
-def _render_zone_style(parent: ET.Element, margin: str) -> None:
-    """Append the four-format ``<zone-style>`` block Tableau writes on every zone."""
-    zone_style = ET.SubElement(parent, "zone-style")
-    for attribute, value in (
-        ("border-color", "#000000"), ("border-style", "none"), ("border-width", "0"),
-        ("margin", margin),
-    ):
-        ET.SubElement(zone_style, "format", {"attr": attribute, "value": value})
+def _dashboard_leaves(
+    plans: list[tuple[str, dict, worksheet.WorksheetPlan]], objects: object
+) -> dict[str, zones.Leaf]:
+    """Map every layout element id to what fills its zone.
+
+    The manifest addresses zones by ``element_id`` - the mock's language - while Tableau
+    addresses them by sheet name and zone type; this is where the two meet, once, for both
+    the views and the non-view objects.
+
+    Args:
+        plans: The resolved worksheets, as ``(datasource, manifest entry, plan)``.
+        objects: The manifest's optional ``objects`` list.
+
+    Returns:
+        ``{element id: Leaf}`` for :func:`zones.render_zones`.
+    """
+    leaves: dict[str, zones.Leaf] = {}
+    for _, entry, plan in plans:
+        element_id = str(entry.get("element_id", "")).strip()
+        if not element_id:
+            continue
+        # Only the colour legend is placed in the dashboard; size/shape keys stay on the
+        # worksheet's own right edge, where they do not compete for the element's box.
+        legend = next(
+            ((reference, pane_id)
+             for card_type, reference, pane_id in worksheet.legend_cards(plan)
+             if card_type == "color"),
+            (),
+        )
+        # First claimant wins: two views on one zone is a manifest bug, and picking the
+        # later one would silently move the analyst's chart.
+        leaves.setdefault(element_id, zones.Leaf(
+            worksheet=plan.name,
+            title=str(entry.get("title", "") or "").strip(),
+            legend=legend,
+        ))
+
+    for entry in objects if isinstance(objects, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        element_id = str(entry.get("element_id", "")).strip()
+        if not element_id:
+            continue
+        leaves.setdefault(element_id, zones.Leaf(
+            kind=str(entry.get("kind", "") or "").strip().lower(),
+            title=str(entry.get("title", "") or "").strip(),
+            text=str(entry.get("text", "") or "").strip(),
+        ))
+    return leaves
 
 
-def _render_dashboard(parent: ET.Element, canvas: dict, root_zone_id: str) -> set[str]:
-    """Render the dashboard: its size from the mock's canvas, and one root zone.
-
-    The zone *tree* (``layout.root``) is the next ticket; what this pins is the geometry
-    the mock was approved at, so the workbook opens at the right size.
+def _render_dashboard(
+    parent: ET.Element,
+    canvas: dict,
+    root: object,
+    leaves: dict[str, zones.Leaf],
+    tokens: worksheet.DesignTokens,
+) -> tuple[str, set[str]]:
+    """Render the dashboard: fixed-size at the mock's canvas, with the spec's zone tree.
 
     Args:
         parent: The ``<dashboards>`` element.
         canvas: The layout's ``canvas`` object (``width`` / ``height`` in px).
-        root_zone_id: The id of the root zone (the dashboard window's ``active`` target).
+        root: The layout tree's ``root`` node.
+        leaves: ``{element id: Leaf}`` - what fills each leaf zone.
+        tokens: The design tokens, for the generated title zones.
 
     Returns:
-        The names of the worksheets this dashboard embeds in a zone - empty until the zone
-        tree lands. :func:`_render_windows` hides exactly these, so a sheet that is embedded
-        nowhere keeps its tab instead of leaving the analyst a blank workbook.
+        ``(root zone id, embedded sheet names)``. The root id is the dashboard window's
+        ``active`` target; :func:`_render_windows` hides exactly the embedded sheets, so a
+        sheet that is embedded nowhere keeps its tab instead of becoming unreachable.
     """
     dashboard = ET.SubElement(parent, "dashboard", {
         "enable-sort-zone-taborder": "true", "name": DASHBOARD_NAME,
@@ -409,20 +446,20 @@ def _render_dashboard(parent: ET.Element, canvas: dict, root_zone_id: str) -> se
     ET.SubElement(dashboard, "style")
     width = str(int(canvas.get("width", DEFAULT_CANVAS["width"])))
     height = str(int(canvas.get("height", DEFAULT_CANVAS["height"])))
+    # A fixed-size dashboard is what makes the mock's geometry hold: with sizing-mode
+    # 'automatic' Tableau re-flows the zones to the viewer's window instead.
     ET.SubElement(dashboard, "size", {
         "maxheight": height, "maxwidth": width, "minheight": height, "minwidth": width,
     })
-    zones = ET.SubElement(dashboard, "zones")
-    root_zone = ET.SubElement(zones, "zone", {
-        "h": ZONE_SPACE, "id": root_zone_id, "type-v2": "layout-basic",
-        "w": ZONE_SPACE, "x": "0", "y": "0",
-    })
-    # TODO(next ticket): nest the manifest's layout.root tree inside this zone, one child
-    # zone per element id, with each worksheet zone naming its sheet - and return those
-    # sheet names here, which is all _render_windows needs to start hiding tabs again.
-    _render_zone_style(root_zone, ROOT_ZONE_MARGIN)  # zone-style is the zone's last child
+    root_zone_id, embedded = zones.render_zones(
+        ET.SubElement(dashboard, "zones"),
+        root if isinstance(root, dict) else {"type": "vert", "children": []},
+        {"width": int(width), "height": int(height)},
+        leaves,
+        tokens,
+    )
     ET.SubElement(dashboard, "simple-id", {"uuid": simple_id("dashboard", DASHBOARD_NAME)})
-    return set()
+    return root_zone_id, embedded
 
 
 def _render_windows(
@@ -555,9 +592,14 @@ def _build_resolvers(
 
 def _plan_worksheets(
     manifest_document: dict, resolvers: dict[str, worksheet.FieldResolver]
-) -> list[tuple[str, worksheet.WorksheetPlan]]:
-    """Resolve every manifest worksheet, paired with its datasource name."""
-    plans: list[tuple[str, worksheet.WorksheetPlan]] = []
+) -> list[tuple[str, dict, worksheet.WorksheetPlan]]:
+    """Resolve every manifest worksheet into ``(datasource, manifest entry, plan)``.
+
+    The entry travels with the plan because the *dashboard* needs what the plan deliberately
+    does not carry - the ``element_id`` the sheet fills and its title - while the datasource
+    name is what the derived-column pass groups by.
+    """
+    plans: list[tuple[str, dict, worksheet.WorksheetPlan]] = []
     for entry in manifest_document.get("worksheets", []) or []:
         if not isinstance(entry, dict):
             continue
@@ -565,14 +607,14 @@ def _plan_worksheets(
         resolver = resolvers.get(source)
         if resolver is None:  # validate_manifest already named this worksheet
             continue
-        plans.append((source, worksheet.plan_worksheet(entry, resolver)))
+        plans.append((source, entry, worksheet.plan_worksheet(entry, resolver)))
     return plans
 
 
 def _collect_derived_columns(
     manifest_document: dict,
     resolvers: dict[str, worksheet.FieldResolver],
-    plans: list[tuple[str, worksheet.WorksheetPlan]],
+    plans: list[tuple[str, dict, worksheet.WorksheetPlan]],
 ) -> dict[str, list[worksheet.FieldRef]]:
     """Collect the non-CSV columns each datasource must declare.
 
@@ -601,7 +643,7 @@ def _collect_derived_columns(
         if reference is not None:
             derived.setdefault(source, {}).setdefault(reference.column_name, reference)
 
-    for source, plan in plans:
+    for source, _, plan in plans:
         for reference in worksheet.bin_columns(plan):
             derived.setdefault(source, {}).setdefault(reference.column_name, reference)
 
@@ -670,7 +712,7 @@ def render_workbook(
             derived.get(name, []),
         )
 
-    if any(plan.spec.geographic for _, plan in plans):
+    if any(plan.spec.geographic for _, _, plan in plans):
         # A map needs its <mapsources> at *both* levels: the workbook's declares the source,
         # each map worksheet's view references it. One without the other renders no basemap.
         ET.SubElement(
@@ -679,17 +721,22 @@ def render_workbook(
 
     if plans:  # the XSD requires >=1 <worksheet>; omit the element otherwise
         worksheets = ET.SubElement(workbook, "worksheets")
-        for _, plan in plans:
+        for _, _, plan in plans:
             worksheet.render_worksheet(
                 worksheets, plan, tokens, simple_id("worksheet", plan.name)
             )
 
-    layout = manifest_document.get("layout")
-    canvas = layout.get("canvas", {}) if isinstance(layout, dict) else {}
-    embedded = _render_dashboard(
-        ET.SubElement(workbook, "dashboards"), canvas, ROOT_ZONE_ID
+    layout = manifest_document.get("layout") if isinstance(manifest_document.get("layout"), dict) else {}
+    root_zone_id, embedded = _render_dashboard(
+        ET.SubElement(workbook, "dashboards"),
+        layout.get("canvas", {}),
+        layout.get("root"),
+        _dashboard_leaves(plans, manifest_document.get("objects", [])),
+        tokens,
     )
-    _render_windows(workbook, [plan for _, plan in plans], ROOT_ZONE_ID, embedded)
+    _render_windows(
+        workbook, [plan for _, _, plan in plans], root_zone_id, embedded
+    )
 
     if target == TARGET_2026:
         explain_data = ET.SubElement(workbook, "explain-data", {

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -926,6 +926,13 @@ def _render_style(parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens)
     if tokens.present:
         add("worksheet", "format", {"attr": "font-family", "value": tokens.font_family})
 
+    # Field labels repeat what the zone's header already says, and Tableau reserves a whole
+    # band of the sheet for them - on a dashboard that band is stolen from the chart.
+    for scope in ("cols", "rows"):
+        add("worksheet", "format", {
+            "attr": "display-field-labels", "scope": scope, "value": "false",
+        })
+
     for shelf, scope, references in (
         ("rows", "rows", plan.rows), ("columns", "cols", plan.columns)
     ):

--- a/skills/tableau-build/scripts/zones.py
+++ b/skills/tableau-build/scripts/zones.py
@@ -23,7 +23,10 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from typing import Optional
+from typing import NamedTuple, Optional
+
+# For DesignTokens only; :mod:`worksheet` does not import this module, so no cycle.
+from worksheet import DesignTokens
 
 #: Dashboard zones live in a 100,000 x 100,000 virtual coordinate space, whatever the canvas.
 ZONE_SPACE = 100000
@@ -47,19 +50,16 @@ OBJECT_ZONE_TYPES: dict[str, str] = {
     "blank": "empty",
 }
 
-#: The other kinds, and the zone type each will eventually carry. Every one of them needs a
-#: reference the manifest does not carry yet - a filter's field (plus the dashboard's own
-#: ``<datasource-dependencies>``), a parameter control's parameter, an image's filename, a
-#: button's action, a legend's sheet and colour field - and Tableau does not treat those as
-#: optional. So the layout reserves the box as an empty zone, keeping the geometry the analyst
-#: approved, and the features-and-actions ticket (#37) turns each into its real zone.
-DEFERRED_ZONE_TYPES: dict[str, str] = {
-    "filter": "filter",
-    "parameter": "paramctrl",
-    "image": "bitmap",
-    "button": "dashboard-object",
-    "legend": "color",
-}
+#: The other kinds. Each one's real zone type (``filter``, ``paramctrl``, ``bitmap``,
+#: ``dashboard-object``, ``color``) needs a reference the manifest does not carry yet - a
+#: filter's field plus the dashboard's own ``<datasource-dependencies>``, a parameter control's
+#: parameter, an image's filename (which the ``.twbx`` would also have to embed), a button's
+#: action, a legend's sheet and colour field - and Tableau does not treat those as optional.
+#: So the layout reserves the box as an empty zone, keeping the geometry the analyst approved,
+#: until the ticket that adds the wiring can emit the real zone.
+DEFERRED_KINDS: frozenset[str] = frozenset({
+    "filter", "parameter", "image", "button", "legend",
+})
 
 #: The zone type of a leaf nothing fills, of a deferred kind, and of an unknown one.
 EMPTY_ZONE_TYPE = "empty"
@@ -89,6 +89,18 @@ class Box:
     h: int
 
 
+class Legend(NamedTuple):
+    """The colour encoding one legend zone keys.
+
+    Attributes:
+        field: The qualified colour field reference (the zone's ``param``).
+        pane_id: Which pane's encoding to show (the zone's ``pane-specification-id``).
+    """
+
+    field: str
+    pane_id: str
+
+
 @dataclass(frozen=True)
 class Leaf:
     """What fills one leaf zone of the layout tree.
@@ -103,15 +115,14 @@ class Leaf:
         title: Title text; when set, a text zone is stacked above the content and the
             sheet's own title is suppressed.
         text: The text a ``text`` object zone displays.
-        legend: ``(qualified colour field, pane-specification-id)`` for a colour legend zone
-            stacked below the content; empty for no legend.
+        legend: The colour legend to stack below the content, or ``None`` for no legend.
     """
 
     worksheet: str = ""
     kind: str = ""
     title: str = ""
     text: str = ""
-    legend: tuple[str, ...] = ()
+    legend: Optional[Legend] = None
 
 
 def render_zone_style(parent: ET.Element, margin: str) -> None:
@@ -170,7 +181,9 @@ class _ZoneWriter:
             render it on.
     """
 
-    def __init__(self, canvas: dict, leaves: dict[str, Leaf], tokens) -> None:
+    def __init__(
+        self, canvas: dict, leaves: dict[str, Leaf], tokens: DesignTokens
+    ) -> None:
         """Set up a writer for one dashboard.
 
         Args:
@@ -337,7 +350,11 @@ class _ZoneWriter:
             parent, box, f"{CONTAINER_PREFIXES['vert']}-{label}",
             type_v2="layout-flow", param="vert",
         )
-        content_height = max(0, box.h - title_height - legend_height)
+        # A box too short for both fixed zones is squeezed, never overflowed: a zone written
+        # past the wrapper's bottom edge would overlap the sibling below it.
+        title_height = min(title_height, box.h)
+        legend_height = min(legend_height, box.h - title_height)
+        content_height = box.h - title_height - legend_height
         cursor = box.y
         if title_height:
             self._title(wrapper, leaf.title, Box(box.x, cursor, box.w, title_height), label)
@@ -393,12 +410,12 @@ class _ZoneWriter:
 
     def _legend(self, parent: ET.Element, leaf: Leaf, box: Box, label: str) -> None:
         """Render a fixed-height colour legend zone keying the sheet's colour encoding."""
-        field_reference, pane_id = leaf.legend[0], leaf.legend[1]
+        legend = leaf.legend
         zone = self._zone(
             parent, box, f"{label} legend", type_v2="color",
             fixed_size=str(LEGEND_HEIGHT_PX), is_fixed="true", leg_item_layout="horz",
-            name=leaf.worksheet or None, pane_specification_id=pane_id,
-            param=field_reference, show_title="false",
+            name=leaf.worksheet or None, pane_specification_id=legend.pane_id,
+            param=legend.field, show_title="false",
         )
         render_zone_style(zone, ZONE_MARGIN)
 
@@ -418,7 +435,11 @@ class _ZoneWriter:
 
 
 def render_zones(
-    parent: ET.Element, root: dict, canvas: dict, leaves: dict[str, Leaf], tokens
+    parent: ET.Element,
+    root: dict,
+    canvas: dict,
+    leaves: dict[str, Leaf],
+    tokens: DesignTokens,
 ) -> tuple[str, set[str]]:
     """Render a layout tree into a dashboard's ``<zones>``.
 

--- a/skills/tableau-build/scripts/zones.py
+++ b/skills/tableau-build/scripts/zones.py
@@ -1,0 +1,437 @@
+"""The dashboard layout engine of tableau-build (CONTRACT.md step 8).
+
+The spec's ``## Layout`` container tree is the geometry the analyst approved the mock at, so
+this module turns it into the workbook's zone tree *by construction* rather than by an
+agent's eyeballing: percentage ``size`` values map deterministically into Tableau's
+100,000 x 100,000 coordinate space at the mock's canvas dimensions, nested ``vert``/``horz``
+containers become ``layout-flow`` zones, and every zone gets a sequential id, a
+``friendly-name``, and ``<zone-style>`` as its **last** child (Tableau reads that element
+positionally - anything after it is ignored).
+
+The module is pure and stdlib-only: it takes the layout tree, the canvas, and a
+``{element id: Leaf}`` map of what fills each leaf, and appends zones to an element. No
+filesystem, no manifest parsing - that is :mod:`twb`'s job, and it is why the contract test
+can drive :func:`render_zones` directly.
+
+Not here: the *wiring* of a filter / parameter / button zone to the field, parameter or sheet
+behind it. A zone of the right type at the right place is what the layout owes; the
+dashboard-level ``<datasource-dependencies>`` and button actions that make one live belong to
+the features-and-actions ticket (#37).
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Optional
+
+#: Dashboard zones live in a 100,000 x 100,000 virtual coordinate space, whatever the canvas.
+ZONE_SPACE = 100000
+
+#: The root zone's margin in px, as Tableau writes it. Scaled by the canvas into zone units,
+#: it is what insets every zone below the root.
+ROOT_MARGIN_PX = 8
+
+#: The margin on the root zone / on every other zone, in the ``<zone-style>`` block.
+ROOT_MARGIN = "8"
+ZONE_MARGIN = "4"
+
+#: Height in px of a generated title text zone and of a colour legend zone.
+TITLE_HEIGHT_PX = 30
+LEGEND_HEIGHT_PX = 22
+
+#: manifest ``objects[].kind`` -> the zone's ``type-v2``, for the kinds a layout can render
+#: on its own: a text block and a spacer need nothing beyond their box and their text.
+OBJECT_ZONE_TYPES: dict[str, str] = {
+    "text": "text",
+    "blank": "empty",
+}
+
+#: The other kinds, and the zone type each will eventually carry. Every one of them needs a
+#: reference the manifest does not carry yet - a filter's field (plus the dashboard's own
+#: ``<datasource-dependencies>``), a parameter control's parameter, an image's filename, a
+#: button's action, a legend's sheet and colour field - and Tableau does not treat those as
+#: optional. So the layout reserves the box as an empty zone, keeping the geometry the analyst
+#: approved, and the features-and-actions ticket (#37) turns each into its real zone.
+DEFERRED_ZONE_TYPES: dict[str, str] = {
+    "filter": "filter",
+    "parameter": "paramctrl",
+    "image": "bitmap",
+    "button": "dashboard-object",
+    "legend": "color",
+}
+
+#: The zone type of a leaf nothing fills, of a deferred kind, and of an unknown one.
+EMPTY_ZONE_TYPE = "empty"
+
+#: Container orientations, and the ``friendly-name`` prefix each carries (the legacy skill's
+#: ``V-``/``H-`` convention, which is what makes a deep zone tree readable while debugging).
+CONTAINER_PREFIXES = {"vert": "V", "horz": "H"}
+
+#: The root zone's friendly name.
+ROOT_FRIENDLY_NAME = "Dashboard"
+
+
+@dataclass(frozen=True)
+class Box:
+    """One zone's rectangle in the 0-100,000 coordinate space.
+
+    Attributes:
+        x: Left edge.
+        y: Top edge.
+        w: Width.
+        h: Height.
+    """
+
+    x: int
+    y: int
+    w: int
+    h: int
+
+
+@dataclass(frozen=True)
+class Leaf:
+    """What fills one leaf zone of the layout tree.
+
+    A leaf is either a **view** (``worksheet``) or a dashboard **object** (``kind``); the
+    optional title and legend are extra zones stacked around it inside the element's own box,
+    so adding them never disturbs its siblings' geometry.
+
+    Attributes:
+        worksheet: The Tableau sheet name for a view zone.
+        kind: The manifest object kind for a non-view zone (see :data:`OBJECT_ZONE_TYPES`).
+        title: Title text; when set, a text zone is stacked above the content and the
+            sheet's own title is suppressed.
+        text: The text a ``text`` object zone displays.
+        legend: ``(qualified colour field, pane-specification-id)`` for a colour legend zone
+            stacked below the content; empty for no legend.
+    """
+
+    worksheet: str = ""
+    kind: str = ""
+    title: str = ""
+    text: str = ""
+    legend: tuple[str, ...] = ()
+
+
+def render_zone_style(parent: ET.Element, margin: str) -> None:
+    """Append the four-format ``<zone-style>`` block Tableau writes on every zone.
+
+    Args:
+        parent: The zone to style.
+        margin: The zone's margin, in px.
+    """
+    zone_style = ET.SubElement(parent, "zone-style")
+    for attribute, value in (
+        ("border-color", "#000000"), ("border-style", "none"), ("border-width", "0"),
+        ("margin", margin),
+    ):
+        ET.SubElement(zone_style, "format", {"attr": attribute, "value": value})
+
+
+def child_sizes(children: list) -> list[float]:
+    """Return the flow-axis proportion of each child, filling in the ones that declare none.
+
+    ``size`` values are proportions of the parent, not absolute percentages: a tree whose
+    siblings sum to 90 still fills the dashboard. A child with no usable ``size`` shares
+    whatever the declared ones leave - and if they leave nothing, every child splits the
+    parent evenly, because a zero-height zone is a zone the analyst cannot see.
+
+    Args:
+        children: The container's child nodes.
+
+    Returns:
+        One positive proportion per child, in order.
+    """
+    declared: list[Optional[float]] = []
+    for child in children:
+        size = child.get("size") if isinstance(child, dict) else None
+        usable = (
+            isinstance(size, (int, float)) and not isinstance(size, bool) and size > 0
+        )
+        declared.append(float(size) if usable else None)
+
+    missing = declared.count(None)
+    if not missing:
+        return [size for size in declared if size is not None]
+
+    share = (100.0 - sum(size for size in declared if size is not None)) / missing
+    if share <= 0:
+        return [100.0 / len(children)] * len(children)
+    return [share if size is None else size for size in declared]
+
+
+class _ZoneWriter:
+    """Renders one layout tree into zones, numbering them as it goes.
+
+    Attributes:
+        embedded: The sheet names the tree places in a zone - what the caller hides in
+            ``<windows>``, since hiding a sheet no zone shows leaves Tableau no tab to
+            render it on.
+    """
+
+    def __init__(self, canvas: dict, leaves: dict[str, Leaf], tokens) -> None:
+        """Set up a writer for one dashboard.
+
+        Args:
+            canvas: The layout's ``canvas`` (``width`` / ``height`` in px) - what px sizes
+                are converted against.
+            leaves: ``{element id: Leaf}``; a leaf id that is absent renders as a blank zone.
+            tokens: The parsed :class:`worksheet.DesignTokens`, for title zone styling.
+        """
+        self._width = max(1.0, float(canvas.get("width") or 1))
+        self._height = max(1.0, float(canvas.get("height") or 1))
+        self._leaves = leaves
+        self._tokens = tokens
+        self._last_id = 0
+        self.embedded: set[str] = set()
+
+    # --- helpers ---------------------------------------------------------------
+
+    def _next_id(self) -> str:
+        """Return the next sequential zone id."""
+        self._last_id += 1
+        return str(self._last_id)
+
+    def _units_x(self, pixels: float) -> int:
+        """Convert a horizontal px measure into zone units at the canvas width."""
+        return round(pixels / self._width * ZONE_SPACE)
+
+    def _units_y(self, pixels: float) -> int:
+        """Convert a vertical px measure into zone units at the canvas height."""
+        return round(pixels / self._height * ZONE_SPACE)
+
+    def _zone(self, parent: ET.Element, box: Box, friendly_name: str, **attributes) -> ET.Element:
+        """Append one zone with its geometry, id and friendly name.
+
+        Args:
+            parent: The zone (or ``<zones>``) to append to.
+            box: The zone's rectangle.
+            friendly_name: The human-readable label every zone carries.
+            **attributes: Extra zone attributes (``name``, ``type-v2``, ...); a ``None``
+                value is dropped, which keeps the callers free of conditionals.
+
+        Returns:
+            The new zone element.
+        """
+        attributes.update({
+            "friendly-name": friendly_name,
+            "h": str(box.h), "id": self._next_id(),
+            "w": str(box.w), "x": str(box.x), "y": str(box.y),
+        })
+        present = {
+            key.replace("_", "-"): str(value)
+            for key, value in attributes.items() if value is not None
+        }
+        return ET.SubElement(parent, "zone", dict(sorted(present.items())))
+
+    # --- the tree ---------------------------------------------------------------
+
+    def render_root(self, parent: ET.Element, root: dict) -> str:
+        """Render the root zone and the tree below it.
+
+        Args:
+            parent: The dashboard's ``<zones>`` element.
+            root: The layout tree's ``root`` node.
+
+        Returns:
+            The root zone's id (the dashboard window's ``<active>`` target).
+        """
+        root_zone = self._zone(
+            parent, Box(0, 0, ZONE_SPACE, ZONE_SPACE), ROOT_FRIENDLY_NAME,
+            type_v2="layout-basic",
+        )
+        root_id = root_zone.get("id")
+        inset_x, inset_y = self._units_x(ROOT_MARGIN_PX), self._units_y(ROOT_MARGIN_PX)
+        self._node(
+            root_zone,
+            root,
+            Box(inset_x, inset_y, ZONE_SPACE - 2 * inset_x, ZONE_SPACE - 2 * inset_y),
+            "root",
+        )
+        render_zone_style(root_zone, ROOT_MARGIN)  # last child, always
+        return root_id
+
+    def _node(self, parent: ET.Element, node: object, box: Box, path: str) -> None:
+        """Render one layout node - a container, a leaf, or a mapped container - into ``box``.
+
+        Args:
+            parent: The zone to nest this node's zone in.
+            node: The layout node.
+            box: The rectangle the node occupies.
+            path: Its position in the tree (``root.2.1``), the fallback friendly name.
+        """
+        if not isinstance(node, dict):
+            return  # validate_manifest already rejected it; keep the rest of the tree
+
+        element_id = str(node.get("id") or "").strip()
+        children = node.get("children")
+        if not (isinstance(children, list) and children):
+            self._leaf(parent, element_id, box, path)
+            return
+
+        orientation = "vert" if str(node.get("type", "")).strip().lower() == "vert" else "horz"
+        container = self._zone(
+            parent, box, f"{CONTAINER_PREFIXES[orientation]}-{element_id or path}",
+            type_v2="layout-flow", param=orientation,
+        )
+        for index, (child, child_box) in enumerate(
+            zip(children, self._divide(box, orientation, child_sizes(children))), start=1
+        ):
+            self._node(container, child, child_box, f"{path}.{index}")
+        render_zone_style(container, ZONE_MARGIN)
+
+    def _divide(self, box: Box, orientation: str, sizes: list[float]) -> list[Box]:
+        """Split ``box`` along the flow axis into one rectangle per proportion.
+
+        Each edge is rounded from the *cumulative* proportion, so the children tile the
+        parent exactly: no rounding gap, no overlap, and the last child ends where the
+        parent does.
+
+        Args:
+            box: The container's rectangle.
+            orientation: ``vert`` (divide the height) or ``horz`` (divide the width).
+            sizes: One positive proportion per child.
+
+        Returns:
+            One :class:`Box` per proportion, in order.
+        """
+        vertical = orientation == "vert"
+        start, extent = (box.y, box.h) if vertical else (box.x, box.w)
+        total = sum(sizes)
+
+        boxes: list[Box] = []
+        edge, consumed = start, 0.0
+        for size in sizes:
+            consumed += size
+            end = start + round(extent * consumed / total)
+            boxes.append(
+                Box(box.x, edge, box.w, end - edge) if vertical
+                else Box(edge, box.y, end - edge, box.h)
+            )
+            edge = end
+        return boxes
+
+    # --- leaves ------------------------------------------------------------------
+
+    def _leaf(self, parent: ET.Element, element_id: str, box: Box, path: str) -> None:
+        """Render one leaf element, wrapping it when it carries a title or a legend.
+
+        Args:
+            parent: The zone to nest the leaf in.
+            element_id: The leaf's element id (``""`` for an unnamed node).
+            box: The rectangle the element occupies.
+            path: Its position in the tree, the fallback friendly name.
+        """
+        label = element_id or path
+        leaf = self._leaves.get(element_id, Leaf())
+        title_height = self._units_y(TITLE_HEIGHT_PX) if leaf.title else 0
+        legend_height = self._units_y(LEGEND_HEIGHT_PX) if leaf.legend else 0
+
+        if not (title_height or legend_height):
+            self._content(parent, leaf, box, label)
+            return
+
+        # The extra zones stack inside the element's own box, so its siblings are untouched.
+        wrapper = self._zone(
+            parent, box, f"{CONTAINER_PREFIXES['vert']}-{label}",
+            type_v2="layout-flow", param="vert",
+        )
+        content_height = max(0, box.h - title_height - legend_height)
+        cursor = box.y
+        if title_height:
+            self._title(wrapper, leaf.title, Box(box.x, cursor, box.w, title_height), label)
+            cursor += title_height
+        self._content(
+            wrapper, leaf, Box(box.x, cursor, box.w, content_height), label,
+            show_title=False,
+        )
+        cursor += content_height
+        if legend_height:
+            self._legend(
+                wrapper, leaf, Box(box.x, cursor, box.w, legend_height), label
+            )
+        render_zone_style(wrapper, ZONE_MARGIN)
+
+    def _content(
+        self, parent: ET.Element, leaf: Leaf, box: Box, label: str, show_title: bool = True
+    ) -> None:
+        """Render the leaf's own zone: a sheet zone, an object zone, or a blank.
+
+        Args:
+            parent: The zone to append to.
+            leaf: What fills the element.
+            box: The rectangle for the content itself.
+            label: The zone's friendly name.
+            show_title: False when a generated title zone already labels the element, which
+                is what suppresses the sheet's own duplicate title.
+        """
+        if leaf.worksheet:
+            # A sheet zone is identified by its 'name' and carries no type-v2.
+            zone = self._zone(
+                parent, box, label, name=leaf.worksheet,
+                show_title=None if show_title else "false",
+            )
+            self.embedded.add(leaf.worksheet)
+        else:
+            kind = leaf.kind.strip().lower()
+            zone = self._zone(
+                parent, box, label, type_v2=OBJECT_ZONE_TYPES.get(kind, EMPTY_ZONE_TYPE),
+            )
+            if kind == "text" and leaf.text:
+                self._formatted_text(zone, leaf.text, bold=False)
+        render_zone_style(zone, ZONE_MARGIN)
+
+    def _title(self, parent: ET.Element, text: str, box: Box, label: str) -> None:
+        """Render a fixed-height text zone carrying the element's title."""
+        zone = self._zone(
+            parent, box, f"{label} title", type_v2="text",
+            fixed_size=str(TITLE_HEIGHT_PX), is_fixed="true",
+        )
+        self._formatted_text(zone, text, bold=True)
+        render_zone_style(zone, ZONE_MARGIN)
+
+    def _legend(self, parent: ET.Element, leaf: Leaf, box: Box, label: str) -> None:
+        """Render a fixed-height colour legend zone keying the sheet's colour encoding."""
+        field_reference, pane_id = leaf.legend[0], leaf.legend[1]
+        zone = self._zone(
+            parent, box, f"{label} legend", type_v2="color",
+            fixed_size=str(LEGEND_HEIGHT_PX), is_fixed="true", leg_item_layout="horz",
+            name=leaf.worksheet or None, pane_specification_id=pane_id,
+            param=field_reference, show_title="false",
+        )
+        render_zone_style(zone, ZONE_MARGIN)
+
+    def _formatted_text(self, zone: ET.Element, text: str, bold: bool) -> None:
+        """Append a single-run ``<formatted-text>`` block styled from the design tokens."""
+        attributes = {
+            "fontname": self._tokens.font_family,
+            "fontsize": str(self._tokens.title_size),
+            "fontcolor": self._tokens.title_color.lower(),
+        }
+        if bold:
+            attributes["bold"] = "true"
+        run = ET.SubElement(
+            ET.SubElement(zone, "formatted-text"), "run", dict(sorted(attributes.items()))
+        )
+        run.text = text
+
+
+def render_zones(
+    parent: ET.Element, root: dict, canvas: dict, leaves: dict[str, Leaf], tokens
+) -> tuple[str, set[str]]:
+    """Render a layout tree into a dashboard's ``<zones>``.
+
+    Args:
+        parent: The dashboard's ``<zones>`` element.
+        root: The layout tree's ``root`` node (``{"type": ..., "children": [...]}``).
+        canvas: The layout's ``canvas`` - the px dimensions px sizes are scaled against.
+        leaves: ``{element id: Leaf}``, what fills each leaf zone.
+        tokens: The parsed :class:`worksheet.DesignTokens`, for title zone styling.
+
+    Returns:
+        ``(root zone id, embedded sheet names)``. The root id is the dashboard window's
+        ``<active>`` target; the sheet names are the ones the caller hides in ``<windows>``.
+    """
+    writer = _ZoneWriter(canvas, leaves, tokens)
+    return writer.render_root(parent, root), writer.embedded

--- a/skills/tableau-build/scripts/zones.py
+++ b/skills/tableau-build/scripts/zones.py
@@ -43,6 +43,11 @@ ZONE_MARGIN = "4"
 TITLE_HEIGHT_PX = 30
 LEGEND_HEIGHT_PX = 22
 
+#: The share of the header row's width the title text takes. The rest is a blank spacer, so
+#: dropping a filter or a button into the row in Desktop needs no restructuring - which is
+#: the whole reason the header is a horizontal container rather than a bare text zone.
+HEADER_TEXT_SHARE = 75.0
+
 #: manifest ``objects[].kind`` -> the zone's ``type-v2``, for the kinds a layout can render
 #: on its own: a text block and a spacer need nothing beyond their box and their text.
 OBJECT_ZONE_TYPES: dict[str, str] = {
@@ -396,13 +401,35 @@ class _ZoneWriter:
         render_zone_style(zone, ZONE_MARGIN)
 
     def _title(self, parent: ET.Element, text: str, box: Box, label: str) -> None:
-        """Render a fixed-height text zone carrying the element's title."""
-        zone = self._zone(
-            parent, box, f"{label} title", type_v2="text",
+        """Render the element's header row: a fixed-height horizontal container holding the
+        title text and a blank spacer.
+
+        A row rather than a bare text zone because that is the structure an analyst edits: a
+        filter, a button or a logo joins the header by filling the spacer, with no zone tree
+        to rebuild. It renders identically while the row holds only the title.
+
+        Args:
+            parent: The wrapper to append the row to.
+            text: The title text.
+            box: The rectangle for the whole header row.
+            label: The element's label, which names every zone in the row.
+        """
+        row = self._zone(
+            parent, box, f"{CONTAINER_PREFIXES['horz']}-{label} header",
+            type_v2="layout-flow", param="horz",
             fixed_size=str(TITLE_HEIGHT_PX), is_fixed="true",
         )
-        self._formatted_text(zone, text, bold=True)
-        render_zone_style(zone, ZONE_MARGIN)
+        text_box, spacer_box = self._divide(
+            box, "horz", [HEADER_TEXT_SHARE, 100.0 - HEADER_TEXT_SHARE]
+        )
+        title_zone = self._zone(row, text_box, f"{label} title", type_v2="text")
+        self._formatted_text(title_zone, text, bold=True)
+        render_zone_style(title_zone, ZONE_MARGIN)
+        spacer = self._zone(
+            row, spacer_box, f"{label} header spacer", type_v2=OBJECT_ZONE_TYPES["blank"],
+        )
+        render_zone_style(spacer, ZONE_MARGIN)
+        render_zone_style(row, ZONE_MARGIN)  # last child, always
 
     def _legend(self, parent: ET.Element, leaf: Leaf, box: Box, label: str) -> None:
         """Render a fixed-height colour legend zone keying the sheet's colour encoding."""

--- a/skills/tableau-build/scripts/zones.py
+++ b/skills/tableau-build/scripts/zones.py
@@ -112,8 +112,9 @@ class Leaf:
     Attributes:
         worksheet: The Tableau sheet name for a view zone.
         kind: The manifest object kind for a non-view zone (see :data:`OBJECT_ZONE_TYPES`).
-        title: Title text; when set, a text zone is stacked above the content and the
-            sheet's own title is suppressed.
+        title: Title text; when set, a text zone is stacked above the content. Without it a
+            view zone has no header at all - the sheet's own title never renders on a
+            dashboard (see :meth:`_ZoneWriter._content`).
         text: The text a ``text`` object zone displays.
         legend: The colour legend to stack below the content, or ``None`` for no legend.
     """
@@ -359,10 +360,7 @@ class _ZoneWriter:
         if title_height:
             self._title(wrapper, leaf.title, Box(box.x, cursor, box.w, title_height), label)
             cursor += title_height
-        self._content(
-            wrapper, leaf, Box(box.x, cursor, box.w, content_height), label,
-            show_title=False,
-        )
+        self._content(wrapper, leaf, Box(box.x, cursor, box.w, content_height), label)
         cursor += content_height
         if legend_height:
             self._legend(
@@ -370,25 +368,23 @@ class _ZoneWriter:
             )
         render_zone_style(wrapper, ZONE_MARGIN)
 
-    def _content(
-        self, parent: ET.Element, leaf: Leaf, box: Box, label: str, show_title: bool = True
-    ) -> None:
+    def _content(self, parent: ET.Element, leaf: Leaf, box: Box, label: str) -> None:
         """Render the leaf's own zone: a sheet zone, an object zone, or a blank.
+
+        A sheet's *own* title is always suppressed: Tableau draws it inside the zone, over
+        the sheet's own height, so a short zone (a KPI card) loses its number to it. A
+        dashboard header is a text object's job - either the element's ``title`` or a text
+        object the layout places beside it.
 
         Args:
             parent: The zone to append to.
             leaf: What fills the element.
             box: The rectangle for the content itself.
             label: The zone's friendly name.
-            show_title: False when a generated title zone already labels the element, which
-                is what suppresses the sheet's own duplicate title.
         """
         if leaf.worksheet:
             # A sheet zone is identified by its 'name' and carries no type-v2.
-            zone = self._zone(
-                parent, box, label, name=leaf.worksheet,
-                show_title=None if show_title else "false",
-            )
+            zone = self._zone(parent, box, label, name=leaf.worksheet, show_title="false")
             self.embedded.add(leaf.worksheet)
         else:
             kind = leaf.kind.strip().lower()

--- a/tests/fixtures/charts/area.xml
+++ b/tests/fixtures/charts/area.xml
@@ -22,6 +22,8 @@
         <style>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/bar-filtered.xml
+++ b/tests/fixtures/charts/bar-filtered.xml
@@ -40,6 +40,8 @@
         <style>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/bar-sorted.xml
+++ b/tests/fixtures/charts/bar-sorted.xml
@@ -23,6 +23,8 @@
         <style>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/bar-stacked.xml
+++ b/tests/fixtures/charts/bar-stacked.xml
@@ -24,6 +24,8 @@
         <style>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/bar-styled.xml
+++ b/tests/fixtures/charts/bar-styled.xml
@@ -28,6 +28,8 @@
           </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/bar.xml
+++ b/tests/fixtures/charts/bar.xml
@@ -22,6 +22,8 @@
         <style>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/calculated-field.xml
+++ b/tests/fixtures/charts/calculated-field.xml
@@ -24,6 +24,8 @@
         <style>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/combo.xml
+++ b/tests/fixtures/charts/combo.xml
@@ -28,6 +28,8 @@
           </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/custom-tooltip.xml
+++ b/tests/fixtures/charts/custom-tooltip.xml
@@ -23,6 +23,8 @@
         <style>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/dual-axis.xml
+++ b/tests/fixtures/charts/dual-axis.xml
@@ -28,6 +28,8 @@
           </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/histogram.xml
+++ b/tests/fixtures/charts/histogram.xml
@@ -24,6 +24,8 @@
         <style>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/kpi-card.xml
+++ b/tests/fixtures/charts/kpi-card.xml
@@ -24,6 +24,8 @@
           </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/line.xml
+++ b/tests/fixtures/charts/line.xml
@@ -22,6 +22,8 @@
         <style>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/map.xml
+++ b/tests/fixtures/charts/map.xml
@@ -28,6 +28,8 @@
           </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/pie.xml
+++ b/tests/fixtures/charts/pie.xml
@@ -22,6 +22,8 @@
         <style>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/scatter.xml
+++ b/tests/fixtures/charts/scatter.xml
@@ -24,6 +24,8 @@
         <style>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/fixtures/charts/text-table.xml
+++ b/tests/fixtures/charts/text-table.xml
@@ -24,6 +24,8 @@
         <style>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
           </style-rule>
         </style>
         <panes>

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1015,11 +1015,12 @@ def test_a_sheet_no_dashboard_zone_shows_keeps_its_tab():
 
 
 def test_dashboard_is_sized_from_the_layout_canvas():
-    """The mock's approved canvas is the workbook's dashboard size."""
+    """The mock's approved canvas is the dashboard's *minimum*: the zone proportions hold at
+    any window size, so a maximum would only pad a wide screen with scrollable margin."""
     size = _render().find("dashboards/dashboard/size")
 
     assert size.attrib == {
-        "maxheight": "768", "maxwidth": "1366", "minheight": "768", "minwidth": "1366",
+        "minheight": "768", "minwidth": "1366", "sizing-mode": "range",
     }
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1014,13 +1014,16 @@ def test_a_sheet_no_dashboard_zone_shows_keeps_its_tab():
     assert "Revenue Detail" not in hidden
 
 
-def test_dashboard_is_sized_from_the_layout_canvas():
-    """The mock's approved canvas is the dashboard's *minimum*: the zone proportions hold at
-    any window size, so a maximum would only pad a wide screen with scrollable margin."""
+def test_dashboard_is_range_sized_above_the_standard_floor():
+    """The zone proportions hold at any window size, so the dashboard gets the standard
+    minimum and no maximum - not the mock's canvas, which is a design surface: pinning the
+    minimum to a 1366px-wide mock would make it unopenable on a smaller laptop."""
     size = _render().find("dashboards/dashboard/size")
 
     assert size.attrib == {
-        "minheight": "768", "minwidth": "1366", "sizing-mode": "range",
+        "minheight": str(twb.MIN_DASHBOARD_HEIGHT),
+        "minwidth": str(twb.MIN_DASHBOARD_WIDTH),
+        "sizing-mode": "range",
     }
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -974,12 +974,12 @@ def test_every_viewpoint_has_entire_view_zoom():
         assert viewpoint.find("zoom").get("type") == "entire-view"
 
 
-def test_every_worksheet_has_a_matching_visible_window():
+def test_every_worksheet_has_a_matching_window():
     """validate_twb's worksheet<->window check is bidirectional; both sides come from here.
 
-    The windows are *visible*: a sheet is hidden only once a dashboard zone embeds it, and
-    the zone tree is the next ticket. Hiding a sheet nothing shows leaves Tableau with no tab
-    to render it on, which is a workbook the analyst cannot see into at all."""
+    A window is hidden only when a dashboard zone embeds its sheet: Tableau renders no tab
+    for hidden='true', so hiding a sheet nothing shows leaves the analyst a workbook with
+    nothing to see."""
     root = _render()
     worksheets = [sheet.get("name") for sheet in root.findall("worksheets/worksheet")]
     windows = [
@@ -988,10 +988,30 @@ def test_every_worksheet_has_a_matching_visible_window():
     ]
 
     assert worksheets == windows == ["Revenue KPI", "Revenue Trend"]
-    assert not [
+    assert [
         window.get("name") for window in root.findall("windows/window")
         if window.get("class") == "worksheet" and window.get("hidden") == "true"
+    ] == ["Revenue KPI", "Revenue Trend"]  # both fill a zone in the layout tree
+
+
+def test_a_sheet_no_dashboard_zone_shows_keeps_its_tab():
+    """The other half of the rule: an un-embedded sheet stays reachable through its tab."""
+    document = _manifest()
+    # A second sheet on the same zone: only one zone exists, so one of them is embedded.
+    document["worksheets"].append({
+        "name": "Revenue Detail",
+        "element_id": "chart-trend",
+        "chart_type": "table",
+        "datasource": "sales_orders",
+        "shelves": {"columns": ["region"], "rows": ["revenue"]},
+    })
+
+    hidden = [
+        window.get("name") for window in _render(document).findall("windows/window")
+        if window.get("class") == "worksheet" and window.get("hidden") == "true"
     ]
+
+    assert "Revenue Detail" not in hidden
 
 
 def test_dashboard_is_sized_from_the_layout_canvas():

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -518,19 +518,23 @@ def test_no_map_means_no_workbook_mapsources():
     assert ET.fromstring(_render(document)).find("mapsources") is None
 
 
-def test_a_sheet_no_dashboard_zone_shows_keeps_its_tab():
-    """Tableau renders no tab for hidden='true', so hiding a sheet the dashboard does not
-    embed makes it unreachable - the workbook opens with nothing in it. Until the zone tree
-    lands, no sheet is embedded, so no sheet may be hidden."""
-    hidden = [
+def test_every_chart_type_gets_a_dashboard_zone_and_a_hidden_tab():
+    """Tableau renders no tab for hidden='true', so a sheet may only be hidden once a zone
+    shows it. With the zone tree in place, every one of the 15 sheets is embedded - so every
+    one is hidden, and the analyst opens on the dashboard rather than on a wall of tabs."""
+    hidden = {
         window.get("name")
         for window in ALL_CHARTS_ROOT.find("windows")
         if window.get("class") == "worksheet" and window.get("hidden") == "true"
-    ]
-    assert hidden == []
+    }
+    embedded = {
+        zone.get("name")
+        for zone in ALL_CHARTS_ROOT.findall("dashboards/dashboard/zones//zone")
+        if zone.get("name")
+    }
+    sheets = {sheet.get("name") for sheet in ALL_CHARTS_ROOT.findall("worksheets/worksheet")}
 
-    zones = ALL_CHARTS_ROOT.findall("dashboards/dashboard/zones//zone")
-    assert not [zone.get("name") for zone in zones if zone.get("name")]
+    assert embedded == sheets == hidden
 
 
 def test_a_sorted_workbook_carries_the_sort_format_flag():

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -720,11 +720,25 @@ def test_token_hex_colours_are_lower_cased():
 
 
 def test_without_tokens_no_styling_is_invented():
-    """No branding step means Tableau's own defaults - not a made-up font or colour."""
+    """No branding step means Tableau's own defaults - not a made-up font or colour. The
+    worksheet rule still carries the field-label switches, which are layout, not branding."""
     root = ET.fromstring(_render(tokens=""))
     element = _worksheet_element("Bar", root)
     assert element.find("layout-options") is None
-    assert element.find("table/style/style-rule[@element='worksheet']") is None
+    rule = element.find("table/style/style-rule[@element='worksheet']")
+    assert [format.get("attr") for format in rule] == ["display-field-labels"] * 2
+
+
+def test_field_labels_are_off_on_every_sheet():
+    """A field label repeats the zone's header and costs the chart a whole band of the
+    sheet - and on a crosstab it is the band the analyst notices."""
+    for element in ALL_CHARTS_ROOT.findall("worksheets/worksheet"):
+        rule = element.find("table/style/style-rule[@element='worksheet']")
+        scopes = {
+            format.get("scope") for format in rule.findall("format")
+            if format.get("attr") == "display-field-labels" and format.get("value") == "false"
+        }
+        assert scopes == {"cols", "rows"}, element.get("name")
 
 
 def test_an_unfilled_token_template_is_ignored():

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -94,21 +94,59 @@ def _walk_both(node, zone, path="root"):
     children = node.get("children") or []
     zone_children = zone.findall("zone")
 
+    if not children:
+        if not zone_children:
+            return
+        # A titled or colour-encoded leaf is wrapped, and the wrapper's children are the
+        # generated title / content / legend zones - never further layout nodes, so the tree
+        # still maps one-to-one.
+        label = zone.get("friendly-name", "")
+        assert label.startswith("V-"), f"{path}: a leaf zone has children but is no wrapper"
+        element = label[len("V-"):]
+        names = [part.get("friendly-name") for part in zone_children]
+        assert set(names) <= {element, f"{element} title", f"{element} legend"}, (
+            f"{path}: unexpected zone(s) under a leaf: {names}"
+        )
+        assert element in names, f"{path}: the wrapper lost its content zone"
+        return
+
     assert len(zone_children) == len(children), f"{path}: child count differs"
-    if children:
-        assert zone.get("type-v2") == "layout-flow", f"{path}: container is not a flow zone"
-        assert zone.get("param") == node.get("type"), f"{path}: orientation differs"
+    assert zone.get("type-v2") == "layout-flow", f"{path}: container is not a flow zone"
+    assert zone.get("param") == node.get("type"), f"{path}: orientation differs"
     for index, (child, child_zone) in enumerate(zip(children, zone_children), start=1):
         _walk_both(child, child_zone, f"{path}.{index}")
 
 
-def test_the_demo_projects_layout_tree_maps_one_to_one():
+def _leaf_ids(node):
+    """Return every element id the tree places on a leaf (in document order)."""
+    children = node.get("children") or []
+    if not children:
+        return [node["id"]] if node.get("id") else []
+    return [element_id for child in children for element_id in _leaf_ids(child)]
+
+
+@pytest.mark.parametrize("decorated", [False, True], ids=["bare", "titles-and-legends"])
+def test_the_demo_projects_layout_tree_maps_one_to_one(decorated):
     """AC #1, on the real thing: the demo's approved container tree, walked against the
-    zone tree it produces. A dropped, added or re-oriented container fails here."""
+    zone tree it produces. A dropped, added or re-oriented container fails here.
+
+    Run twice, because the shape the build actually produces is the decorated one: with a
+    title and a colour legend on every element, each leaf gains a wrapper, and the walk has
+    to still hold - a wrapper is transparent to the hierarchy, not a new level of it.
+    """
     layout = build.spec_layout(DEMO_SPEC.read_text(encoding="utf-8-sig"))
     assert layout is not None, f"the demo spec at {DEMO_SPEC} carries no layout tree"
 
-    container, _, _ = _render(layout["root"], canvas=layout["canvas"])
+    leaves = {} if not decorated else {
+        element_id: zones.Leaf(
+            worksheet=f"Sheet {index}",
+            title=f"Title {index}",
+            legend=zones.Legend("[ds].[none:region:nk]", "0"),
+        )
+        for index, element_id in enumerate(_leaf_ids(layout["root"]), start=1)
+    }
+
+    container, _, _ = _render(layout["root"], leaves, canvas=layout["canvas"])
 
     _walk_both(layout["root"], container.find("zone").find("zone"))
 
@@ -312,7 +350,8 @@ def test_a_colour_encoded_chart_gets_a_legend_zone_below_it():
     container, _, _ = _render(
         {"type": "vert", "children": [{"id": "chart", "size": 100}]},
         {"chart": zones.Leaf(
-            worksheet="Trend", legend=("[federated.abc].[none:region:nk]", "0")
+            worksheet="Trend",
+            legend=zones.Legend("[federated.abc].[none:region:nk]", "0"),
         )},
     )
     wrapper = container.find("zone/zone/zone")
@@ -330,7 +369,7 @@ def test_a_titled_colour_encoded_chart_stacks_title_sheet_legend():
     """All three parts share the element's box, and the sheet takes what is left."""
     container, _, _ = _render(
         {"type": "vert", "children": [{"id": "chart", "size": 100}]},
-        {"chart": zones.Leaf(worksheet="Trend", title="T", legend=("[c]", "1"))},
+        {"chart": zones.Leaf(worksheet="Trend", title="T", legend=zones.Legend("[c]", "1"))},
     )
     wrapper = container.find("zone/zone/zone")
     parts = wrapper.findall("zone")
@@ -339,6 +378,25 @@ def test_a_titled_colour_encoded_chart_stacks_title_sheet_legend():
         "text", "Trend", "color",
     ]
     assert sum(int(zone.get("h")) for zone in parts) == int(wrapper.get("h"))
+
+
+def test_a_box_too_short_for_its_title_and_legend_is_squeezed_not_overflowed():
+    """A zone written past its wrapper's bottom edge overlaps the sibling below it."""
+    root = {"type": "vert", "children": [
+        {"id": "sliver", "size": 3}, {"id": "rest", "size": 97},
+    ]}
+
+    container, _, _ = _render(
+        root,
+        {"sliver": zones.Leaf(worksheet="Tiny", title="T", legend=zones.Legend("[c]", "0"))},
+    )
+    wrapper, sibling = container.findall("zone/zone/zone")
+    parts = wrapper.findall("zone")
+
+    assert sum(int(zone.get("h")) for zone in parts) == int(wrapper.get("h"))
+    assert all(int(zone.get("h")) >= 0 for zone in parts)
+    bottom = int(parts[-1].get("y")) + int(parts[-1].get("h"))
+    assert bottom == int(wrapper.get("y")) + int(wrapper.get("h")) == int(sibling.get("y"))
 
 
 @pytest.mark.parametrize("kind, type_v2", [
@@ -366,9 +424,7 @@ def test_every_object_kind_the_manifest_accepts_has_a_zone_type():
     become a blank - so the two tables must cover the same set."""
     import manifest
 
-    assert manifest.OBJECT_KINDS == set(zones.OBJECT_ZONE_TYPES) | set(
-        zones.DEFERRED_ZONE_TYPES
-    )
+    assert manifest.OBJECT_KINDS == set(zones.OBJECT_ZONE_TYPES) | zones.DEFERRED_KINDS
 
 
 def test_a_text_object_carries_its_text():

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import pytest
 
 import build
+import twb
 import worksheet
 import zones
 
@@ -545,14 +546,17 @@ def test_a_layout_rich_manifest_validates():
     ) == []
 
 
-def test_the_dashboard_is_range_sized_from_the_canvas(layout_rich_workbook):
-    """The canvas is the floor, not a cage: zone units are normalised, so the mock's
-    proportions survive a larger window, and no maximum means no dead scrollable margin."""
+def test_the_dashboard_is_range_sized_above_the_standard_floor(layout_rich_workbook):
+    """Zone units are normalised, so the mock's proportions survive any window size: the
+    dashboard gets the standard minimum and no maximum, and the 1366x768 canvas the tree was
+    laid out against does not become the size the analyst is stuck with."""
     _, root = layout_rich_workbook
     size = root.find("dashboards/dashboard/size")
 
     assert size.attrib == {
-        "minheight": "768", "minwidth": "1366", "sizing-mode": "range",
+        "minheight": str(twb.MIN_DASHBOARD_HEIGHT),
+        "minwidth": str(twb.MIN_DASHBOARD_WIDTH),
+        "sizing-mode": "range",
     }
 
 

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -5,7 +5,7 @@ workbook's zone tree has to *be* that tree - not an approximation of it. What is
 is everything the mock's geometry depends on and an LLM checklist got wrong:
 
 * the zone hierarchy is the container tree one-to-one (a test walks both);
-* the dashboard is fixed-size at the mock's canvas, and sibling zones reproduce the declared
+* the dashboard's minimum size is the mock's canvas, and sibling zones reproduce the declared
   ``size`` percentages within rounding, tiling their parent exactly;
 * zone ids are sequential and unique, every zone carries a ``friendly-name``, and
   ``<zone-style>`` is the last child everywhere;
@@ -332,8 +332,10 @@ def test_a_titled_element_gets_a_text_zone_above_its_sheet():
     assert sheet_zone.get("name") == "Trend" and sheet_zone.get("show-title") == "false"
 
 
-def test_an_untitled_sheet_keeps_its_own_title_and_needs_no_wrapper():
-    """No title in the manifest means Tableau's own styled sheet title - and one zone less."""
+def test_a_sheets_own_title_is_always_off_titled_or_not():
+    """Tableau draws a sheet's own title inside the zone, out of the sheet's own height: a
+    KPI card 30px shorter than its number is a card that shows no number. The header is a
+    text zone's job, so an untitled element gets no header - and one zone less."""
     container, _, _ = _render(
         {"type": "vert", "children": [{"id": "chart", "size": 100}]},
         {"chart": zones.Leaf(worksheet="Trend")},
@@ -341,7 +343,7 @@ def test_an_untitled_sheet_keeps_its_own_title_and_needs_no_wrapper():
     zone = container.find("zone/zone/zone")
 
     assert zone.get("name") == "Trend"
-    assert zone.get("show-title") is None
+    assert zone.get("show-title") == "false"
     assert zone.findall("zone") == []
 
 
@@ -535,13 +537,14 @@ def test_a_layout_rich_manifest_validates():
     ) == []
 
 
-def test_the_dashboard_is_fixed_size_at_the_canvas(layout_rich_workbook):
-    """Without a fixed size Tableau re-flows the zones and the mock's geometry is lost."""
+def test_the_dashboard_is_range_sized_from_the_canvas(layout_rich_workbook):
+    """The canvas is the floor, not a cage: zone units are normalised, so the mock's
+    proportions survive a larger window, and no maximum means no dead scrollable margin."""
     _, root = layout_rich_workbook
     size = root.find("dashboards/dashboard/size")
 
     assert size.attrib == {
-        "maxheight": "768", "maxwidth": "1366", "minheight": "768", "minwidth": "1366",
+        "minheight": "768", "minwidth": "1366", "sizing-mode": "range",
     }
 
 

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -1,0 +1,536 @@
+"""Contract test for tableau-build's dashboard layout engine (CONTRACT.md step 8).
+
+The spec's ``## Layout`` container tree is what the analyst approved the mock at, so the
+workbook's zone tree has to *be* that tree - not an approximation of it. What is pinned here
+is everything the mock's geometry depends on and an LLM checklist got wrong:
+
+* the zone hierarchy is the container tree one-to-one (a test walks both);
+* the dashboard is fixed-size at the mock's canvas, and sibling zones reproduce the declared
+  ``size`` percentages within rounding, tiling their parent exactly;
+* zone ids are sequential and unique, every zone carries a ``friendly-name``, and
+  ``<zone-style>`` is the last child everywhere;
+* a titled element gets its own text zone (styled from ``DESIGN-TOKENS.md``) and a
+  colour-encoded chart gets a legend zone, both by construction.
+
+:mod:`zones` is pure and stdlib-only, so the geometry is driven directly rather than through
+a built ``.twbx``.
+"""
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+import build
+import worksheet
+import zones
+
+CANVAS = {"width": 1366, "height": 768}
+
+#: The demo project's approved spec - a real 4-level tree with a mapped container in it.
+DEMO_SPEC = (
+    Path(__file__).resolve().parent.parent
+    / "demo" / "output" / "mock-version" / "v_1" / "IMPLEMENTATION-SPEC.md"
+)
+
+#: The root margin, in zone units, at CANVAS - what every child of the root is inset by.
+INSET_X = round(zones.ROOT_MARGIN_PX / CANVAS["width"] * zones.ZONE_SPACE)
+INSET_Y = round(zones.ROOT_MARGIN_PX / CANVAS["height"] * zones.ZONE_SPACE)
+
+
+def _render(root, leaves=None, canvas=None, tokens=None):
+    """Render one layout tree and return ``(<zones> element, root zone id, embedded)``."""
+    container = ET.Element("zones")
+    root_id, embedded = zones.render_zones(
+        container,
+        root,
+        canvas or CANVAS,
+        leaves or {},
+        tokens or worksheet.DesignTokens(),
+    )
+    return container, root_id, embedded
+
+
+def _tree(node):
+    """Reduce a rendered zone element to ``(kind, [children])`` for a shape comparison."""
+    kind = node.get("name") or node.get("param") or node.get("type-v2") or "?"
+    return kind, [_tree(child) for child in node.findall("zone")]
+
+
+# --- Hierarchy ----------------------------------------------------------------
+
+def test_zone_hierarchy_mirrors_the_container_tree():
+    """The whole point: the approved container tree survives into the workbook (AC #1)."""
+    root = {
+        "type": "vert",
+        "children": [
+            {"type": "horz", "size": 20, "children": [
+                {"id": "kpi-a", "size": 50},
+                {"id": "kpi-b", "size": 50},
+            ]},
+            {"id": "chart-trend", "size": 80},
+        ],
+    }
+    leaves = {
+        "kpi-a": zones.Leaf(worksheet="A"),
+        "kpi-b": zones.Leaf(worksheet="B"),
+        "chart-trend": zones.Leaf(worksheet="Trend"),
+    }
+
+    container, _, _ = _render(root, leaves)
+
+    assert _tree(container.find("zone")) == (
+        "layout-basic", [
+            ("vert", [
+                ("horz", [("A", []), ("B", [])]),
+                ("Trend", []),
+            ]),
+        ],
+    )
+
+
+def _walk_both(node, zone, path="root"):
+    """Assert one layout node and one zone agree, then recurse into their children."""
+    children = node.get("children") or []
+    zone_children = zone.findall("zone")
+
+    assert len(zone_children) == len(children), f"{path}: child count differs"
+    if children:
+        assert zone.get("type-v2") == "layout-flow", f"{path}: container is not a flow zone"
+        assert zone.get("param") == node.get("type"), f"{path}: orientation differs"
+    for index, (child, child_zone) in enumerate(zip(children, zone_children), start=1):
+        _walk_both(child, child_zone, f"{path}.{index}")
+
+
+def test_the_demo_projects_layout_tree_maps_one_to_one():
+    """AC #1, on the real thing: the demo's approved container tree, walked against the
+    zone tree it produces. A dropped, added or re-oriented container fails here."""
+    layout = build.spec_layout(DEMO_SPEC.read_text(encoding="utf-8-sig"))
+    assert layout is not None, f"the demo spec at {DEMO_SPEC} carries no layout tree"
+
+    container, _, _ = _render(layout["root"], canvas=layout["canvas"])
+
+    _walk_both(layout["root"], container.find("zone").find("zone"))
+
+
+def test_a_mapped_container_is_one_zone_holding_its_children():
+    """A node with both an 'id' and 'children' (a DZV panel) is filled by its children."""
+    root = {
+        "type": "vert",
+        "children": [
+            {"id": "pnl-detail", "type": "horz", "size": 100, "children": [
+                {"id": "chart-a", "size": 50},
+                {"id": "chart-b", "size": 50},
+            ]},
+        ],
+    }
+    leaves = {"chart-a": zones.Leaf(worksheet="A"), "chart-b": zones.Leaf(worksheet="B")}
+
+    container, _, _ = _render(root, leaves)
+    panel = container.find("zone/zone/zone")
+
+    assert panel.get("type-v2") == "layout-flow" and panel.get("param") == "horz"
+    assert panel.get("friendly-name") == "H-pnl-detail"
+    assert [zone.get("name") for zone in panel.findall("zone")] == ["A", "B"]
+
+
+def test_the_root_zone_is_layout_basic_and_children_are_inset_by_its_margin():
+    """The root fills the coordinate space; its 8px margin insets everything below it."""
+    container, root_id, _ = _render({"type": "vert", "children": [{"id": "a", "size": 100}]})
+    root_zone = container.find("zone")
+
+    assert root_id == "1"
+    assert root_zone.attrib == {
+        "friendly-name": "Dashboard", "h": "100000", "id": "1",
+        "type-v2": "layout-basic", "w": "100000", "x": "0", "y": "0",
+    }
+    flow = root_zone.find("zone")
+    assert (int(flow.get("x")), int(flow.get("y"))) == (INSET_X, INSET_Y)
+    assert int(flow.get("w")) == zones.ZONE_SPACE - 2 * INSET_X
+    assert int(flow.get("h")) == zones.ZONE_SPACE - 2 * INSET_Y
+
+
+# --- Geometry -----------------------------------------------------------------
+
+def test_sibling_sizes_reproduce_the_declared_percentages():
+    """A 20/80 vert split is a 20/80 split of the parent's height (AC #2)."""
+    root = {"type": "vert", "children": [
+        {"id": "top", "size": 20}, {"id": "bottom", "size": 80},
+    ]}
+
+    container, _, _ = _render(root)
+    top, bottom = container.findall("zone/zone/zone")
+    extent = zones.ZONE_SPACE - 2 * INSET_Y
+
+    assert int(top.get("h")) == pytest.approx(extent * 0.20, abs=1)
+    assert int(bottom.get("h")) == pytest.approx(extent * 0.80, abs=1)
+    # Same x/w: a vert split only divides the height.
+    assert top.get("w") == bottom.get("w") and top.get("x") == bottom.get("x")
+
+
+def test_siblings_tile_their_parent_exactly():
+    """Rounding must never leave a gap or an overlap - the last child absorbs the remainder."""
+    root = {"type": "horz", "children": [
+        {"id": "a", "size": 33}, {"id": "b", "size": 33}, {"id": "c", "size": 34},
+    ]}
+
+    container, _, _ = _render(root)
+    parent = container.find("zone/zone")
+    children = parent.findall("zone")
+
+    edge = int(parent.get("x"))
+    for child in children:
+        assert int(child.get("x")) == edge
+        edge += int(child.get("w"))
+    assert edge == int(parent.get("x")) + int(parent.get("w"))
+
+
+def test_children_without_a_size_share_what_is_left():
+    """A tree that declares some sizes and not others must still fill the parent."""
+    root = {"type": "vert", "children": [
+        {"id": "a", "size": 50}, {"id": "b"}, {"id": "c"},
+    ]}
+
+    container, _, _ = _render(root)
+    parent = container.find("zone/zone")
+    heights = [int(child.get("h")) for child in parent.findall("zone")]
+
+    assert sum(heights) == int(parent.get("h"))
+    assert heights[1] == heights[2]  # the two undeclared children split the other half
+    assert heights[0] == pytest.approx(heights[1] * 2, abs=2)
+
+
+def test_percentages_that_do_not_total_100_are_normalised():
+    """The spec's sizes are proportions; a tree summing to 90 still fills the dashboard."""
+    root = {"type": "horz", "children": [{"id": "a", "size": 30}, {"id": "b", "size": 60}]}
+
+    container, _, _ = _render(root)
+    parent = container.find("zone/zone")
+    left, right = parent.findall("zone")
+
+    assert int(left.get("w")) + int(right.get("w")) == int(parent.get("w"))
+    assert int(right.get("w")) == pytest.approx(2 * int(left.get("w")), abs=2)
+
+
+# --- Invariants Tableau enforces ----------------------------------------------
+
+def test_zone_ids_are_sequential_unique_integers():
+    """Ids are cross-referenced by <active id> and device layouts, so they must be sane."""
+    root = {"type": "vert", "children": [
+        {"type": "horz", "size": 50, "children": [{"id": "a", "size": 100}]},
+        {"id": "b", "size": 50},
+    ]}
+
+    container, _, _ = _render(root)
+    ids = [int(zone.get("id")) for zone in container.iter("zone")]
+
+    assert ids == sorted(ids) and len(set(ids)) == len(ids)
+    assert ids == list(range(1, len(ids) + 1))
+
+
+def test_every_zone_has_a_friendly_name():
+    """ZoneFriendlyName is in the format manifest; a nameless zone reads as a bug (AC #3)."""
+    root = {"type": "vert", "children": [
+        {"type": "horz", "size": 50, "children": [{"id": "a", "size": 100}]},
+        {"id": "b", "size": 50},
+    ]}
+
+    container, _, _ = _render(root, {"a": zones.Leaf(worksheet="A", title="Chart A")})
+
+    for zone in container.iter("zone"):
+        assert (zone.get("friendly-name") or "").strip(), ET.tostring(zone)
+
+
+def test_zone_style_is_always_the_last_child():
+    """Tableau reads <zone-style> positionally: anything after it is ignored."""
+    root = {"type": "vert", "children": [
+        {"type": "horz", "size": 100, "children": [{"id": "a", "size": 100}]},
+    ]}
+
+    container, _, _ = _render(root, {"a": zones.Leaf(worksheet="A", title="T")})
+
+    for zone in container.iter("zone"):
+        assert [child.tag for child in zone][-1] == "zone-style", ET.tostring(zone)
+        assert len(zone.findall("zone-style")) == 1
+
+
+# --- Content ------------------------------------------------------------------
+
+def test_a_worksheet_zone_names_its_sheet_and_reports_it_as_embedded():
+    """The dashboard embeds the sheet; the caller hides exactly the embedded ones."""
+    container, _, embedded = _render(
+        {"type": "vert", "children": [{"id": "chart", "size": 100}]},
+        {"chart": zones.Leaf(worksheet="Revenue Trend")},
+    )
+    zone = container.find("zone/zone/zone")
+
+    assert zone.get("name") == "Revenue Trend"
+    assert zone.get("type-v2") is None  # a sheet zone is typed by its 'name', not type-v2
+    assert embedded == {"Revenue Trend"}
+
+
+def test_a_titled_element_gets_a_text_zone_above_its_sheet():
+    """The spec's title becomes a styled text zone; the sheet's own title is suppressed."""
+    tokens = worksheet.DesignTokens(
+        font_family="Inter", title_size=14, title_color="#1a2b3c", present=True
+    )
+    container, _, _ = _render(
+        {"type": "vert", "children": [{"id": "chart", "size": 100}]},
+        {"chart": zones.Leaf(worksheet="Trend", title="Revenue over time")},
+        tokens=tokens,
+    )
+    wrapper = container.find("zone/zone/zone")
+    title_zone, sheet_zone = wrapper.findall("zone")
+
+    assert wrapper.get("param") == "vert"  # the title stacks above the sheet
+    assert title_zone.get("type-v2") == "text"
+    assert title_zone.get("is-fixed") == "true"
+    assert title_zone.get("fixed-size") == str(zones.TITLE_HEIGHT_PX)
+    run = title_zone.find("formatted-text/run")
+    assert run.text == "Revenue over time"
+    assert run.attrib == {
+        "bold": "true", "fontcolor": "#1a2b3c", "fontname": "Inter", "fontsize": "14",
+    }
+    assert sheet_zone.get("name") == "Trend" and sheet_zone.get("show-title") == "false"
+
+
+def test_an_untitled_sheet_keeps_its_own_title_and_needs_no_wrapper():
+    """No title in the manifest means Tableau's own styled sheet title - and one zone less."""
+    container, _, _ = _render(
+        {"type": "vert", "children": [{"id": "chart", "size": 100}]},
+        {"chart": zones.Leaf(worksheet="Trend")},
+    )
+    zone = container.find("zone/zone/zone")
+
+    assert zone.get("name") == "Trend"
+    assert zone.get("show-title") is None
+    assert zone.findall("zone") == []
+
+
+def test_a_colour_encoded_chart_gets_a_legend_zone_below_it():
+    """A colour encoding with no key in the dashboard reads as a broken chart."""
+    container, _, _ = _render(
+        {"type": "vert", "children": [{"id": "chart", "size": 100}]},
+        {"chart": zones.Leaf(
+            worksheet="Trend", legend=("[federated.abc].[none:region:nk]", "0")
+        )},
+    )
+    wrapper = container.find("zone/zone/zone")
+    sheet_zone, legend_zone = wrapper.findall("zone")
+
+    assert sheet_zone.get("name") == "Trend"
+    assert legend_zone.get("type-v2") == "color"
+    assert legend_zone.get("name") == "Trend"  # the sheet whose encoding it keys
+    assert legend_zone.get("param") == "[federated.abc].[none:region:nk]"
+    assert legend_zone.get("pane-specification-id") == "0"
+    assert legend_zone.get("fixed-size") == str(zones.LEGEND_HEIGHT_PX)
+
+
+def test_a_titled_colour_encoded_chart_stacks_title_sheet_legend():
+    """All three parts share the element's box, and the sheet takes what is left."""
+    container, _, _ = _render(
+        {"type": "vert", "children": [{"id": "chart", "size": 100}]},
+        {"chart": zones.Leaf(worksheet="Trend", title="T", legend=("[c]", "1"))},
+    )
+    wrapper = container.find("zone/zone/zone")
+    parts = wrapper.findall("zone")
+
+    assert [zone.get("type-v2") or zone.get("name") for zone in parts] == [
+        "text", "Trend", "color",
+    ]
+    assert sum(int(zone.get("h")) for zone in parts) == int(wrapper.get("h"))
+
+
+@pytest.mark.parametrize("kind, type_v2", [
+    ("text", "text"), ("blank", "empty"),
+    # Deferred to #37: each needs a reference the manifest does not carry yet, so the layout
+    # reserves the box rather than emitting a zone Tableau cannot resolve.
+    ("image", "empty"), ("filter", "empty"), ("legend", "empty"),
+    ("button", "empty"), ("parameter", "empty"),
+    ("nonsense", "empty"),
+])
+def test_object_kinds_map_to_their_zone_type(kind, type_v2):
+    """Every manifest object kind gets a zone - none of them drops out of the layout."""
+    container, _, embedded = _render(
+        {"type": "vert", "children": [{"id": "obj", "size": 100}]},
+        {"obj": zones.Leaf(kind=kind)},
+    )
+    zone = container.find("zone/zone/zone")
+
+    assert zone.get("type-v2") == type_v2
+    assert embedded == set()  # an object zone embeds no sheet
+
+
+def test_every_object_kind_the_manifest_accepts_has_a_zone_type():
+    """A kind validate_manifest allows but this module has never heard of would silently
+    become a blank - so the two tables must cover the same set."""
+    import manifest
+
+    assert manifest.OBJECT_KINDS == set(zones.OBJECT_ZONE_TYPES) | set(
+        zones.DEFERRED_ZONE_TYPES
+    )
+
+
+def test_a_text_object_carries_its_text():
+    """A title/label zone with no text is an empty box on the analyst's dashboard."""
+    container, _, _ = _render(
+        {"type": "vert", "children": [{"id": "obj", "size": 100}]},
+        {"obj": zones.Leaf(kind="text", text="Sales Performance")},
+    )
+    run = container.find("zone/zone/zone/formatted-text/run")
+
+    assert run.text == "Sales Performance"
+
+
+def test_an_unmapped_leaf_becomes_an_empty_zone_not_a_missing_one():
+    """validate_manifest rejects an unfilled zone; if one still arrives, keep the geometry."""
+    container, _, _ = _render({"type": "vert", "children": [{"id": "ghost", "size": 100}]})
+    zone = container.find("zone/zone/zone")
+
+    assert zone.get("type-v2") == "empty"
+    assert zone.get("friendly-name") == "ghost"
+
+
+# --- The zone tree inside a real workbook --------------------------------------
+
+DATA_MODEL = """# Data Model
+
+## Data source: `sales_orders.csv`
+
+| Field | Type | Role | Sample values | Description |
+|-------|------|------|---------------|-------------|
+| region | string | dimension | West | Sales region |
+| revenue | real | measure | 1200.5 | Order revenue |
+"""
+
+CSV_HEADERS = {"sales_orders.csv": ["region", "revenue"]}
+
+TARGET_VERSION = "2026.1+"
+
+#: A header/sidebar/main dashboard: nested containers three deep, a titled and colour-encoded
+#: chart, and one zone of every object kind - the shapes a real spec produces.
+LAYOUT_RICH_MANIFEST = {
+    "target_tableau_version": TARGET_VERSION,
+    "datasources": [{
+        "name": "sales_orders",
+        "csv": "sales_orders.csv",
+        "fields": [{"name": "region", "type": "string"}, {"name": "revenue", "type": "real"}],
+    }],
+    "worksheets": [{
+        "name": "Revenue by Region",
+        "element_id": "chart-revenue",
+        "chart_type": "bar",
+        "datasource": "sales_orders",
+        "title": "Revenue by region",
+        "shelves": {"columns": ["region"], "rows": ["revenue"]},
+        "encodings": {"color": "region"},
+    }],
+    "objects": [
+        {"element_id": "txt-title", "kind": "text", "text": "Sales Performance"},
+        {"element_id": "img-logo", "kind": "image"},
+        {"element_id": "flt-region", "kind": "filter"},
+        {"element_id": "prm-target", "kind": "parameter"},
+        {"element_id": "leg-region", "kind": "legend"},
+        {"element_id": "btn-reset", "kind": "button"},
+        {"element_id": "spc-gap", "kind": "blank"},
+    ],
+    "layout": {
+        "canvas": {"width": 1366, "height": 768},
+        "root": {
+            "type": "vert",
+            "children": [
+                {"type": "horz", "size": 10, "children": [
+                    {"id": "img-logo", "size": 20},
+                    {"id": "txt-title", "size": 80},
+                ]},
+                {"type": "horz", "size": 90, "children": [
+                    {"id": "pnl-sidebar", "type": "vert", "size": 25, "children": [
+                        {"id": "flt-region", "size": 25},
+                        {"id": "prm-target", "size": 25},
+                        {"id": "leg-region", "size": 20},
+                        {"id": "btn-reset", "size": 20},
+                        {"id": "spc-gap", "size": 10},
+                    ]},
+                    {"id": "chart-revenue", "size": 75},
+                ]},
+            ],
+        },
+    },
+    "actions": [],
+    "parameters": [],
+}
+
+
+@pytest.fixture(scope="module")
+def layout_rich_workbook():
+    """The rendered ``.twb`` XML of :data:`LAYOUT_RICH_MANIFEST` (text and parsed root)."""
+    import twb
+
+    xml_text = twb.render_workbook(LAYOUT_RICH_MANIFEST, DATA_MODEL, CSV_HEADERS)
+    return xml_text, ET.fromstring(xml_text)
+
+
+def test_a_layout_rich_manifest_validates():
+    """The schema accepts the tree, so a failure below is the assembler's, not the manifest's."""
+    import manifest
+
+    assert manifest.validate_manifest(
+        LAYOUT_RICH_MANIFEST, DATA_MODEL, TARGET_VERSION
+    ) == []
+
+
+def test_the_dashboard_is_fixed_size_at_the_canvas(layout_rich_workbook):
+    """Without a fixed size Tableau re-flows the zones and the mock's geometry is lost."""
+    _, root = layout_rich_workbook
+    size = root.find("dashboards/dashboard/size")
+
+    assert size.attrib == {
+        "maxheight": "768", "maxwidth": "1366", "minheight": "768", "minwidth": "1366",
+    }
+
+
+def test_the_workbooks_zone_tree_mirrors_the_manifests(layout_rich_workbook):
+    """End to end: element ids in, a nested zone tree out, with the wrappers where expected."""
+    _, root = layout_rich_workbook
+    dashboard_zones = root.find("dashboards/dashboard/zones")
+
+    friendly_names = [zone.get("friendly-name") for zone in dashboard_zones.iter("zone")]
+    assert friendly_names == [
+        "Dashboard", "V-root",
+        "H-root.1", "img-logo", "txt-title",
+        "H-root.2",
+        "V-pnl-sidebar", "flt-region", "prm-target", "leg-region", "btn-reset", "spc-gap",
+        # The titled, colour-encoded chart is wrapped: title above, legend below.
+        "V-chart-revenue", "chart-revenue title", "chart-revenue", "chart-revenue legend",
+    ]
+
+
+def test_the_layout_rich_workbook_passes_the_legacy_validators(layout_rich_workbook, tmp_path):
+    """The cross-reference checks the legacy skill shipped, on a full zone tree."""
+    import validate_twb
+
+    xml_text, _ = layout_rich_workbook
+    twb_path = tmp_path / "layout-rich.twb"
+    twb_path.write_text(xml_text, encoding="utf-8")
+
+    report = validate_twb.TwbValidator(str(twb_path)).validate()
+
+    assert not [
+        f"{result.name}: {result.details}" for result in report.results if not result.passed
+    ]
+
+
+def test_the_layout_rich_workbook_passes_the_xsd(layout_rich_workbook, tmp_path):
+    """Zone attributes and nesting are schema-checked: Tableau will not repair a bad tree."""
+    pytest.importorskip("lxml")
+    import validate_twb_xsd
+
+    xml_text, _ = layout_rich_workbook
+    twb_path = tmp_path / "layout-rich.twb"
+    twb_path.write_text(xml_text, encoding="utf-8")
+
+    _, errors = validate_twb_xsd.validate(
+        twb_path, validate_twb_xsd.load_schema(validate_twb_xsd.XSD_PATH)
+    )
+
+    assert not [f"line {error.line}: {error.message}" for error in errors]

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -98,13 +98,13 @@ def _walk_both(node, zone, path="root"):
         if not zone_children:
             return
         # A titled or colour-encoded leaf is wrapped, and the wrapper's children are the
-        # generated title / content / legend zones - never further layout nodes, so the tree
-        # still maps one-to-one.
+        # generated header row / content / legend zones - never further layout nodes, so the
+        # tree still maps one-to-one.
         label = zone.get("friendly-name", "")
         assert label.startswith("V-"), f"{path}: a leaf zone has children but is no wrapper"
         element = label[len("V-"):]
         names = [part.get("friendly-name") for part in zone_children]
-        assert set(names) <= {element, f"{element} title", f"{element} legend"}, (
+        assert set(names) <= {element, f"H-{element} header", f"{element} legend"}, (
             f"{path}: unexpected zone(s) under a leaf: {names}"
         )
         assert element in names, f"{path}: the wrapper lost its content zone"
@@ -307,8 +307,9 @@ def test_a_worksheet_zone_names_its_sheet_and_reports_it_as_embedded():
     assert embedded == {"Revenue Trend"}
 
 
-def test_a_titled_element_gets_a_text_zone_above_its_sheet():
-    """The spec's title becomes a styled text zone; the sheet's own title is suppressed."""
+def test_a_titled_element_gets_a_header_row_above_its_sheet():
+    """The spec's title becomes a styled text zone in a fixed-height header row; the sheet's
+    own title is suppressed."""
     tokens = worksheet.DesignTokens(
         font_family="Inter", title_size=14, title_color="#1a2b3c", present=True
     )
@@ -318,17 +319,24 @@ def test_a_titled_element_gets_a_text_zone_above_its_sheet():
         tokens=tokens,
     )
     wrapper = container.find("zone/zone/zone")
-    title_zone, sheet_zone = wrapper.findall("zone")
+    header_row, sheet_zone = wrapper.findall("zone")
 
-    assert wrapper.get("param") == "vert"  # the title stacks above the sheet
+    assert wrapper.get("param") == "vert"  # the header stacks above the sheet
+    assert header_row.get("param") == "horz"
+    assert header_row.get("is-fixed") == "true"
+    assert header_row.get("fixed-size") == str(zones.TITLE_HEIGHT_PX)
+
+    title_zone, spacer = header_row.findall("zone")
     assert title_zone.get("type-v2") == "text"
-    assert title_zone.get("is-fixed") == "true"
-    assert title_zone.get("fixed-size") == str(zones.TITLE_HEIGHT_PX)
     run = title_zone.find("formatted-text/run")
     assert run.text == "Revenue over time"
     assert run.attrib == {
         "bold": "true", "fontcolor": "#1a2b3c", "fontname": "Inter", "fontsize": "14",
     }
+    # The spacer is what a filter or a button fills later, so the row must not be all text.
+    assert spacer.get("type-v2") == "empty"
+    assert int(title_zone.get("w")) + int(spacer.get("w")) == int(header_row.get("w"))
+    assert int(title_zone.get("w")) > int(spacer.get("w"))
     assert sheet_zone.get("name") == "Trend" and sheet_zone.get("show-title") == "false"
 
 
@@ -377,7 +385,7 @@ def test_a_titled_colour_encoded_chart_stacks_title_sheet_legend():
     parts = wrapper.findall("zone")
 
     assert [zone.get("type-v2") or zone.get("name") for zone in parts] == [
-        "text", "Trend", "color",
+        "layout-flow", "Trend", "color",  # the header row, the sheet, the legend
     ]
     assert sum(int(zone.get("h")) for zone in parts) == int(wrapper.get("h"))
 
@@ -559,8 +567,10 @@ def test_the_workbooks_zone_tree_mirrors_the_manifests(layout_rich_workbook):
         "H-root.1", "img-logo", "txt-title",
         "H-root.2",
         "V-pnl-sidebar", "flt-region", "prm-target", "leg-region", "btn-reset", "spc-gap",
-        # The titled, colour-encoded chart is wrapped: title above, legend below.
-        "V-chart-revenue", "chart-revenue title", "chart-revenue", "chart-revenue legend",
+        # The titled, colour-encoded chart is wrapped: header row above, legend below.
+        "V-chart-revenue",
+        "H-chart-revenue header", "chart-revenue title", "chart-revenue header spacer",
+        "chart-revenue", "chart-revenue legend",
     ]
 
 


### PR DESCRIPTION
Closes #36.

## What this does

`tableau-build` produced worksheets but no dashboard: the layout tree in
`IMPLEMENTATION-SPEC.md` — the geometry the analyst approved the mock at — was not turned into
anything. This adds `skills/tableau-build/scripts/zones.py`, which converts that container tree
into the workbook's zone hierarchy **by construction** rather than by an agent eyeballing
percentages, and wires `twb.py` into it.

- **The zone tree *is* the container tree.** Each node becomes one zone; sibling `size` values
  are proportions of the parent along its flow axis, mapped into Tableau's 0–100000 space at
  the canvas dimensions. Edges are rounded from the *cumulative* proportion, so children tile
  their parent exactly — no rounding gap, no overlap.
- **Invariants Tableau actually enforces** are pinned: sequential unique zone ids, a
  `friendly-name` on every zone (the legacy `V-`/`H-` convention), and `<zone-style>` as the
  **last** child everywhere (Tableau reads it positionally — anything after it is ignored).
- **Generated zones stack inside the element's own box**, never disturbing its siblings: a
  header row above the sheet, a colour legend below it. A box too short for both is squeezed,
  never overflowed — a zone written past its wrapper's bottom edge overlaps the sibling below.
- **`twb.py` hides exactly the sheets a zone embeds.** Hiding a sheet no zone shows leaves
  Tableau no tab to render it on, and the analyst opens a workbook with nothing in it.

`zones.py` is pure and stdlib-only — it takes the tree, the canvas and a `{element id: Leaf}`
map and appends zones to an element — so `tests/test_zones.py` drives the geometry directly
instead of through a built `.twbx`.

## What the first Tableau Desktop open changed

The engine landed geometrically correct and visually wrong in four ways. All fixed here:

| Was | Now |
|-----|-----|
| A sheet's own title rendered unless the element declared a `title` | `show-title='false'` on **every** sheet zone. Tableau draws that title inside the zone, out of the sheet's own height — a KPI card lost its big number to it. |
| A `title` became a bare text zone | A fixed-height **`H` container: title text + blank spacer**. Identical rendering, but a filter or button joins the header row without rebuilding the zone tree. |
| Field labels on | `display-field-labels=false` on every sheet, both scopes — they repeat the zone's header and cost the chart a whole band. |
| Dashboard fixed at the mock's canvas | `sizing-mode='range'`, **1100 x 800** minimum, no maximum. Zone units are normalised, so the approved proportions hold at any window size; a hard maximum only forces the viewer to scroll a wide screen's worth of empty margin. |

## Deferred, on purpose

`filter` / `parameter` / `image` / `button` / `legend` objects reserve their box as an empty
zone. Each needs a reference the manifest does not carry yet (a field plus the dashboard's own
`<datasource-dependencies>`, a parameter, an embedded filename, an action, a sheet + colour
field) and Tableau does not treat those as optional — so the layout keeps the geometry the
analyst approved and the wiring lands with #37 (`filter` / `parameter` / `button`) and #46
(`image` / `legend`). A chart's *own* colour legend zone is emitted and covered by tests today.

## Verification

- `422 passed` — full suite, including the new `tests/test_zones.py` (AC #1 walks the demo
  project's real 4-level tree against the zone tree it produces, parametrized bare /
  titles-and-legends so a wrapper is proven transparent to the hierarchy).
- `tests/fixtures/charts/*.xml` regenerated for the field-label rules (+2 lines each).
- **AC #4, in Tableau Desktop 2025.1.10**: a scratch project built and opened; 32 zones, ids
  sequential and unique, every sibling group tiling its parent exactly, all 5 sheets embedded
  and hidden. Details in the [verification comment on #36](https://github.com/laviDrori0702/tableau-dashboard-creator-skill/issues/36#issuecomment-5128072561).
- `/code-review` ran on both axes (Standards + Spec); its findings are closed in `4a0163d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
