### PR TITLE
feat(build): features and actions - calcs, parameters, filter/highlight/parameter actions, DZV

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -334,7 +334,7 @@ the mock's behavior, and the spec's Tableau mapping.
 |-----------------|-------------------------------------------------------------------------------------|-----------------------------------------------|
 | `toggle panel`  | Show/hide a region of the dashboard on demand.                                      | Dynamic Zone Visibility, or a show/hide button container. |
 | `swap view`     | Replace one chart with an alternative in the same slot (e.g. bar ⇄ line).           | Parameter + Dynamic Zone Visibility, or sheet swap. |
-| `drill`         | Move between levels of a hierarchy (e.g. year → quarter → month) in place.          | Hierarchy expand/collapse, or set/parameter action. |
+| `drill`         | Move between levels of a hierarchy (e.g. year → quarter → month) in place.          | Hierarchy expand/collapse, or a **parameter** action. `tableau-build` emits no set/URL actions, so a drill that a set action would express has to be specced as a parameter action. |
 | `cross-filter`  | Selecting marks in one chart filters the others.                                    | Filter action (`Use as Filter`). |
 | `highlight`     | Selecting marks in one chart highlights related marks elsewhere without filtering.  | Highlight action. |
 | `parameter swap`| A control changes a measure/dimension/threshold used across the dashboard.          | Parameter + parameter action / calculated field. |

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -162,11 +162,13 @@ invented zone is caught rather than silently built.
   a parameter. Either shape is normal: a two-value parameter with a control (`= true` / `=
   "on"`, the collapse-this-panel toggle) or a parameter a parameter action writes into,
   compared against its opening value (`<> "All"`, the nothing-to-show-until-you-pick reveal,
-  which needs no control because clearing the selection resets it). **Never write that calc as
-  an LOD expression** — `{FIXED : …}` is view-independent too and Tableau accepts it, but it is
-  hard to reason about and hard to repair by hand. A row-level boolean is not a visibility
-  field at all: it splits the marks and the zone stops toggling. The Detail-shelf placement the
-  field needs, the parameter declarations and the format flags are all the builder's job.
+  which needs no control because clearing the selection resets it). **Never write a *visibility*
+  calc as an LOD expression** — `{FIXED : …}` is view-independent too and Tableau accepts it,
+  but it is hard to reason about and hard to repair by hand. That is the only place LODs are
+  ruled out; elsewhere they are ordinary `calculated_fields`. A row-level boolean is not a
+  visibility field at all: it splits the marks and the zone stops toggling. The Detail-shelf
+  placement the field needs, the parameter declarations and the format flags are the builder's
+  job.
 - **An image / button / legend object reserves its box, empty.** Each of those zone types needs
   a reference the manifest does not carry (a filename, an action, a sheet + colour field), and
   Tableau does not treat those as optional — so the layout keeps the geometry until the wiring

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -39,10 +39,11 @@ stray field name or datasource id can leak into the analyst's workbook. Pick the
 `pie`, `scatter`, `map`, `text` = KPI card, `table` = text table, `histogram`, `dual-axis`,
 `combo`, plus `heatmap` / `treemap` / `bullet` / `gantt` / `boxplot`).
 
-Four things the spec may ask for are **not** chart types — they are optional keys on any
-worksheet: `sort`, `filters`, `tooltip`, and `axis_titles` / `number_formats`. A *stacked*
-bar is a `bar` with a `color` encoding. Reach for a modifier before reaching for a new
-chart type.
+Several things the spec may ask for are **not** chart types — they are optional keys on any
+worksheet: `sort`, `filters`, `tooltip`, `reference_lines`, and `axis_titles` /
+`number_formats`; a running total or percent-of-total is a `table_calc` on the shelf entry. A
+*stacked* bar is a `bar` with a `color` encoding. Reach for a modifier before reaching for a
+new chart type.
 
 Styling comes from `DESIGN-TOKENS.md` when the analyst ran `tableau-brand`: its font family
 and chart-title size/colour are applied to every worksheet automatically. When it is absent,
@@ -149,12 +150,27 @@ invented zone is caught rather than silently built.
   generated zones stack *inside* the element's own box, so they never disturb its siblings.
 - **Field labels are off on every sheet.** They repeat what the zone's header already says
   and cost the chart a whole band of the sheet.
-- **A filter / parameter / image / button / legend object reserves its box, empty.** Each of
-  those zone types needs a reference the manifest does not carry yet (a field plus the
-  dashboard's own `<datasource-dependencies>`, a parameter, a filename, an action, a sheet +
-  colour field), and Tableau does not treat those as optional — so the layout keeps the
-  geometry and the features-and-actions ticket turns each into its real zone. `text` and
-  `blank` objects render fully today.
+- **The dashboard is interactive** (CONTRACT.md §6). An `actions` entry of type `filter`
+  cross-filters its target zones from the marks clicked in its source view, `highlight` brushes
+  related marks, and `parameter` writes a clicked mark's `field` into a declared parameter;
+  `run_on` chooses click (`select`) or `hover`, and one Tableau action is emitted per target. A
+  `filter` object is a quick-filter card over one worksheet's field, and a `parameter` object is
+  that parameter's control. Endpoints are validated: an action source and its filter/highlight
+  targets must be **view** zones, a parameter action's target a declared parameter.
+- **A `visibility` key on a layout node is Dynamic Zone Visibility**, and its boolean
+  calculated field must resolve to **one value, independent of the view** — so the calc compares
+  a parameter. Either shape is normal: a two-value parameter with a control (`= true` / `=
+  "on"`, the collapse-this-panel toggle) or a parameter a parameter action writes into,
+  compared against its opening value (`<> "All"`, the nothing-to-show-until-you-pick reveal,
+  which needs no control because clearing the selection resets it). **Never write that calc as
+  an LOD expression** — `{FIXED : …}` is view-independent too and Tableau accepts it, but it is
+  hard to reason about and hard to repair by hand. A row-level boolean is not a visibility
+  field at all: it splits the marks and the zone stops toggling. The Detail-shelf placement the
+  field needs, the parameter declarations and the format flags are all the builder's job.
+- **An image / button / legend object reserves its box, empty.** Each of those zone types needs
+  a reference the manifest does not carry (a filename, an action, a sheet + colour field), and
+  Tableau does not treat those as optional — so the layout keeps the geometry until the wiring
+  lands. `filter`, `parameter`, `text` and `blank` objects render fully today.
 
 > The full `STATE.md` schema and the ordering / staleness / versioning rules live in
 > `CONTRACT.md` at the repo root. This skill restates only its own slice; `build.py`,

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -16,9 +16,9 @@ a bad spec-to-manifest translation is fixed row-by-row before any XML is generat
 | `worksheets` | yes | One per layout zone that is a **view**: unique `name`, a known `chart_type`, the `element_id` it fills, its `datasource`, and shelves/encodings whose fields resolve. |
 | `layout` | yes | The spec's `## Layout` container tree, copied as-is (canvas + nested `vert`/`horz` + id leaves with `%` sizes). |
 | `actions` | yes (`[]` if none) | Dashboard actions; `type` from `filter`/`highlight`/`parameter`/`set`/`url`. `source` is always a zone; a target is a zone for `filter`/`highlight`, a declared parameter for `parameter` (see below). |
-| `parameters` | yes (`[]` if none) | Each needs a `name` and a `data_type`. |
-| `objects` | optional | Layout zones no view fills — a filter card, title text, a logo, a legend. `kind` from `filter`/`parameter`/`text`/`image`/`legend`/`button`/`blank`. `text` and `blank` render today; the rest reserve their box as an empty zone until the wiring they need lands. |
-| `calculated_fields` | optional | Fields that legitimately are not in the data model; declaring one makes it usable on a shelf of its `datasource`. |
+| `parameters` | yes (`[]` if none) | Each needs a `name`, a `data_type` (`string`/`integer`/`real`/`boolean`/`date`/`datetime`), and a `current_value`. Give it a domain — a `values` list **or** a `range` (`min`/`max`, optional `step`), never both — or it is a free-entry box. Optional `format`. |
+| `objects` | optional | Layout zones no view fills — a filter card, a parameter control, title text, a logo, a legend. `kind` from `filter`/`parameter`/`text`/`image`/`legend`/`button`/`blank`. `filter`, `parameter`, `text` and `blank` render today; `image`, `button` and `legend` reserve their box as an empty zone until the wiring they need lands. |
+| `calculated_fields` | optional | Fields that legitimately are not in the data model; declaring one makes it usable on a shelf of its `datasource`. Each takes a `name`, a `formula`, a `datasource`, an optional `type` (default `real`) and an optional `format`. |
 
 **Copy the `layout` tree from the spec verbatim** — `validate` diffs the two and rejects any
 zone the manifest drops or invents, so the workbook cannot disagree with the approved mock.
@@ -65,6 +65,11 @@ measure with none of them defaults to `SUM`. Date parts: `year`, `quarter`, `mon
 `day`, `date`. Never write an expression like `"SUM([revenue])"` — that is the spec's prose,
 not a field reference.
 
+A shelf entry may also carry `table_calc` — a quick table calculation over the aggregate:
+`{"field": "revenue", "aggregation": "sum", "table_calc": "CumTotal"}` for a running total.
+One of `CumTotal`, `WindowTotal`, `Difference`, `PctDiff`, `PctValue`, `PctTotal`, `Rank`,
+`PctRank`; it computes across the table (Tableau's "Table (across)" addressing).
+
 Encodings the builder emits: `color`, `size`, `shape`, `text`, `lod`, `wedge-size`,
 `geometry`, `tooltip`. Any other name is a validation error, not a silent drop.
 
@@ -77,6 +82,7 @@ Encodings the builder emits: `color`, `size`, `shape`, `text`, `lod`, `wedge-siz
 | `tooltip` | `[{"label": "Revenue", "field": "revenue", "aggregation": "sum"}]` | A custom tooltip template, one label/value pair per line. |
 | `axis_titles` | `{"rows": "Revenue per category"}` | Overrides the generated axis title. |
 | `number_formats` | `[{"field": "revenue", "format": "$#,##0"}]` | Cell number format for that field. |
+| `reference_lines` | `[{"field": "revenue", "aggregation": "sum", "formula": "average", "scope": "per-table", "label": "<Computation>: <Value>"}]` | A line drawn at an aggregate of the measure. `formula` from `constant`/`total`/`sum`/`min`/`max`/`average`/`median`/`quantiles`/`percentile`/`stdev`/`confidence`/`medianconfidence` (default `average`); `scope` from `per-cell`/`per-pane`/`per-table` (default `per-table`). A `label` string is used verbatim; without one, `label_type` from `none`/`automatic`/`value`/`computation`/`custom` (default `computation`). |
 | `title` | `"Revenue by region"` | Puts a styled text zone above the sheet's zone in the dashboard and suppresses the sheet's own title. Omit to keep Tableau's sheet title. |
 
 An `objects` entry of `kind: "text"` takes its content the same way: `{"element_id":
@@ -89,8 +95,73 @@ data model does not document is rejected, not silently dropped.
 and chart-title size/colour are applied to every worksheet; when it does not, Tableau's own
 defaults apply. Nothing in the manifest sets fonts or colours.
 
-**Action targets depend on the type**: `filter` / `highlight` target layout zones, a
-`parameter` action targets a declared parameter by name. The `source` is always a zone.
+## Interactions
+
+**Actions.** `source` is always a **view** zone (the sheet whose marks are clicked), and so is
+every `filter` / `highlight` target; a `parameter` action targets a declared **parameter** by
+name and needs a `field` — the field read off the clicked mark and written into the parameter.
+`run_on` is `select` (click a mark; the default) or `hover`. One Tableau action is emitted
+**per target**, so a source fanning out to three zones is three actions.
+
+```json
+{"name": "Trend cross-filter", "type": "filter", "source": "chart-trend",
+ "targets": ["chart-detail", "kpi-revenue"], "run_on": "select"}
+{"name": "Pick region", "type": "parameter", "source": "chart-trend",
+ "targets": ["Selected Region"], "field": "region"}
+```
+
+Clearing the selection **resets** a parameter action's parameter to its `current_value`, so
+whatever the parameter drives returns to its opening state. That is what makes a parameter
+action safe to use without a control: the viewer cannot get stuck in a state only a control
+could undo.
+
+`set` and `url` validate but render nothing yet.
+
+**A filter card** (`objects` entry, `kind: "filter"`) is the UI for **one** worksheet's filter,
+so it names both the `worksheet` and the `field`: `{"element_id": "flt-region", "kind":
+"filter", "field": "region", "worksheet": "Revenue Trend", "mode": "checkdropdown"}`. The card
+lists the field's members, so the field must be a `string` or `boolean` field of that
+worksheet's datasource — for a date or a numeric range use the worksheet's own `filters` with
+`min`/`max` instead. `mode` is `checkdropdown` (a dropdown of checkboxes; the default) or
+`typeinlist` (a search box over the list). "Apply to all sheets" is a Desktop-side choice, not
+a manifest key.
+
+**A parameter control** (`kind: "parameter"`) names one declared parameter:
+`{"element_id": "prm-topn", "kind": "parameter", "parameter": "Top N"}`. Reference the
+parameter from a calculated field's formula as `[Parameters].[Top N]` — every worksheet whose
+calculations read it declares it automatically.
+
+### Dynamic Zone Visibility
+
+**Show/hide a zone** with `visibility` on a **layout** node: `{"id": "chart-category",
+"visibility": "Show Breakdown"}`. The value must be the name of a declared **boolean**
+calculated field, and the zone is shown when it is true. For a zone with a generated header or
+legend, the whole wrapper is what shows and hides.
+
+**The one rule the calc must obey: it resolves to a single value, independent of the view.**
+Tableau reads *one* value per view, so a row-level boolean (`SUM([revenue]) > 1000`,
+`[region] = "East"`) is not a visibility field — it splits the marks and the zone stops
+toggling. In practice that means **the calc compares a parameter**, and which parameter shape
+you reach for depends on who decides:
+
+| the viewer decides, with a control | the viewer's *selection* decides |
+|---|---|
+| A two-value parameter and a control zone for it — the usual toggle. `boolean` (`true`/`false`) is the natural type; a `string` with `values: ["on", "off"]` works the same way and is the form this repo has round-tripped through Desktop. Calc: `[Parameters].[Show Detail] = true` / `= "on"`. | A parameter a **parameter action** writes into, compared against its opening value: `[Parameters].[Selected Region] <> "All"`. The panel appears once a region is picked and hides itself when the selection clears (the action resets the parameter). No control zone needed. |
+
+Both are ordinary DZV; pick by intent. A toggle is right for "let me collapse this"; a
+selection-driven reveal is right for "there is nothing to show until you pick something", and
+costs no dashboard real estate.
+
+**Do not write the visibility calc as an LOD expression.** A `{FIXED : …}` or `{MAX(…)}` also
+makes a field view-independent, and Tableau accepts it — but it is hard to reason about, hard
+to fix by hand in Desktop, and silently changes what "single value" means when a filter moves.
+A parameter comparison is the whole vocabulary needed here.
+
+Everything mechanical is the builder's job, not the manifest's: it puts the visibility field on
+the controlled sheet's Detail shelf (Tableau evaluates it off the *view* — the `<datagraph>`
+alone is not enough, and a workbook missing it opens fine and simply never toggles), declares
+the parameter on that sheet and on its datasource, and emits the four document-format flags.
+None of that is expressible in the manifest, and none of it needs to be.
 
 ## Example
 
@@ -110,7 +181,9 @@ defaults apply. Nothing in the manifest sets fonts or colours.
   ],
   "calculated_fields": [
     {"name": "Revenue per Order", "formula": "SUM([revenue]) / COUNTD([order_id])",
-     "datasource": "sales_orders", "type": "real"}
+     "datasource": "sales_orders", "type": "real", "format": "$#,##0"},
+    {"name": "Show Breakdown", "formula": "[Parameters].[Selected Region] <> \"All\"",
+     "datasource": "sales_orders", "type": "boolean"}
   ],
   "worksheets": [
     {
@@ -135,11 +208,26 @@ defaults apply. Nothing in the manifest sets fonts or colours.
       "filters": [{"field": "region", "values": ["West", "East"], "context": true}],
       "sort": {"field": "region", "direction": "DESC",
                "by": {"field": "revenue", "aggregation": "sum"}},
-      "number_formats": [{"field": "revenue", "format": "$#,##0"}]
+      "number_formats": [{"field": "revenue", "format": "$#,##0"}],
+      "reference_lines": [{"field": "revenue", "aggregation": "sum", "formula": "average",
+                           "scope": "per-table", "label": "<Computation>: <Value>"}]
+    },
+    {
+      "name": "Running Revenue",
+      "element_id": "chart-cumulative",
+      "chart_type": "area",
+      "datasource": "sales_orders",
+      "title": "Revenue to date",
+      "shelves": {
+        "columns": [{"field": "order_date", "date_part": "month"}],
+        "rows": [{"field": "revenue", "aggregation": "sum", "table_calc": "CumTotal"}]
+      }
     }
   ],
   "objects": [
-    {"element_id": "flt-region", "kind": "filter"}
+    {"element_id": "flt-region", "kind": "filter", "field": "region",
+     "worksheet": "Revenue Trend", "mode": "checkdropdown"},
+    {"element_id": "prm-topn", "kind": "parameter", "parameter": "Top N"}
   ],
   "layout": {
     "canvas": {"width": 1366, "height": 768},
@@ -147,15 +235,26 @@ defaults apply. Nothing in the manifest sets fonts or colours.
       "type": "vert",
       "children": [
         {"id": "flt-region", "size": 8},
-        {"id": "kpi-revenue", "size": 22},
-        {"id": "chart-trend", "size": 70}
+        {"id": "prm-topn", "size": 8},
+        {"id": "kpi-revenue", "size": 20},
+        {"id": "chart-trend", "size": 34},
+        {"id": "chart-cumulative", "size": 30, "visibility": "Show Breakdown"}
       ]
     }
   },
   "actions": [
     {"name": "Region cross-filter", "type": "filter", "source": "chart-trend",
-     "targets": ["kpi-revenue"], "run_on": "select"}
+     "targets": ["kpi-revenue"], "run_on": "select"},
+    {"name": "Region highlight", "type": "highlight", "source": "chart-trend",
+     "targets": ["chart-cumulative"], "run_on": "hover"},
+    {"name": "Pick region", "type": "parameter", "source": "chart-trend",
+     "targets": ["Selected Region"], "field": "region"}
   ],
-  "parameters": []
+  "parameters": [
+    {"name": "Selected Region", "data_type": "string", "current_value": "All",
+     "values": ["All", "East", "North", "West"]},
+    {"name": "Top N", "data_type": "integer", "current_value": 10,
+     "range": {"min": 5, "max": 50, "step": 5}, "format": "#,##0"}
+  ]
 }
 ```

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -113,9 +113,14 @@ name and needs a `field` — the field read off the clicked mark and written int
 Clearing the selection **resets** a parameter action's parameter to its `current_value`, so
 whatever the parameter drives returns to its opening state. That is what makes a parameter
 action safe to use without a control: the viewer cannot get stuck in a state only a control
-could undo.
+could undo. The reset is why **a parameter action's target must be a `string` parameter** —
+that is the only type whose reset value has an attested serialization, and a target that
+could not be reset is rejected rather than built without it. Give it a `values` domain
+(`["All", "West", "East"]`) and open it on the neutral member.
 
-`set` and `url` validate but render nothing yet.
+`set` and `url` actions are **rejected**: the builder emits nothing for them, and a dashboard
+that validated with one would open with the interaction silently missing. A `drill`
+(CONTRACT.md §6) is built as a `parameter` action.
 
 **A filter card** (`objects` entry, `kind: "filter"`) is the UI for **one** worksheet's filter,
 so it names both the `worksheet` and the `field`: `{"element_id": "flt-region", "kind":
@@ -146,7 +151,7 @@ you reach for depends on who decides:
 
 | the viewer decides, with a control | the viewer's *selection* decides |
 |---|---|
-| A two-value parameter and a control zone for it — the usual toggle. `boolean` (`true`/`false`) is the natural type; a `string` with `values: ["on", "off"]` works the same way and is the form this repo has round-tripped through Desktop. Calc: `[Parameters].[Show Detail] = true` / `= "on"`. | A parameter a **parameter action** writes into, compared against its opening value: `[Parameters].[Selected Region] <> "All"`. The panel appears once a region is picked and hides itself when the selection clears (the action resets the parameter). No control zone needed. |
+| A two-value parameter and a control zone for it — the usual toggle. `boolean` (`true`/`false`) is the natural type; a `string` with `values: ["on", "off"]` works the same way and is the form this repo has round-tripped through Desktop. Calc: `[Parameters].[Show Detail] = true` / `= "on"`. | A `string` parameter a **parameter action** writes into, compared against its opening value: `[Parameters].[Selected Region] <> "All"`. The panel appears once a region is picked and hides itself when the selection clears (the action resets the parameter). No control zone needed. |
 
 Both are ordinary DZV; pick by intent. A toggle is right for "let me collapse this"; a
 selection-driven reveal is right for "there is nothing to show until you pick something", and

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -18,7 +18,7 @@ a bad spec-to-manifest translation is fixed row-by-row before any XML is generat
 | `actions` | yes (`[]` if none) | Dashboard actions; `type` from `filter`/`highlight`/`parameter`/`set`/`url`. `source` is always a zone; a target is a zone for `filter`/`highlight`, a declared parameter for `parameter` (see below). |
 | `parameters` | yes (`[]` if none) | Each needs a `name`, a `data_type` (`string`/`integer`/`real`/`boolean`/`date`/`datetime`), and a `current_value`. Give it a domain — a `values` list **or** a `range` (`min`/`max`, optional `step`), never both — or it is a free-entry box. Optional `format`. |
 | `objects` | optional | Layout zones no view fills — a filter card, a parameter control, title text, a logo, a legend. `kind` from `filter`/`parameter`/`text`/`image`/`legend`/`button`/`blank`. `filter`, `parameter`, `text` and `blank` render today; `image`, `button` and `legend` reserve their box as an empty zone until the wiring they need lands. |
-| `calculated_fields` | optional | Fields that legitimately are not in the data model; declaring one makes it usable on a shelf of its `datasource`. Each takes a `name`, a `formula`, a `datasource`, an optional `type` (default `real`) and an optional `format`. |
+| `calculated_fields` | optional | Fields that legitimately are not in the data model; declaring one makes it usable on a shelf of its `datasource`. Each takes a `name`, a `formula`, a `datasource`, an optional `type` (default `real`) and an optional `format`. Any Tableau formula, **LOD expressions included** (`{FIXED [region]: SUM([revenue])}`) — an LOD is row-level, so it is re-aggregated when placed on a shelf, while a formula that already aggregates is not. |
 
 **Copy the `layout` tree from the spec verbatim** — `validate` diffs the two and rejects any
 zone the manifest drops or invents, so the workbook cannot disagree with the approved mock.
@@ -156,6 +156,10 @@ costs no dashboard real estate.
 makes a field view-independent, and Tableau accepts it — but it is hard to reason about, hard
 to fix by hand in Desktop, and silently changes what "single value" means when a filter moves.
 A parameter comparison is the whole vocabulary needed here.
+
+This restriction is **specific to visibility calcs**. LOD expressions are otherwise a normal,
+supported part of a manifest — declare one as any other `calculated_fields` entry and place it
+on a shelf like any measure.
 
 Everything mechanical is the builder's job, not the manifest's: it puts the visibility field on
 the controlled sheet's Detail shelf (Tableau evaluates it off the *view* — the `<datagraph>`

--- a/skills/tableau-build/references/snippets/dashboard/parameter-action.twb
+++ b/skills/tableau-build/references/snippets/dashboard/parameter-action.twb
@@ -1,0 +1,857 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<workbook original-version='18.1' source-build='2025.1.10 (20251.25.1121.1650)' source-platform='win' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <document-format-change-manifest>
+    <AccessibleZoneTabOrder />
+    <AnimationOnByDefault />
+    <AutoCreateAndUpdateDSDPhoneLayouts />
+    <MarkAnimation />
+    <ObjectModelEncapsulateLegacy />
+    <ObjectModelExtractV2 />
+    <ObjectModelTableType />
+    <ParameterAction />
+    <ParameterActionClearSelection />
+    <SchemaViewerObjectModel />
+    <SetMembershipControl />
+    <SheetIdentifierTracking />
+    <_.fcp.VConnDownstreamExtractsWithWarnings.true...VConnDownstreamExtractsWithWarnings />
+    <WindowsPersistSimpleIdentifiers />
+    <ZoneBackgroundTransparency />
+  </document-format-change-manifest>
+  <preferences>
+    <preference name='ui.encoding.shelf.height' value='24' />
+    <preference name='ui.shelf.height' value='26' />
+  </preferences>
+  <datasources>
+    <datasource caption='sales_orders' inline='true' name='federated.1hckotw0bte0i51b8k3sd1ffpnqc' version='18.1'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
+            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+          </named-connection>
+        </named-connections>
+        <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
+          <columns character-set='UTF-8' header='yes' locale='en_US' separator=','>
+            <column datatype='string' name='order_id' ordinal='0' />
+            <column datatype='date' name='order_date' ordinal='1' />
+            <column datatype='string' name='customer_name' ordinal='2' />
+            <column datatype='string' name='region' ordinal='3' />
+            <column datatype='string' name='country' ordinal='4' />
+            <column datatype='string' name='product_category' ordinal='5' />
+            <column datatype='string' name='product_name' ordinal='6' />
+            <column datatype='integer' name='quantity' ordinal='7' />
+            <column datatype='real' name='unit_price' ordinal='8' />
+            <column datatype='real' name='discount' ordinal='9' />
+            <column datatype='real' name='revenue' ordinal='10' />
+            <column datatype='real' name='cost' ordinal='11' />
+            <column datatype='real' name='profit' ordinal='12' />
+          </columns>
+        </relation>
+        <metadata-records>
+          <metadata-record class='capability'>
+            <remote-name />
+            <remote-type>0</remote-type>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias />
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='string' name='character-set'>&quot;UTF-8&quot;</attribute>
+              <attribute datatype='string' name='collation'>&quot;en_US&quot;</attribute>
+              <attribute datatype='string' name='field-delimiter'>&quot;,&quot;</attribute>
+              <attribute datatype='string' name='header-row'>&quot;true&quot;</attribute>
+              <attribute datatype='string' name='locale'>&quot;en_US&quot;</attribute>
+              <attribute datatype='string' name='single-char'>&quot;&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>order_id</remote-name>
+            <remote-type>129</remote-type>
+            <local-name>[order_id]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>order_id</remote-alias>
+            <ordinal>0</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <scale>1</scale>
+            <width>1073741823</width>
+            <contains-null>true</contains-null>
+            <collation flag='0' name='LEN_RUS' />
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>order_date</remote-name>
+            <remote-type>133</remote-type>
+            <local-name>[order_date]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>order_date</remote-alias>
+            <ordinal>1</ordinal>
+            <local-type>date</local-type>
+            <aggregation>Year</aggregation>
+            <contains-null>true</contains-null>
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>customer_name</remote-name>
+            <remote-type>129</remote-type>
+            <local-name>[customer_name]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>customer_name</remote-alias>
+            <ordinal>2</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <scale>1</scale>
+            <width>1073741823</width>
+            <contains-null>true</contains-null>
+            <collation flag='0' name='LEN_RUS' />
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>region</remote-name>
+            <remote-type>129</remote-type>
+            <local-name>[region]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>region</remote-alias>
+            <ordinal>3</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <scale>1</scale>
+            <width>1073741823</width>
+            <contains-null>true</contains-null>
+            <collation flag='0' name='LEN_RUS' />
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>country</remote-name>
+            <remote-type>129</remote-type>
+            <local-name>[country]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>country</remote-alias>
+            <ordinal>4</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <scale>1</scale>
+            <width>1073741823</width>
+            <contains-null>true</contains-null>
+            <collation flag='0' name='LEN_RUS' />
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>product_category</remote-name>
+            <remote-type>129</remote-type>
+            <local-name>[product_category]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>product_category</remote-alias>
+            <ordinal>5</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <scale>1</scale>
+            <width>1073741823</width>
+            <contains-null>true</contains-null>
+            <collation flag='0' name='LEN_RUS' />
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>product_name</remote-name>
+            <remote-type>129</remote-type>
+            <local-name>[product_name]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>product_name</remote-alias>
+            <ordinal>6</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <scale>1</scale>
+            <width>1073741823</width>
+            <contains-null>true</contains-null>
+            <collation flag='0' name='LEN_RUS' />
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>quantity</remote-name>
+            <remote-type>20</remote-type>
+            <local-name>[quantity]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>quantity</remote-alias>
+            <ordinal>7</ordinal>
+            <local-type>integer</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>unit_price</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[unit_price]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>unit_price</remote-alias>
+            <ordinal>8</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>discount</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[discount]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>discount</remote-alias>
+            <ordinal>9</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>revenue</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[revenue]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>revenue</remote-alias>
+            <ordinal>10</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>cost</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[cost]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>cost</remote-alias>
+            <ordinal>11</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>profit</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[profit]</local-name>
+            <parent-name>[sales_orders.csv]</parent-name>
+            <remote-alias>profit</remote-alias>
+            <ordinal>12</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+          </metadata-record>
+        </metadata-records>
+      </connection>
+      <aliases enabled='yes' />
+      <column caption='LineChart' datatype='string' name='[Calculation_2562266762300547077]' role='dimension' type='nominal'>
+        <calculation class='tableau' formula='&quot;LineChart&quot;' />
+      </column>
+      <column caption='barChart' datatype='string' name='[LineChart (copy)_2562266762300608518]' role='dimension' type='nominal'>
+        <calculation class='tableau' formula='&quot;BarChart&quot;' />
+      </column>
+      <column caption='sales_orders.csv' datatype='table' name='[__tableau_internal_object_id__].[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]' role='measure' type='quantitative' />
+      <column caption='Cost' datatype='real' name='[cost]' role='measure' type='quantitative' />
+      <column caption='Country' datatype='string' name='[country]' role='dimension' semantic-role='[Country].[ISO3166_2]' type='nominal' />
+      <column caption='Customer Name' datatype='string' name='[customer_name]' role='dimension' type='nominal' />
+      <column caption='Discount' datatype='real' name='[discount]' role='measure' type='quantitative' />
+      <column caption='Order Date' datatype='date' name='[order_date]' role='dimension' type='ordinal' />
+      <column caption='Order Id' datatype='string' name='[order_id]' role='dimension' type='nominal' />
+      <column caption='Product Category' datatype='string' name='[product_category]' role='dimension' type='nominal' />
+      <column caption='Product Name' datatype='string' name='[product_name]' role='dimension' type='nominal' />
+      <column caption='Profit' datatype='real' name='[profit]' role='measure' type='quantitative' />
+      <column caption='Quantity' datatype='integer' name='[quantity]' role='measure' type='quantitative' />
+      <column caption='Region' datatype='string' name='[region]' role='dimension' type='nominal' />
+      <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
+      <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
+      <group caption='Action (Product Category)' hidden='true' name='[Action (Product Category)]' name-style='unqualified' user:auto-column='sheet_link'>
+        <groupfilter function='crossjoin'>
+          <groupfilter function='level-members' level='[product_category]' />
+        </groupfilter>
+      </group>
+      <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+          <relation name='Extract' table='[Extract].[Extract]' type='table' />
+          <refresh>
+            <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />
+          </refresh>
+          <metadata-records>
+            <metadata-record class='column'>
+              <remote-name>order_id</remote-name>
+              <remote-type>129</remote-type>
+              <local-name>[order_id]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>order_id</remote-alias>
+              <ordinal>0</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>string</local-type>
+              <aggregation>Count</aggregation>
+              <approx-count>40</approx-count>
+              <contains-null>true</contains-null>
+              <collation flag='0' name='LEN_RUS' />
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+            <metadata-record class='column'>
+              <remote-name>order_date</remote-name>
+              <remote-type>133</remote-type>
+              <local-name>[order_date]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>order_date</remote-alias>
+              <ordinal>1</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>date</local-type>
+              <aggregation>Year</aggregation>
+              <approx-count>40</approx-count>
+              <contains-null>true</contains-null>
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+            <metadata-record class='column'>
+              <remote-name>customer_name</remote-name>
+              <remote-type>129</remote-type>
+              <local-name>[customer_name]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>customer_name</remote-alias>
+              <ordinal>2</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>string</local-type>
+              <aggregation>Count</aggregation>
+              <approx-count>7</approx-count>
+              <contains-null>true</contains-null>
+              <collation flag='0' name='LEN_RUS' />
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+            <metadata-record class='column'>
+              <remote-name>region</remote-name>
+              <remote-type>129</remote-type>
+              <local-name>[region]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>region</remote-alias>
+              <ordinal>3</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>string</local-type>
+              <aggregation>Count</aggregation>
+              <approx-count>3</approx-count>
+              <contains-null>true</contains-null>
+              <collation flag='0' name='LEN_RUS' />
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+            <metadata-record class='column'>
+              <remote-name>country</remote-name>
+              <remote-type>129</remote-type>
+              <local-name>[country]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>country</remote-alias>
+              <ordinal>4</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>string</local-type>
+              <aggregation>Count</aggregation>
+              <approx-count>7</approx-count>
+              <contains-null>true</contains-null>
+              <collation flag='0' name='LEN_RUS' />
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+            <metadata-record class='column'>
+              <remote-name>product_category</remote-name>
+              <remote-type>129</remote-type>
+              <local-name>[product_category]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>product_category</remote-alias>
+              <ordinal>5</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>string</local-type>
+              <aggregation>Count</aggregation>
+              <approx-count>3</approx-count>
+              <contains-null>true</contains-null>
+              <collation flag='0' name='LEN_RUS' />
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+            <metadata-record class='column'>
+              <remote-name>product_name</remote-name>
+              <remote-type>129</remote-type>
+              <local-name>[product_name]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>product_name</remote-alias>
+              <ordinal>6</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>string</local-type>
+              <aggregation>Count</aggregation>
+              <approx-count>13</approx-count>
+              <contains-null>true</contains-null>
+              <collation flag='0' name='LEN_RUS' />
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+            <metadata-record class='column'>
+              <remote-name>quantity</remote-name>
+              <remote-type>20</remote-type>
+              <local-name>[quantity]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>quantity</remote-alias>
+              <ordinal>7</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>integer</local-type>
+              <aggregation>Sum</aggregation>
+              <approx-count>22</approx-count>
+              <contains-null>true</contains-null>
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+            <metadata-record class='column'>
+              <remote-name>unit_price</remote-name>
+              <remote-type>5</remote-type>
+              <local-name>[unit_price]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>unit_price</remote-alias>
+              <ordinal>8</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>real</local-type>
+              <aggregation>Sum</aggregation>
+              <approx-count>12</approx-count>
+              <contains-null>true</contains-null>
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+            <metadata-record class='column'>
+              <remote-name>discount</remote-name>
+              <remote-type>5</remote-type>
+              <local-name>[discount]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>discount</remote-alias>
+              <ordinal>9</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>real</local-type>
+              <aggregation>Sum</aggregation>
+              <approx-count>5</approx-count>
+              <contains-null>true</contains-null>
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+            <metadata-record class='column'>
+              <remote-name>revenue</remote-name>
+              <remote-type>5</remote-type>
+              <local-name>[revenue]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>revenue</remote-alias>
+              <ordinal>10</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>real</local-type>
+              <aggregation>Sum</aggregation>
+              <approx-count>39</approx-count>
+              <contains-null>true</contains-null>
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+            <metadata-record class='column'>
+              <remote-name>cost</remote-name>
+              <remote-type>5</remote-type>
+              <local-name>[cost]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>cost</remote-alias>
+              <ordinal>11</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>real</local-type>
+              <aggregation>Sum</aggregation>
+              <approx-count>27</approx-count>
+              <contains-null>true</contains-null>
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+            <metadata-record class='column'>
+              <remote-name>profit</remote-name>
+              <remote-type>5</remote-type>
+              <local-name>[profit]</local-name>
+              <parent-name>[Extract]</parent-name>
+              <remote-alias>profit</remote-alias>
+              <ordinal>12</ordinal>
+              <family>sales_orders.csv</family>
+              <local-type>real</local-type>
+              <aggregation>Sum</aggregation>
+              <approx-count>40</approx-count>
+              <contains-null>true</contains-null>
+              <object-id>[sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0]</object-id>
+            </metadata-record>
+          </metadata-records>
+        </connection>
+      </extract>
+      <layout dim-ordering='alphabetic' measure-ordering='alphabetic' show-structure='true' />
+      <semantic-values>
+        <semantic-value key='[Country].[Name]' value='&quot;Israel&quot;' />
+      </semantic-values>
+      <object-graph>
+        <objects>
+          <object caption='sales_orders.csv' id='sales_orders.csv_09EB5EA8C4E1488681646EA8C7C1C3B0'>
+            <properties context=''>
+              <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
+                <columns character-set='UTF-8' header='yes' locale='en_US' separator=','>
+                  <column datatype='string' name='order_id' ordinal='0' />
+                  <column datatype='date' name='order_date' ordinal='1' />
+                  <column datatype='string' name='customer_name' ordinal='2' />
+                  <column datatype='string' name='region' ordinal='3' />
+                  <column datatype='string' name='country' ordinal='4' />
+                  <column datatype='string' name='product_category' ordinal='5' />
+                  <column datatype='string' name='product_name' ordinal='6' />
+                  <column datatype='integer' name='quantity' ordinal='7' />
+                  <column datatype='real' name='unit_price' ordinal='8' />
+                  <column datatype='real' name='discount' ordinal='9' />
+                  <column datatype='real' name='revenue' ordinal='10' />
+                  <column datatype='real' name='cost' ordinal='11' />
+                  <column datatype='real' name='profit' ordinal='12' />
+                </columns>
+              </relation>
+            </properties>
+            <properties context='extract'>
+              <relation name='Extract' table='[Extract].[Extract]' type='table' />
+            </properties>
+          </object>
+        </objects>
+      </object-graph>
+    </datasource>
+    <datasource hasconnection='false' inline='true' name='Parameters' version='18.1'>
+      <aliases enabled='yes' />
+      <column caption='chart-type-parameter' datatype='string' datatype-customized='true' name='[Parameter 1]' param-domain-type='list' role='measure' type='nominal' value='&quot;BarChart&quot;'>
+        <calculation class='tableau' formula='&quot;BarChart&quot;' />
+        <members>
+          <member value='&quot;BarChart&quot;' />
+          <member value='&quot;LineChart&quot;' />
+        </members>
+      </column>
+    </datasource>
+  </datasources>
+  <actions>
+    <edit-parameter-action caption='change-parameter-action-example-1' name='[Action1_8FEEB8D6A773474C87A597541E6B4262]'>
+      <activation type='on-select' />
+      <source dashboard='Dashboard 4' type='sheet' worksheet='barChart header' />
+      <agg-type type='attr' />
+      <clear-option type='do-nothing' value='s:LROOT:' />
+      <params>
+        <param name='source-field' value='[federated.1hckotw0bte0i51b8k3sd1ffpnqc].[none:Calculation_2562266762300362755:nk]' />
+        <param name='target-parameter' value='[Parameters].[Parameter 1]' />
+      </params>
+    </edit-parameter-action>
+  </actions>
+  <worksheets>
+    <worksheet name='barChart header'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='sales_orders' name='federated.1hckotw0bte0i51b8k3sd1ffpnqc' />
+          </datasources>
+          <datasource-dependencies datasource='federated.1hckotw0bte0i51b8k3sd1ffpnqc'>
+            <column caption='&quot;BarChart&quot;' datatype='string' name='[Calculation_2562266762300362755]' role='dimension' type='nominal' user:unnamed='Sheet 3'>
+              <calculation class='tableau' formula='&quot;BarChart&quot;' />
+            </column>
+            <column-instance column='[Calculation_2562266762300362755]' derivation='None' name='[none:Calculation_2562266762300362755:nk]' pivot='key' type='nominal' />
+          </datasource-dependencies>
+          <aggregation value='true' />
+        </view>
+        <style />
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <text column='[federated.1hckotw0bte0i51b8k3sd1ffpnqc].[none:Calculation_2562266762300362755:nk]' />
+            </encodings>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='true' />
+                <format attr='mark-labels-cull' value='true' />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows />
+        <cols />
+      </table>
+      <simple-id uuid='{06DA3D58-7E50-4934-8680-F8AAA2108848}' />
+    </worksheet>
+    <worksheet name='lineChart header'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='sales_orders' name='federated.1hckotw0bte0i51b8k3sd1ffpnqc' />
+          </datasources>
+          <datasource-dependencies datasource='federated.1hckotw0bte0i51b8k3sd1ffpnqc'>
+            <column caption='LineChart' datatype='string' name='[Calculation_2562266762300547077]' role='dimension' type='nominal'>
+              <calculation class='tableau' formula='&quot;LineChart&quot;' />
+            </column>
+            <column-instance column='[Calculation_2562266762300547077]' derivation='None' name='[none:Calculation_2562266762300547077:nk]' pivot='key' type='nominal' />
+          </datasource-dependencies>
+          <aggregation value='true' />
+        </view>
+        <style />
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <text column='[federated.1hckotw0bte0i51b8k3sd1ffpnqc].[none:Calculation_2562266762300547077:nk]' />
+            </encodings>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='true' />
+                <format attr='mark-labels-cull' value='true' />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows />
+        <cols />
+      </table>
+      <simple-id uuid='{69EC519C-27A1-4DB9-B913-6EFF955AF584}' />
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard enable-sort-zone-taborder='true' name='Dashboard 4'>
+      <style />
+      <size sizing-mode='automatic' />
+      <datasources>
+        <datasource name='Parameters' />
+      </datasources>
+      <datasource-dependencies datasource='Parameters'>
+        <column caption='chart-type-parameter' datatype='string' datatype-customized='true' name='[Parameter 1]' param-domain-type='list' role='measure' type='nominal' value='&quot;BarChart&quot;'>
+          <calculation class='tableau' formula='&quot;BarChart&quot;' />
+          <members>
+            <member value='&quot;BarChart&quot;' />
+            <member value='&quot;LineChart&quot;' />
+          </members>
+        </column>
+      </datasource-dependencies>
+      <zones>
+        <zone h='100000' id='2' type-v2='layout-basic' w='100000' x='0' y='0'>
+          <zone h='97704' id='24' param='horz' type-v2='layout-flow' w='98698' x='651' y='1148'>
+            <zone h='97704' id='15' param='horz' type-v2='layout-flow' w='98698' x='651' y='1148'>
+              <zone h='97704' id='1' param='vert' type-v2='layout-flow' w='98698' x='651' y='1148'>
+                <zone h='97704' id='5' param='horz' type-v2='layout-flow' w='98698' x='651' y='1148'>
+                  <zone fixed-size='432' h='97704' id='8' is-fixed='true' param='vert' type-v2='layout-flow' w='98698' x='651' y='1148'>
+                    <zone h='90243' id='20' param='horz' type-v2='layout-flow' w='98698' x='651' y='1148'>
+                      <zone fixed-size='92' h='90243' id='21' is-fixed='true' name='barChart header' show-title='false' w='8137' x='651' y='1148'>
+                        <layout-cache type-h='cell' type-w='fixed' />
+                        <zone-style>
+                          <format attr='border-color' value='#000000' />
+                          <format attr='border-style' value='none' />
+                          <format attr='border-width' value='0' />
+                          <format attr='margin' value='4' />
+                        </zone-style>
+                      </zone>
+                      <zone fixed-size='92' h='90243' id='22' is-fixed='true' name='lineChart header' show-title='false' w='8137' x='8788' y='1148'>
+                        <layout-cache type-h='cell' type-w='cell' />
+                        <zone-style>
+                          <format attr='border-color' value='#000000' />
+                          <format attr='border-style' value='none' />
+                          <format attr='border-width' value='0' />
+                          <format attr='margin' value='4' />
+                        </zone-style>
+                      </zone>
+                    </zone>
+                    <zone h='7461' id='25' mode='compact' param='[Parameters].[Parameter 1]' type-v2='paramctrl' w='98698' x='651' y='91391'>
+                      <zone-style>
+                        <format attr='border-color' value='#000000' />
+                        <format attr='border-style' value='none' />
+                        <format attr='border-width' value='0' />
+                        <format attr='margin' value='4' />
+                      </zone-style>
+                    </zone>
+                  </zone>
+                </zone>
+              </zone>
+            </zone>
+          </zone>
+          <zone-style>
+            <format attr='border-color' value='#000000' />
+            <format attr='border-style' value='none' />
+            <format attr='border-width' value='0' />
+            <format attr='margin' value='8' />
+          </zone-style>
+        </zone>
+      </zones>
+      <devicelayouts>
+        <devicelayout auto-generated='true' name='Phone'>
+          <size maxheight='700' minheight='700' sizing-mode='vscroll' />
+          <zones>
+            <zone h='100000' id='27' type-v2='layout-basic' w='100000' x='0' y='0'>
+              <zone h='97704' id='26' param='vert' type-v2='layout-flow' w='98698' x='651' y='1148'>
+                <zone fixed-size='280' h='90243' id='21' is-fixed='true' name='barChart header' show-title='false' w='8137' x='651' y='1148'>
+                  <layout-cache cell-count-h='1' type-h='cell' type-w='fixed' />
+                  <zone-style>
+                    <format attr='border-color' value='#000000' />
+                    <format attr='border-style' value='none' />
+                    <format attr='border-width' value='0' />
+                    <format attr='margin' value='4' />
+                    <format attr='padding' value='0' />
+                  </zone-style>
+                </zone>
+                <zone fixed-size='280' h='90243' id='22' is-fixed='true' name='lineChart header' show-title='false' w='8137' x='8788' y='1148'>
+                  <layout-cache cell-count-h='1' type-h='cell' type-w='cell' />
+                  <zone-style>
+                    <format attr='border-color' value='#000000' />
+                    <format attr='border-style' value='none' />
+                    <format attr='border-width' value='0' />
+                    <format attr='margin' value='4' />
+                    <format attr='padding' value='0' />
+                  </zone-style>
+                </zone>
+                <zone h='7461' id='25' mode='compact' param='[Parameters].[Parameter 1]' type-v2='paramctrl' w='98698' x='651' y='91391'>
+                  <zone-style>
+                    <format attr='border-color' value='#000000' />
+                    <format attr='border-style' value='none' />
+                    <format attr='border-width' value='0' />
+                    <format attr='margin' value='4' />
+                    <format attr='padding' value='0' />
+                  </zone-style>
+                </zone>
+              </zone>
+              <zone-style>
+                <format attr='border-color' value='#000000' />
+                <format attr='border-style' value='none' />
+                <format attr='border-width' value='0' />
+                <format attr='margin' value='8' />
+              </zone-style>
+            </zone>
+          </zones>
+        </devicelayout>
+      </devicelayouts>
+      <simple-id uuid='{FCB12ED5-FD7F-4C05-BB4F-7858A12ADFF8}' />
+    </dashboard>
+  </dashboards>
+  <windows source-height='30'>
+    <window class='dashboard' maximized='true' name='Dashboard 4'>
+      <viewpoints>
+        <viewpoint name='barChart header'>
+          <zoom type='entire-view' />
+        </viewpoint>
+        <viewpoint name='lineChart header'>
+          <zoom type='entire-view' />
+        </viewpoint>
+      </viewpoints>
+      <active id='21' />
+      <simple-id uuid='{374C5FD3-962B-46F8-8F3E-CF0ECEB89012}' />
+    </window>
+    <window class='worksheet' name='barChart header'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+          <strip size='31'>
+            <card type='title' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[federated.1hckotw0bte0i51b8k3sd1ffpnqc].[none:Calculation_2562266762300350466:qk]</field>
+            <field>[federated.1hckotw0bte0i51b8k3sd1ffpnqc].[none:Calculation_2562266762300362755:nk]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+      <simple-id uuid='{573141D5-C2BC-41F8-851F-6319303970A9}' />
+    </window>
+    <window class='worksheet' name='lineChart header'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+          <strip size='31'>
+            <card type='title' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[federated.1hckotw0bte0i51b8k3sd1ffpnqc].[none:Calculation_2562266762300350466:qk]</field>
+            <field>[federated.1hckotw0bte0i51b8k3sd1ffpnqc].[none:Calculation_2562266762300362755:nk]</field>
+            <field>[federated.1hckotw0bte0i51b8k3sd1ffpnqc].[none:Calculation_2562266762300489732:nk]</field>
+            <field>[federated.1hckotw0bte0i51b8k3sd1ffpnqc].[none:Calculation_2562266762300547077:nk]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+      <simple-id uuid='{E43028E7-B3CF-4296-996D-455A19A57E8D}' />
+    </window>
+  </windows>
+  <thumbnails>
+    <thumbnail height='192' name='Dashboard 4' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7DAAAOwwHHb6hk
+      AAAGLUlEQVR4nO3a3U9b9x3H8c/xs4OJMQwGeCVSyug0SFctUta1W3eV3U3T/tZd9WZTLzZF
+      IkvSLk2Ek4hCXQwG82COn8/DrlYltXrRBQ1Vn/fr7hxZ9vf8pLd/+lkO0jRNBZjKXPcAwHUi
+      AFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgj
+      AFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgj
+      AFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgj
+      AFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgj
+      AFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFgjAFibCmA8HqvVaimO4zfu93o9
+      dbtdTSaTKx3g+94vSRIdHx9rNBpd6ecBrwvSNE1fv/Hy5UtdXFyoUqmo1+tpfX1dnU5HR0dH
+      Wltb087OjjY3N9VqtXT79m21Wi29ePFC9+/fV6FQ+MEDNBoNraysKAxDHR4ean19XXt7e8pm
+      s8rn8+p2uyoWi6rVapKk0WikRqOhra0t1ev1q1kF2JraAaIoUqPRUBiG6vf7evDggWZmZhTH
+      sSaTiRYXF9VqtXR+fq5nz56pXq+rWq0qCIL/aYB2u61ms6mDgwNVq1Vtb2+r1+tpOBxqOBwq
+      CAIVCgU1m01FUaROp6PV1VUVi8W3fnhgageIokhhGKpSqWgwGKhYLCqfz2s8HitJEhUKBaVp
+      qsFgoFKppHw+r16vp3K5rEzmhx8pwjD89ts+k8koSRL1+/1vd6ByuawgCDSZTBQEgXK5nJIk
+      URzHKpVKV7YQ8DQVAOCEX4FgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBg
+      jQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBg
+      jQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBg
+      jQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBg
+      jQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBgjQBg
+      bTqANFUUx9cwCvD/l3v9Yjy41NcHbT398kt9+PEnGpy1VVtaUXh5oc8fP9bd336iYnSqfz49
+      0Ie/3lQuI52fnqg891MNz49UW76lcj7R7qtdLf1sTa3mvlZXlnXZmygZd1WsLqrfOVSkrG4u
+      LKnXOVQpGOjh14nubSwoU64qCru6ubSsG4Xc980MXJkgTdP0vxf/+Oxveu/Or/Tw0RfKJkON
+      +n3FSaTxjXc0l+nq7gfv6+ikraOzVNlRW5lSVZf9geKLQx11R1rfeE/zs1mdXga6aO9qMOgr
+      H+S1eOf3Gu490tk4o7mCFOeqGl/s6qif092NZbVz7+jk6Weq/+KXOmud6s9/+ZOymeA61wUm
+      3gjgrN3UfjvUwvyc0mio4/aJqrWbKs4uKTfsKCrWtPqTip78+7mGx/taufORHvz9U9376A/q
+      tptaurWhWiHUXz/d1se/+40Ovmlq4WZV82vrau48UWF2XpViTsoUlcQDHbZaWnv35/pmv6Vy
+      IVKusqAb+bzq9ZXrXBMYeSMAwM3UIfjZ59tq7Db1ehXRqK/Hjx6pc36p5DuvT5NYcUJD+HGa
+      OmmeHB8rN8qplITqpWUlvWOFo0Bb72/pq+dP9XyY6t1bizo8HapWjNU+ONB5eVl/vLd1HfMD
+      b2VqByjPzCqZjPTq5Y7+9eQLZUtVrdRuaH9/T9nSnG4vzunFV6/0cPuxwjirDzY3ND9XvY7Z
+      gbc2dQY4Pz1WkJ9RThMlmYJKxbxymUCnp2earc4pq1TjyUijSJopl5TPBTq7CFUjAvwIcQiG
+      Nf4KAWsEAGsEAGsEAGsEAGv/ASNZ0xP5EPsFAAAAAElFTkSuQmCC
+    </thumbnail>
+    <thumbnail height='24' name='barChart header' width='64'>
+      iVBORw0KGgoAAAANSUhEUgAAAEAAAAAYCAYAAABKtPtEAAAACXBIWXMAAA7DAAAOwwHHb6hk
+      AAACu0lEQVRYhe2YwSs0cRzGP7bV1JpoNWYLadtECacxTclFcpCSpORgj27OXCjJUnZLOUoS
+      e6Nc9oLyByDtbm2Wg+S0G7tNVmYx+x7e2t432Zfxag72c5tfv+/zPD39vpepKBQKBX4wDrsD
+      2E25ALsD2E25ALsD2E25ALsD2E25ALsD2E25ALsD2E25ALsD2I2lAqanp1EUBUVRUFWV8fFx
+      EomE5RD5fJ719XV6e3tRVRW/308ulyMUCpHL5SzrfgSnlSFZlolEIsiyjGmaHB8fs7GxwcLC
+      AoIgfFpva2uLZDLJ7u4uNTU1xONxK7FKsrOzQ0dHB52dnX+df3kFHA4HXV1deDweXl5ePj2f
+      Tqe5urpiZmYGt9uNw+F4E/I7sfQC/kTXdTY3N5EkiaqqKgzDYHV1lf39fQzDoKmpifn5edrb
+      24lGo8RiMerr61lcXGR0dBRVVfF6vbjd7jfaj4+PrKyscHR0xNPTE2NjY0xNTfH6+vquRyqV
+      Ynt7m/7+fmZnZ/H5fNzd3RGLxYq6fX19LC0t/Z8CBEHA5/NxdnZGPp+nsrISr9dLdXU16XSa
+      m5sbgsEga2trAFxcXDA8PMzBwQEA5+fn72q7XC4mJyeZm5sDIBQKcX9/jyRJJT1ub2+RZZm9
+      vb2i1retgCAIDA4OIooi2WyWRCJBPB4nHA5zcnJCJBLB4/EU77e2tuJyuYrfDQ0NXF9fk8lk
+      Puz5L4/GxkZkWf6Q1pcLME2T09NTLi8vcTqdPD8/I0kSoiii6zqHh4fouv7ufF1dHc3NzQQC
+      ATKZDKZpEo1GS3p+1gN+r1MymcQ0TQzDKJ5bKiCVSjEwMICiKGiaRiAQwO/3U1tbS1tbG9ls
+      lu7ubkZGRnh4eEAUxZJ6ExMTtLS0MDQ0hKZpBIPBkvetePT09BAOh9E0jeXl5eJ5Rfmv8A/n
+      F9DAKchoqvNbAAAAAElFTkSuQmCC
+    </thumbnail>
+    <thumbnail height='24' name='lineChart header' width='64'>
+      iVBORw0KGgoAAAANSUhEUgAAAEAAAAAYCAYAAABKtPtEAAAACXBIWXMAAA7DAAAOwwHHb6hk
+      AAACVklEQVRYhe2YT0sqURiHHyeJCKJNggatE/qzGsYkcFOQumgpuEj6ANUqRAJXorRyodBi
+      QBeFX6CFZPgBJMHF1CJw09pwJc5CmDMtLgx0r7frrbn3LJpn+875zcOPdzgwPtu2bb4ximwB
+      2XgFyBaQjVeAbAHZeAXIFpCNV4BsAdl4BcgWkI1XgGwB2XyqgHK5zGAwcNvFodPpoGkaiUSC
+      ZrMJQKPRwDAM19/l6gbkcjna7faXMp6enqhWq3Q6Ha6vr5mbm3PJbjp+N8MuLy+/dF4IQbPZ
+      5OzsDEVRCAQCHBwcuGQ3HVc3oFAoOGvabrcplUocHR2haRrxeNyZmaZJsVgkGo2yu7vL1dUV
+      k8mE8XjMZDIhHA7/km3bNnd3dxweHqKqKplMxvkM7+/vSSQSqKpKLBaj0WgghJjJ2dUN+BlN
+      07i4uADAMAweHx9ZX1/n/Pych4cH57l6vY7f7yedTv82y+fzEY/HyWazwI+CDcNgf3+ftbU1
+      VlZWGA6HmKaJrutsbW2xvb39R8d/WsA0LMtieXmZ29tbVldX382EEMzPz/P8/EwkEpkpzzRN
+      bm5uyGazbGxsoCgKhUJhZp//fg0uLi4SCoWo1WqYpokQgpeXF3q9HoqikEwmqVQqCCF4fX2l
+      1Wp9mGdZFgsLCwQCASzLotvt0u/3Z/b5VAGDwYBkMomqqqiqSi6X+6vzx8fHjEYj9vb22NnZ
+      IZ/PO7PNzU1OT0/RNI1MJoNlWR9mLS0tEYlESKVSxGIxWq0WwWDQmeu6jq7rAIzHY05OTt5d
+      pz7vr/A35w0rENYNGSa1zwAAAABJRU5ErkJggg==
+    </thumbnail>
+  </thumbnails>
+</workbook>

--- a/skills/tableau-build/scripts/features.py
+++ b/skills/tableau-build/scripts/features.py
@@ -1,0 +1,482 @@
+"""Parameters, dashboard actions and Dynamic Zone Visibility for tableau-build (step 8).
+
+:mod:`twb` owns the workbook shell, :mod:`worksheet` what goes inside a sheet, :mod:`zones`
+the dashboard's geometry. This module owns the three constructs that make a built dashboard
+*interactive* rather than merely correct, and that live in their own workbook-level elements:
+
+* the **``Parameters`` datasource** - the inline, connectionless datasource every parameter is
+  a column of (``[Parameters].[Top N]``);
+* the workbook's **``<actions>``** block - filter and highlight actions (``<action>``) and
+  parameter actions (``<edit-parameter-action>``), bound to real sheet names;
+* the **``<datagraph>``** behind Dynamic Zone Visibility - the node/edge graph that wires a
+  boolean field to a zone's visibility.
+
+The module is pure and stdlib-only: elements in, elements out. It deliberately does **not**
+generate ids: an action's ``name`` and a zone's id come from the caller, so every generated id
+in the workbook stays hash-derived from one place (:mod:`twb`) and a rebuild is byte-identical.
+"""
+
+from __future__ import annotations
+
+import uuid
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Optional
+
+# --- Parameters ----------------------------------------------------------------
+
+#: The name (and caption) of the inline datasource every parameter lives in. Not a federated
+#: id: ``[Parameters]`` is the literal name Tableau references a parameter through.
+PARAMETERS_DATASOURCE = "Parameters"
+
+#: manifest ``data_type`` -> the parameter column's ``type`` attribute.
+#: ``manifest.PARAMETER_TYPES`` reads this table, so an undeclarable type fails validation.
+PARAMETER_TYPES: dict[str, str] = {
+    "string": "nominal",
+    "integer": "quantitative",
+    "real": "quantitative",
+    "boolean": "nominal",
+    "date": "ordinal",
+    "datetime": "ordinal",
+}
+
+#: A parameter is always a measure, whatever its datatype - attested for both a string and an
+#: integer parameter, and it is what puts the control in the Parameters section of the pane.
+PARAMETER_ROLE = "measure"
+
+#: Bare-value datatypes; everything else needs delimiters (see :func:`parameter_literal`).
+_BARE_VALUE_TYPES = frozenset({"integer", "real"})
+
+#: What a parameter action's ``<clear-option>`` value is prefixed with - Tableau's own token,
+#: read off a Desktop 2025.1-saved workbook (``s:LROOT:All`` resets a parameter to ``All``).
+#: The value that follows is *undelimited*: the plain text, not a :func:`parameter_literal`.
+#: ponytail: only attested for a string parameter, which is why non-string parameters keep the
+#: attested ``do-nothing`` instead - if a numeric parameter ever needs resetting, save one in
+#: Desktop and check whether the tag is still ``s``.
+CLEAR_VALUE_PREFIX = "s:LROOT:"
+
+
+def parameter_literal(value: object, data_type: str) -> str:
+    """Render a parameter value the way Tableau writes it in ``value`` and its calculation.
+
+    Args:
+        value: The manifest's value (a string, number or boolean).
+        data_type: The parameter's manifest data type.
+
+    Returns:
+        The literal: ``"on"`` for a string (quotes included), ``10`` for a number,
+        ``true``/``false`` for a boolean, and ``#2024-01-01#`` for a date.
+    """
+    if data_type == "boolean":
+        return "true" if value in (True, "true", "True", 1) else "false"
+    if data_type in _BARE_VALUE_TYPES:
+        return str(value)
+    text = str(value)
+    if data_type in {"date", "datetime"}:
+        return text if text.startswith("#") else f"#{text}#"
+    return text if text.startswith('"') else f'"{text}"'
+
+
+@dataclass(frozen=True)
+class Parameter:
+    """One resolved parameter: its literal current value and its domain.
+
+    Attributes:
+        name: The parameter's name - also its column name, so a formula reads
+            ``[Parameters].[Top N]`` rather than ``[Parameters].[Parameter 1]``.
+        data_type: The manifest data type (a key of :data:`PARAMETER_TYPES`).
+        value: The current value, already rendered as a Tableau literal.
+        clear_value: The serialized value a parameter action resets to when the selection is
+            cleared (see :data:`CLEAR_VALUE_PREFIX`); ``""`` for a parameter whose type has no
+            attested serialization, which keeps the value the last click put there.
+        members: A list domain's allowed values, as literals; empty for the other domains.
+        bounds: A range domain's ``(min, max, granularity)`` literals, or ``None``.
+        number_format: A ``default-format`` pattern for the control, or ``""``.
+    """
+
+    name: str
+    data_type: str
+    value: str
+    clear_value: str = ""
+    members: tuple[str, ...] = ()
+    bounds: Optional[tuple[str, str, str]] = None
+    number_format: str = ""
+
+    @property
+    def column_name(self) -> str:
+        """str: The bracketed column name (``[Top N]``)."""
+        return f"[{self.name}]"
+
+    @property
+    def reference(self) -> str:
+        """str: The qualified reference a formula or a control uses."""
+        return f"[{PARAMETERS_DATASOURCE}].{self.column_name}"
+
+    @property
+    def domain_type(self) -> str:
+        """str: The ``param-domain-type``: a member list, a range, or any value."""
+        if self.members:
+            return "list"
+        return "range" if self.bounds else "any"
+
+
+def plan_parameters(entries: object) -> list[Parameter]:
+    """Resolve the manifest's ``parameters`` list into :class:`Parameter`s.
+
+    Args:
+        entries: The manifest's ``parameters`` value.
+
+    Returns:
+        One :class:`Parameter` per named entry, in manifest order. An entry
+        ``manifest.validate_manifest`` would have rejected (no name, unknown data type) is
+        skipped rather than guessed at.
+    """
+    parameters: list[Parameter] = []
+    for entry in entries if isinstance(entries, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name", "")).strip()
+        data_type = str(entry.get("data_type", "")).strip().lower()
+        if not name or data_type not in PARAMETER_TYPES:
+            continue
+
+        values = entry.get("values")
+        members = (
+            tuple(parameter_literal(value, data_type) for value in values)
+            if isinstance(values, list) and values else ()
+        )
+        bounds = None
+        span = entry.get("range")
+        if not members and isinstance(span, dict):
+            minimum, maximum = span.get("min"), span.get("max")
+            if minimum is not None and maximum is not None:
+                # No step means "any value in the range"; Tableau writes the granularity as
+                # 1, which is the smallest step its slider offers for an integer.
+                step = span.get("step", 1)
+                bounds = (
+                    parameter_literal(minimum, data_type),
+                    parameter_literal(maximum, data_type),
+                    parameter_literal(step, data_type),
+                )
+
+        current = entry.get("current_value")
+        if current is None:
+            # Without a current value the control opens on nothing; the first allowed value
+            # (or the range's floor) is the only defensible default.
+            current = values[0] if members else (span or {}).get("min", "")
+        parameters.append(Parameter(
+            name=name,
+            data_type=data_type,
+            value=parameter_literal(current, data_type),
+            clear_value=(
+                f"{CLEAR_VALUE_PREFIX}{current}" if data_type == "string" else ""
+            ),
+            members=members,
+            bounds=bounds,
+            number_format=str(entry.get("format", "")).strip(),
+        ))
+    return parameters
+
+
+def render_parameter_column(
+    parent: ET.Element, parameter: Parameter, with_domain: bool = True
+) -> None:
+    """Render one parameter's ``<column>``.
+
+    Args:
+        parent: The element to append the column to (the ``Parameters`` datasource, the
+            dashboard's dependencies, or a worksheet's).
+        parameter: The resolved parameter.
+        with_domain: Emit the ``<members>`` / ``<range>`` child. A worksheet declares the
+            parameter only to resolve a calculation, and Tableau writes no domain there.
+    """
+    attributes = {
+        "caption": parameter.name,
+        "datatype": parameter.data_type,
+        "name": parameter.column_name,
+        "param-domain-type": parameter.domain_type,
+        "role": PARAMETER_ROLE,
+        "type": PARAMETER_TYPES[parameter.data_type],
+        "value": parameter.value,
+    }
+    if parameter.number_format:
+        attributes["default-format"] = parameter.number_format
+    column = ET.SubElement(parent, "column", dict(sorted(attributes.items())))
+    # The calculation *is* the current value: a parameter is a constant the viewer edits.
+    ET.SubElement(column, "calculation", {"class": "tableau", "formula": parameter.value})
+    if not with_domain:
+        return
+    if parameter.members:
+        members = ET.SubElement(column, "members")
+        for member in parameter.members:
+            ET.SubElement(members, "member", {"value": member})
+    elif parameter.bounds:
+        minimum, maximum, granularity = parameter.bounds
+        ET.SubElement(
+            column, "range", {"granularity": granularity, "max": maximum, "min": minimum}
+        )
+
+
+def render_parameters_datasource(
+    parent: ET.Element, parameters: list[Parameter], version: str
+) -> None:
+    """Render the inline ``Parameters`` datasource, one column per parameter.
+
+    It carries no connection (``hasconnection='false'``) and must be the **last** datasource:
+    Tableau resolves ``[Parameters].[...]`` references from it after the real datasources.
+
+    Args:
+        parent: The workbook's ``<datasources>`` element.
+        parameters: The resolved parameters (nothing is emitted for an empty list).
+        version: The workbook document version.
+    """
+    if not parameters:
+        return
+    datasource = ET.SubElement(parent, "datasource", {
+        "hasconnection": "false",
+        "inline": "true",
+        "name": PARAMETERS_DATASOURCE,
+        "version": version,
+    })
+    ET.SubElement(datasource, "aliases", {"enabled": "yes"})
+    for parameter in parameters:
+        render_parameter_column(datasource, parameter)
+
+
+# --- Actions -------------------------------------------------------------------
+
+#: manifest ``run_on`` -> the ``<activation>`` type. ``manifest.ACTION_RUN_ON`` reads this.
+ACTIVATIONS: dict[str, str] = {"select": "on-select", "hover": "on-hover"}
+
+#: The Tableau command behind each sheet-to-sheet action type.
+ACTION_COMMANDS: dict[str, str] = {"filter": "tsc:tsl-filter", "highlight": "tsc:brush"}
+
+
+@dataclass(frozen=True)
+class SheetAction:
+    """One filter or highlight action, from one sheet to one other sheet.
+
+    One action per *target* rather than one action targeting the whole dashboard: targeting
+    the dashboard filters every sheet on it, including ones the manifest never listed.
+
+    Attributes:
+        name: The action's XML ``name`` (``[Action1_<32 hex>]``), generated by the caller.
+        caption: The action's display name.
+        kind: ``filter`` or ``highlight`` (a key of :data:`ACTION_COMMANDS`).
+        source: The sheet whose marks the viewer selects.
+        target: The sheet the action acts on.
+        activation: ``on-select`` or ``on-hover``.
+    """
+
+    name: str
+    caption: str
+    kind: str
+    source: str
+    target: str
+    activation: str = "on-select"
+
+
+@dataclass(frozen=True)
+class ParameterAction:
+    """One parameter action: selecting a mark writes a field's value into a parameter.
+
+    Attributes:
+        name: The action's XML ``name``, generated by the caller.
+        caption: The action's display name.
+        source: The sheet whose marks the viewer selects.
+        source_field: The qualified column-instance the value is read from.
+        target_parameter: The qualified parameter the value is written to.
+        clear_value: The serialized value the parameter is reset to when the selection is
+            cleared (:data:`CLEAR_VALUE_PREFIX`); ``""`` keeps the last clicked value.
+        activation: ``on-select`` or ``on-hover``.
+    """
+
+    name: str
+    caption: str
+    source: str
+    source_field: str
+    target_parameter: str
+    clear_value: str = ""
+    activation: str = "on-select"
+
+
+#: The document-format flags a workbook with an ``<edit-parameter-action>`` carries. Tableau
+#: gates the element on them: without ``ParameterAction`` Desktop loads the workbook against a
+#: schema where ``edit-parameter-action`` is not declared at all and refuses it outright
+#: ("no declaration found for element"), even though the 2026.1 XSD accepts it. The second flag
+#: goes with the ``<clear-option>`` child. Both verified against a Desktop 2025.1.10-saved
+#: workbook (``skill/tableau-dashboard-creator/references/snippets/dashboard/parameter-action.twb``).
+PARAMETER_ACTION_FORMAT_FLAGS: tuple[str, ...] = (
+    "ParameterAction",
+    "ParameterActionClearSelection",
+)
+
+
+def render_actions(
+    parent: ET.Element,
+    dashboard_name: str,
+    sheet_actions: list[SheetAction],
+    parameter_actions: list[ParameterAction],
+) -> None:
+    """Render the workbook's ``<actions>`` block.
+
+    Nothing is emitted when both lists are empty: the schema requires at least one child, so
+    an empty ``<actions/>`` is a workbook Tableau refuses rather than a workbook with no
+    interactivity. Sheet actions come first and parameter actions last - the XSD's order.
+
+    Args:
+        parent: The ``<workbook>`` element.
+        dashboard_name: The dashboard every action's source sits on.
+        sheet_actions: The filter / highlight actions.
+        parameter_actions: The parameter actions.
+    """
+    if not (sheet_actions or parameter_actions):
+        return
+    actions = ET.SubElement(parent, "actions")
+
+    for action in sheet_actions:
+        element = ET.SubElement(
+            actions, "action", {"caption": action.caption, "name": action.name}
+        )
+        ET.SubElement(
+            element, "activation", {"auto-clear": "true", "type": action.activation}
+        )
+        ET.SubElement(element, "source", {
+            "dashboard": dashboard_name, "type": "sheet", "worksheet": action.source,
+        })
+        command = ET.SubElement(
+            element, "command", {"command": ACTION_COMMANDS[action.kind]}
+        )
+        # 'exclude' keeps the action off its own source; the field parameter says which
+        # fields are matched - all the ones the two sheets share.
+        matched = "special-fields" if action.kind == "filter" else "field-captions"
+        for name, value in (
+            ("exclude", action.source), (matched, "all"), ("target", action.target),
+        ):
+            ET.SubElement(command, "param", {"name": name, "value": value})
+
+    for action in parameter_actions:
+        element = ET.SubElement(
+            actions, "edit-parameter-action",
+            {"caption": action.caption, "name": action.name},
+        )
+        ET.SubElement(element, "activation", {"type": action.activation})
+        ET.SubElement(element, "source", {
+            "dashboard": dashboard_name, "type": "sheet", "worksheet": action.source,
+        })
+        # ATTR() of the selected marks' field. Clearing the selection puts the parameter back
+        # to its opening value, so a panel the parameter reveals hides itself again and the
+        # viewer cannot get stuck in a state only a parameter control could undo.
+        ET.SubElement(element, "agg-type", {"type": "attr"})
+        ET.SubElement(element, "clear-option", (
+            {"type": "assign-fixed-value", "value": action.clear_value}
+            if action.clear_value else {"type": "do-nothing", "value": CLEAR_VALUE_PREFIX}
+        ))
+        params = ET.SubElement(element, "params")
+        for name, value in (
+            ("source-field", action.source_field),
+            ("target-parameter", action.target_parameter),
+        ):
+            ET.SubElement(params, "param", {"name": name, "value": value})
+
+
+# --- Dynamic Zone Visibility ----------------------------------------------------
+
+#: The document-format flags a workbook with a ``<datagraph>`` carries. Emitted only when DZV
+#: is present, sorted into :data:`twb.FORMAT_CHANGE_FLAGS` (Tableau writes them alphabetically).
+DZV_FORMAT_FLAGS: tuple[str, ...] = (
+    "DatagraphCoreV1",
+    "DatagraphNodeDashboardZoneVisibilityV1",
+    "DatagraphNodeSingleValueFieldV1",
+    "ZoneVisibilityControl",
+)
+
+
+@dataclass(frozen=True)
+class ZoneVisibility:
+    """One zone whose visibility a boolean field controls.
+
+    Attributes:
+        zone_id: The dashboard zone's id (the layout engine's sequential number).
+        field: The qualified boolean field (``[federated.x].[Show Detail]``).
+    """
+
+    zone_id: str
+    field: str
+
+
+def _guid(*parts: str) -> str:
+    """Return a deterministic lower-case UUID for a datagraph slot.
+
+    Args:
+        *parts: What the guid identifies (the slot name, the zone, the field).
+
+    Returns:
+        A UUID5 string. Deterministic so a rebuild stays byte-identical; the graph only
+        needs its guids to agree with each other, not to be random.
+    """
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, "twb:dzv:" + ":".join(parts)))
+
+
+def render_datagraph(
+    parent: ET.Element, visibilities: list[ZoneVisibility], dashboard_identifier: str
+) -> None:
+    """Render the ``<datagraph>`` that drives Dynamic Zone Visibility.
+
+    Each controlled zone is two nodes and one edge: a ``single-value-field-node`` reads the
+    boolean field, and its value output feeds a ``dashboard-zone-visibility-node``'s
+    visibility input. Every node also has to be listed in ``<node-execution-subgraphs>``
+    against the one execution subgraph, or Tableau evaluates none of them.
+
+    Args:
+        parent: The ``<workbook>`` element (the datagraph goes after ``<windows>``).
+        visibilities: The controlled zones (nothing is emitted for an empty list).
+        dashboard_identifier: The dashboard's ``<simple-id>`` uuid, braced and upper-case.
+    """
+    if not visibilities:
+        return
+    subgraph = _guid("subgraph")
+    graph = ET.SubElement(ET.SubElement(parent, "datagraph"), "graph")
+    ET.SubElement(
+        ET.SubElement(graph, "properties"), "default-execution-subgraph-guid",
+        {"value": subgraph},
+    )
+
+    # {zone id: (field node guid, value output guid, zone node guid, visibility input guid)}
+    slots = {
+        entry.zone_id: (
+            _guid("field", entry.zone_id), _guid("value", entry.zone_id),
+            _guid("zone", entry.zone_id), _guid("visibility", entry.zone_id),
+        )
+        for entry in visibilities
+    }
+
+    pairs = ET.SubElement(graph, "node-execution-subgraphs")
+    for entry in visibilities:
+        field_node, _, zone_node, _ = slots[entry.zone_id]
+        for node in (field_node, zone_node):
+            ET.SubElement(pairs, "pair", {
+                "execution-subgraph-guid": subgraph, "node-guid": node,
+            })
+
+    nodes = ET.SubElement(graph, "nodes")
+    for entry in visibilities:
+        field_node, value_output, zone_node, visibility_input = slots[entry.zone_id]
+        ET.SubElement(nodes, "single-value-field-node", {
+            "fieldname": entry.field,
+            "fieldname-input-guid": _guid("fieldname-input", entry.zone_id),
+            "node-guid": field_node,
+            "value-output-guid": value_output,
+        })
+        ET.SubElement(nodes, "dashboard-zone-visibility-node", {
+            "dashboard-identifier": dashboard_identifier,
+            "node-guid": zone_node,
+            "visibility-input-guid": visibility_input,
+            "zone-id": entry.zone_id,
+        })
+
+    edges = ET.SubElement(graph, "edges")
+    for entry in visibilities:
+        _, value_output, _, visibility_input = slots[entry.zone_id]
+        ET.SubElement(edges, "edge", {"from": value_output, "to": visibility_input})
+    ET.SubElement(graph, "pin-values")

--- a/skills/tableau-build/scripts/features.py
+++ b/skills/tableau-build/scripts/features.py
@@ -50,9 +50,10 @@ _BARE_VALUE_TYPES = frozenset({"integer", "real"})
 #: What a parameter action's ``<clear-option>`` value is prefixed with - Tableau's own token,
 #: read off a Desktop 2025.1-saved workbook (``s:LROOT:All`` resets a parameter to ``All``).
 #: The value that follows is *undelimited*: the plain text, not a :func:`parameter_literal`.
-#: ponytail: only attested for a string parameter, which is why non-string parameters keep the
-#: attested ``do-nothing`` instead - if a numeric parameter ever needs resetting, save one in
-#: Desktop and check whether the tag is still ``s``.
+#: The ``s`` is a string's type tag and is all that is attested, so a parameter action may
+#: only target a string parameter - ``manifest.PARAMETER_ACTION_TARGET_TYPE`` enforces that,
+#: which is what makes the reset below unconditional for anything that validates (issue #49
+#: lifts the restriction once the other types' tags are read off a Desktop-saved workbook).
 CLEAR_VALUE_PREFIX = "s:LROOT:"
 
 
@@ -128,8 +129,8 @@ def plan_parameters(entries: object) -> list[Parameter]:
 
     Returns:
         One :class:`Parameter` per named entry, in manifest order. An entry
-        ``manifest.validate_manifest`` would have rejected (no name, unknown data type) is
-        skipped rather than guessed at.
+        ``manifest.validate_manifest`` would have rejected (no name, unknown data type, no
+        current value) is skipped rather than guessed at.
     """
     parameters: list[Parameter] = []
     for entry in entries if isinstance(entries, list) else []:
@@ -161,9 +162,7 @@ def plan_parameters(entries: object) -> list[Parameter]:
 
         current = entry.get("current_value")
         if current is None:
-            # Without a current value the control opens on nothing; the first allowed value
-            # (or the range's floor) is the only defensible default.
-            current = values[0] if members else (span or {}).get("min", "")
+            continue  # validate_manifest requires it; guessing would hide a bad manifest
         parameters.append(Parameter(
             name=name,
             data_type=data_type,
@@ -304,8 +303,8 @@ class ParameterAction:
 #: gates the element on them: without ``ParameterAction`` Desktop loads the workbook against a
 #: schema where ``edit-parameter-action`` is not declared at all and refuses it outright
 #: ("no declaration found for element"), even though the 2026.1 XSD accepts it. The second flag
-#: goes with the ``<clear-option>`` child. Both verified against a Desktop 2025.1.10-saved
-#: workbook (``skill/tableau-dashboard-creator/references/snippets/dashboard/parameter-action.twb``).
+#: goes with the ``<clear-option>`` child. Both verified against the Desktop 2025.1.10-saved
+#: workbook this skill keeps at ``references/snippets/dashboard/parameter-action.twb``.
 PARAMETER_ACTION_FORMAT_FLAGS: tuple[str, ...] = (
     "ParameterAction",
     "ParameterActionClearSelection",

--- a/skills/tableau-build/scripts/manifest.py
+++ b/skills/tableau-build/scripts/manifest.py
@@ -29,10 +29,20 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Optional
+from typing import NamedTuple, Optional
 
+from features import ACTIVATIONS, PARAMETER_TYPES
 # Names, not the module: half the functions below take a parameter called ``worksheet``.
-from worksheet import CHART_SPECS, DATE_PART_DERIVATIONS, ENCODING_ORDER
+from worksheet import (
+    CHART_SPECS,
+    DATE_PART_DERIVATIONS,
+    ENCODING_ORDER,
+    REFERENCE_LINE_FORMULAS,
+    REFERENCE_LINE_LABEL_TYPES,
+    REFERENCE_LINE_SCOPES,
+    TABLE_CALC_PREFIXES,
+)
+from zones import FILTER_MODES
 
 #: Sections a manifest must carry (actions/parameters may be empty lists, never absent -
 #: "None" must be said explicitly so a forgotten section is not mistaken for "no actions").
@@ -74,6 +84,19 @@ AGGREGATIONS = frozenset({
 #: dropped silently, and Tableau shows no sign of the missing encoding.
 DATE_PARTS = frozenset(DATE_PART_DERIVATIONS)
 ENCODING_NAMES = frozenset(ENCODING_ORDER)
+
+#: Table calculations a shelf entry may ask for, and the parameter data types / action
+#: activations the builder can emit - all read off the builder's own tables.
+TABLE_CALCS = frozenset(TABLE_CALC_PREFIXES)
+PARAMETER_DATA_TYPES = frozenset(PARAMETER_TYPES)
+ACTION_RUN_ON = frozenset(ACTIVATIONS)
+
+#: Types a quick-filter card can render: it lists the field's *members*, so a date or numeric
+#: field belongs in a worksheet filter with bounds instead (see :data:`zones.FILTER_MODES`).
+CARD_FILTER_TYPES = frozenset({"string", "boolean"})
+
+#: The type a Dynamic Zone Visibility field must have - a zone is shown or hidden, nothing else.
+VISIBILITY_TYPE = "boolean"
 
 # A data-source heading in DATA-MODEL.md: "## Data source: `sales.csv`" -> "sales.csv".
 _DATASOURCE_HEADING = re.compile(
@@ -172,7 +195,8 @@ def load_manifest(path: Path | str) -> tuple[Optional[dict], Optional[str]]:
 # --- Layout tree --------------------------------------------------------------
 
 def _collect_layout_ids(
-    node: object, path: str, ids: list[str], container_ids: set[str], errors: list[str]
+    node: object, path: str, ids: list[str], container_ids: set[str], errors: list[str],
+    visibility: Optional[list[tuple[str, str]]] = None,
 ) -> None:
     """Walk one layout node, recording every placed id and any structural error.
 
@@ -190,10 +214,22 @@ def _collect_layout_ids(
         ids: Accumulator for placed element ids.
         container_ids: Accumulator for the ids of nodes that hold children.
         errors: Accumulator for validation errors.
+        visibility: Accumulator for ``(path, field name)`` of every node whose zone is shown
+            or hidden by a boolean field (Dynamic Zone Visibility), or ``None`` to ignore them.
     """
     if not isinstance(node, dict):
         errors.append(f"{path}: every layout node must be a JSON object")
         return
+
+    if visibility is not None and node.get("visibility") is not None:
+        shown_by = node.get("visibility")
+        if isinstance(shown_by, str) and shown_by.strip():
+            visibility.append((path, shown_by.strip()))
+        else:
+            errors.append(
+                f"{path}: 'visibility' must be the name of a boolean calculated field "
+                f"(got {shown_by!r})"
+            )
 
     element_id, children = node.get("id"), node.get("children")
     if element_id is None and children is None:
@@ -223,7 +259,7 @@ def _collect_layout_ids(
         return
     for index, child in enumerate(children):
         _collect_layout_ids(
-            child, f"{path}.children[{index}]", ids, container_ids, errors
+            child, f"{path}.children[{index}]", ids, container_ids, errors, visibility
         )
 
 
@@ -247,7 +283,9 @@ def placed_layout_ids(layout: object) -> set[str]:
     return set(ids)
 
 
-def _validate_layout(layout: object, errors: list[str]) -> tuple[list[str], set[str]]:
+def _validate_layout(
+    layout: object, errors: list[str]
+) -> tuple[list[str], set[str], list[tuple[str, str]]]:
     """Validate the layout section and return what it places.
 
     Args:
@@ -255,12 +293,13 @@ def _validate_layout(layout: object, errors: list[str]) -> tuple[list[str], set[
         errors: Accumulator for validation errors.
 
     Returns:
-        ``(placed ids, container ids)``. A container id is filled by its children, so it
-        needs no worksheet or object of its own.
+        ``(placed ids, container ids, visibility bindings)``. A container id is filled by its
+        children, so it needs no worksheet or object of its own; a visibility binding is the
+        ``(path, field name)`` of a zone under Dynamic Zone Visibility.
     """
     if not isinstance(layout, dict):
         errors.append("layout: must be an object with 'canvas' and 'root' (copy the spec's)")
-        return [], set()
+        return [], set(), []
 
     canvas = layout.get("canvas")
     if not (
@@ -272,15 +311,18 @@ def _validate_layout(layout: object, errors: list[str]) -> tuple[list[str], set[
 
     ids: list[str] = []
     container_ids: set[str] = set()
+    visibility: list[tuple[str, str]] = []
     if isinstance(layout.get("root"), dict):
-        _collect_layout_ids(layout["root"], "layout.root", ids, container_ids, errors)
+        _collect_layout_ids(
+            layout["root"], "layout.root", ids, container_ids, errors, visibility
+        )
     else:
         errors.append("layout.root: must be a container object ('type' + 'children')")
 
     duplicates = sorted({placed for placed in ids if ids.count(placed) > 1})
     if duplicates:
         errors.append("layout places id(s) more than once: " + ", ".join(duplicates))
-    return ids, container_ids
+    return ids, container_ids, visibility
 
 
 # --- Datasources / worksheets -------------------------------------------------
@@ -418,7 +460,7 @@ def _worksheet_field_references(worksheet: dict) -> list[tuple[str, object]]:
         for encoding, entry in encodings.items():
             references.append((f"encodings.{encoding}", entry))
 
-    for key in ("filters", "tooltip", "number_formats"):
+    for key in ("filters", "tooltip", "number_formats", "reference_lines"):
         entries = worksheet.get(key)
         if isinstance(entries, list):
             for index, entry in enumerate(entries):
@@ -448,7 +490,10 @@ def _validate_reference(
         errors: Accumulator for validation errors.
     """
     bin_size: object = None
+    table_calc = ""
     if isinstance(entry, dict):
+        raw_calc = entry.get("table_calc")
+        table_calc = raw_calc.strip() if isinstance(raw_calc, str) else ""
         field_name = _bare_field(entry.get("field"))
         # A JSON null (or any other non-string) means "not specified", same as a missing
         # key - never coerce it to a string, or `null` reads as the literal text "none".
@@ -493,6 +538,11 @@ def _validate_reference(
             f"{label}: {where} '{field_name}' has a 'bin' of {bin_size!r} - a bin width "
             f"must be a positive number (e.g. 500 for a histogram of 0-500, 500-1000, ...)"
         )
+    if table_calc and table_calc not in TABLE_CALCS:
+        errors.append(
+            f"{label}: {where} '{field_name}' has unknown table_calc '{table_calc}' "
+            f"(expected one of: {', '.join(sorted(TABLE_CALCS))})"
+        )
 
 
 def _validate_modifiers(label: str, worksheet: dict, errors: list[str]) -> None:
@@ -533,6 +583,26 @@ def _validate_modifiers(label: str, worksheet: dict, errors: list[str]) -> None:
                     f"{label}: filters[{index}] has nothing to filter on - give it "
                     f"'values' (a member list) or 'min'/'max' (a range)"
                 )
+
+    lines = worksheet.get("reference_lines")
+    if isinstance(lines, list):
+        for index, entry in enumerate(lines):
+            if not isinstance(entry, dict):
+                errors.append(
+                    f"{label}: reference_lines[{index}] must be an object with a 'field'"
+                )
+                continue
+            for key, allowed in (
+                ("formula", REFERENCE_LINE_FORMULAS),
+                ("scope", REFERENCE_LINE_SCOPES),
+                ("label_type", REFERENCE_LINE_LABEL_TYPES),
+            ):
+                value = entry.get(key)
+                if isinstance(value, str) and value.strip().lower() not in allowed:
+                    errors.append(
+                        f"{label}: reference_lines[{index}] has unknown {key} "
+                        f"'{value}' (expected one of: {', '.join(sorted(allowed))})"
+                    )
 
     sort = worksheet.get("sort")
     if isinstance(sort, dict):
@@ -634,8 +704,83 @@ def _validate_worksheets(
     return filled
 
 
+class ViewZone(NamedTuple):
+    """One worksheet as the rest of the manifest addresses it.
+
+    Attributes:
+        name: The Tableau sheet name.
+        datasource: The datasource the sheet reads (whose fields a card may filter).
+    """
+
+    name: str
+    datasource: str
+
+
+def _view_zones(worksheets: object) -> dict[str, ViewZone]:
+    """Map ``{element id: ViewZone}`` for the worksheets that name a zone.
+
+    A filter card and a filter/highlight action are both defined in terms of a *view*: the
+    card filters one sheet, and an action runs from one sheet's marks to another's. This is
+    the one place the manifest's element ids are turned into that.
+
+    Args:
+        worksheets: The manifest's ``worksheets`` value.
+
+    Returns:
+        ``{element id: ViewZone}``; malformed entries are skipped (already reported).
+    """
+    views: dict[str, ViewZone] = {}
+    for entry in worksheets if isinstance(worksheets, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        element_id = str(entry.get("element_id", "")).strip()
+        name = str(entry.get("name", "")).strip()
+        if element_id and name:
+            views.setdefault(
+                element_id, ViewZone(name, str(entry.get("datasource", "")).strip())
+            )
+    return views
+
+
+def _field_types(
+    manifest_document: dict, data_model_text: str
+) -> dict[str, dict[str, str]]:
+    """Return ``{datasource name: {field name: type}}`` for every field a sheet can name.
+
+    Merges the CSV's documented types (``DATA-MODEL.md``, the field authority) with the
+    manifest's calculated fields, so a check like "is this field a discrete dimension?" has
+    one place to look.
+
+    Args:
+        manifest_document: The whole manifest.
+        data_model_text: The contents of ``DATA-MODEL.md``.
+
+    Returns:
+        The merged type map.
+    """
+    documented = documented_field_types(data_model_text)
+    types: dict[str, dict[str, str]] = {}
+    for entry in manifest_document.get("datasources") or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name", "")).strip()
+        if name:
+            types[name] = dict(documented.get(str(entry.get("csv", "")).strip(), {}))
+    for entry in manifest_document.get("calculated_fields") or []:
+        if not isinstance(entry, dict):
+            continue
+        source = str(entry.get("datasource", "")).strip()
+        name = str(entry.get("name", "")).strip()
+        if source in types and name:
+            # No 'type' means a numeric result - the same default the assembler applies.
+            types[source][name] = str(entry.get("type", "")).strip().lower() or "real"
+    return types
+
+
 def _validate_objects(
-    objects: object, layout_ids: set[str], container_ids: set[str], errors: list[str]
+    objects: object, layout_ids: set[str], container_ids: set[str],
+    views: dict[str, ViewZone], field_types: dict[str, dict[str, str]],
+    parameter_names: set[str], errors: list[str],
 ) -> set[str]:
     """Validate the non-worksheet dashboard objects and return the zones they fill.
 
@@ -644,6 +789,9 @@ def _validate_objects(
         layout_ids: The element ids the layout tree places.
         container_ids: Mapped-container ids (filled by their children, not an object of
             their own - CONTRACT.md §1.1).
+        views: ``{element id: ViewZone}`` - the sheets a filter card may filter.
+        field_types: ``{datasource: {field: type}}``.
+        parameter_names: The declared parameter names.
         errors: Accumulator for validation errors.
 
     Returns:
@@ -677,23 +825,93 @@ def _validate_objects(
                 f"{label}: unknown kind '{kind}' "
                 f"(expected one of: {', '.join(sorted(OBJECT_KINDS))})"
             )
+        elif kind == "filter":
+            _validate_filter_card(
+                label, dashboard_object, views, field_types, errors
+            )
+        elif kind == "parameter":
+            parameter = str(dashboard_object.get("parameter", "")).strip()
+            if parameter not in parameter_names:
+                errors.append(
+                    f"{label}: 'parameter' is {parameter or 'missing'} - a parameter control "
+                    f"names one declared parameter (declared: "
+                    f"{', '.join(sorted(parameter_names)) or 'none'})"
+                )
     return filled
 
 
+def _validate_filter_card(
+    label: str, dashboard_object: dict, views: dict[str, ViewZone],
+    field_types: dict[str, dict[str, str]], errors: list[str],
+) -> None:
+    """Validate one quick-filter card against the worksheet it filters.
+
+    A card is the UI for one worksheet's filter, so it has to name that worksheet *and* a
+    field of the worksheet's datasource. The field also has to be one whose members a card can
+    list - a card over a date or a measure would need bounds, which belong on the worksheet's
+    ``filters`` instead.
+
+    Args:
+        label: The object's error label.
+        dashboard_object: The ``objects`` entry.
+        views: ``{element id: ViewZone}``.
+        field_types: ``{datasource: {field: type}}``.
+        errors: Accumulator for validation errors.
+    """
+    sheet_names = {view.name: view.datasource for view in views.values()}
+    sheet = str(dashboard_object.get("worksheet", "")).strip()
+    field_name = _bare_field(dashboard_object.get("field"))
+
+    if not field_name:
+        errors.append(f"{label}: a filter card needs a 'field' (the field it filters on)")
+    if sheet not in sheet_names:
+        errors.append(
+            f"{label}: a filter card needs a 'worksheet' naming the sheet it filters "
+            f"- '{sheet}' is not one "
+            f"(declared: {', '.join(sorted(sheet_names)) or 'none'})"
+        )
+    elif field_name:
+        datatype = field_types.get(sheet_names[sheet], {}).get(field_name)
+        if datatype is None:
+            errors.append(
+                f"{label}: field '{field_name}' is not a field of worksheet '{sheet}'s "
+                f"datasource '{sheet_names[sheet]}'"
+            )
+        elif datatype not in CARD_FILTER_TYPES:
+            errors.append(
+                f"{label}: field '{field_name}' is a '{datatype}' - a filter card lists a "
+                f"field's members, so it needs one of: "
+                f"{', '.join(sorted(CARD_FILTER_TYPES))}. For a date or numeric range, put "
+                f"'filters' with min/max on worksheet '{sheet}' instead"
+            )
+
+    mode = str(dashboard_object.get("mode", "")).strip()
+    if mode and mode not in FILTER_MODES:
+        errors.append(
+            f"{label}: unknown filter mode '{mode}' "
+            f"(expected one of: {', '.join(sorted(FILTER_MODES))})"
+        )
+
+
 def _validate_actions(
-    actions: object, known_ids: set[str], parameter_names: set[str], errors: list[str]
+    actions: object, known_ids: set[str], parameter_names: set[str],
+    views: dict[str, ViewZone], field_types: dict[str, dict[str, str]],
+    errors: list[str],
 ) -> None:
     """Validate the dashboard actions' types and endpoints.
 
-    The **source** is always a zone (the view whose marks the analyst clicks). What a
-    **target** is depends on the type: ``filter`` / ``highlight`` target other zones, a
-    ``parameter`` action targets a declared parameter, and ``set`` / ``url`` actions target
+    The **source** is always a *view* zone: an action runs off the marks the analyst clicks,
+    and a text or filter zone has none. What a **target** is depends on the type: ``filter`` /
+    ``highlight`` target other view zones, a ``parameter`` action targets a declared parameter
+    (and needs the ``field`` whose value it writes there), and ``set`` / ``url`` actions target
     a set / a URL that this schema does not model - those are left to the builder.
 
     Args:
         actions: The manifest's ``actions`` value.
         known_ids: Element ids an action may point at (the layout's zones).
         parameter_names: Declared parameter names (the targets of a parameter action).
+        views: ``{element id: ViewZone}`` - the zones an action may run from or to.
+        field_types: ``{datasource: {field: type}}``, for a parameter action's source field.
         errors: Accumulator for validation errors.
     """
     if not isinstance(actions, list):
@@ -717,11 +935,35 @@ def _validate_actions(
                 f"(expected one of: {', '.join(sorted(ACTION_TYPES))})"
             )
 
+        run_on = str(action.get("run_on", "")).strip().lower()
+        if run_on and run_on not in ACTION_RUN_ON:
+            errors.append(
+                f"{label}: unknown run_on '{run_on}' "
+                f"(expected one of: {', '.join(sorted(ACTION_RUN_ON))})"
+            )
+
         source = str(action.get("source", "")).strip()
         if not source:
             errors.append(f"{label}: needs a 'source' element id")
         elif source not in known_ids:
             errors.append(f"{label}: source '{source}' is not a zone in the layout tree")
+        elif source not in views:
+            errors.append(
+                f"{label}: source '{source}' is not a view - an action runs off the marks "
+                f"the analyst clicks, so its source must be a zone a worksheet fills"
+            )
+        elif action_type == "parameter":
+            source_field = _bare_field(action.get("field"))
+            if not source_field:
+                errors.append(
+                    f"{label}: a parameter action needs a 'field' - the field whose value "
+                    f"the clicked mark writes into the parameter"
+                )
+            elif source_field not in field_types.get(views[source].datasource, {}):
+                errors.append(
+                    f"{label}: field '{source_field}' is not a field of source "
+                    f"'{source}'s datasource '{views[source].datasource}'"
+                )
 
         targets = action.get("targets", [])
         target_names = [
@@ -736,6 +978,11 @@ def _validate_actions(
             elif action_type in {"filter", "highlight"} and target not in known_ids:
                 errors.append(
                     f"{label}: target '{target}' is not a zone in the layout tree"
+                )
+            elif action_type in {"filter", "highlight"} and target not in views:
+                errors.append(
+                    f"{label}: target '{target}' is not a view - a {action_type} action "
+                    f"acts on a worksheet's marks, not on a text or control zone"
                 )
             elif action_type == "parameter" and target not in parameter_names:
                 errors.append(
@@ -771,9 +1018,68 @@ def _validate_parameters(parameters: object, errors: list[str]) -> set[str]:
         elif name in seen:
             errors.append(f"{label}: duplicate parameter name '{name}'")
         seen.add(name)
-        if not str(parameter.get("data_type", "")).strip():
+
+        data_type = str(parameter.get("data_type", "")).strip().lower()
+        if not data_type:
             errors.append(f"{label}: needs a 'data_type' (string/integer/real/boolean/date)")
+        elif data_type not in PARAMETER_DATA_TYPES:
+            errors.append(
+                f"{label}: unknown data_type '{data_type}' "
+                f"(expected one of: {', '.join(sorted(PARAMETER_DATA_TYPES))})"
+            )
+
+        # A parameter has one domain: a member list, a numeric range, or anything. Two
+        # domains would make the control's behaviour depend on which one the builder read.
+        values, span = parameter.get("values"), parameter.get("range")
+        if values is not None and not (isinstance(values, list) and values):
+            errors.append(
+                f"{label}: 'values' must be a non-empty list of the allowed values"
+            )
+        if span is not None:
+            if not (
+                isinstance(span, dict)
+                and isinstance(span.get("min"), (int, float))
+                and isinstance(span.get("max"), (int, float))
+            ):
+                errors.append(f"{label}: 'range' needs numeric 'min' and 'max'")
+            elif values:
+                errors.append(
+                    f"{label}: has both 'values' and 'range' - a parameter's domain is a "
+                    f"member list or a range, not both"
+                )
     return seen
+
+
+def _validate_visibility(
+    bindings: list[tuple[str, str]], manifest_document: dict, errors: list[str]
+) -> None:
+    """Validate every layout node's ``visibility`` field (Dynamic Zone Visibility).
+
+    Tableau shows or hides a zone on a single boolean value, and the builder qualifies that
+    field against the datasource that declares it - so the field has to be a declared
+    *calculated* field of type ``boolean``. A CSV column would need one value per view, which
+    is not something the manifest can promise.
+
+    Args:
+        bindings: ``(path, field name)`` pairs from the layout walk.
+        manifest_document: The whole manifest.
+        errors: Accumulator for validation errors.
+    """
+    if not bindings:
+        return
+    booleans = {
+        str(entry.get("name", "")).strip()
+        for entry in manifest_document.get("calculated_fields") or []
+        if isinstance(entry, dict)
+        and str(entry.get("type", "")).strip().lower() == VISIBILITY_TYPE
+    }
+    for path, field_name in bindings:
+        if field_name not in booleans:
+            errors.append(
+                f"{path}: visibility '{field_name}' is not a declared calculated field of "
+                f"type '{VISIBILITY_TYPE}' (declared boolean: "
+                f"{', '.join(sorted(booleans)) or 'none'})"
+            )
 
 
 def validate_manifest(
@@ -809,7 +1115,9 @@ def validate_manifest(
             f"'{target_tableau_version}' - copy STATE.md's value"
         )
 
-    layout_ids, container_ids = _validate_layout(manifest_document.get("layout"), errors)
+    layout_ids, container_ids, visibility = _validate_layout(
+        manifest_document.get("layout"), errors
+    )
     zone_ids = {
         element_id for element_id in layout_ids
         if not element_id.startswith(INTERACTION_PREFIX)
@@ -829,9 +1137,14 @@ def validate_manifest(
         container_ids, errors
     )
 
+    views = _view_zones(manifest_document.get("worksheets"))
+    field_types = _field_types(manifest_document, data_model_text)
+    parameter_names = _validate_parameters(manifest_document.get("parameters", []), errors)
     filled |= _validate_objects(
-        manifest_document.get("objects", []), zone_ids, container_ids, errors
+        manifest_document.get("objects", []), zone_ids, container_ids, views, field_types,
+        parameter_names, errors,
     )
+    _validate_visibility(visibility, manifest_document, errors)
 
     # A leaf zone nothing fills would build an empty container - the spec mapped it to
     # something, so the translation dropped it.
@@ -843,8 +1156,8 @@ def validate_manifest(
             "filter card / text / image zone)"
         )
 
-    parameter_names = _validate_parameters(manifest_document.get("parameters", []), errors)
     _validate_actions(
-        manifest_document.get("actions", []), zone_ids, parameter_names, errors
+        manifest_document.get("actions", []), zone_ids, parameter_names, views, field_types,
+        errors,
     )
     return errors

--- a/skills/tableau-build/scripts/manifest.py
+++ b/skills/tableau-build/scripts/manifest.py
@@ -59,8 +59,13 @@ CHART_TYPES = frozenset(CHART_SPECS)
 #: the rows shelf, or the second axis (and the whole point of the chart) is missing.
 DUAL_AXIS_TYPES = frozenset({"dual-axis", "combo"})
 
-#: Dashboard action types (the Tableau constructs behind CONTRACT.md §6's vocabulary).
-ACTION_TYPES = frozenset({"filter", "highlight", "parameter", "set", "url"})
+#: Dashboard action types (the Tableau constructs behind CONTRACT.md §6's vocabulary), and
+#: the ones this builder knows the *name* of but emits nothing for. An unemitted type has to
+#: fail validation: accepting it would build a dashboard whose interaction is silently absent,
+#: and CONTRACT.md §6's `drill` - the only term that reaches for a set action - is buildable
+#: as a parameter action instead.
+ACTION_TYPES = frozenset({"filter", "highlight", "parameter"})
+UNBUILDABLE_ACTION_TYPES = frozenset({"set", "url"})
 
 #: Non-worksheet dashboard objects, for layout zones no view fills (a filter card, a title,
 #: a logo, a legend). Every *leaf* zone must be filled by a worksheet or one of these; a
@@ -97,6 +102,15 @@ CARD_FILTER_TYPES = frozenset({"string", "boolean"})
 
 #: The type a Dynamic Zone Visibility field must have - a zone is shown or hidden, nothing else.
 VISIBILITY_TYPE = "boolean"
+
+#: The parameter data type a parameter action may target. Deselecting has to reset the
+#: parameter (:data:`features.CLEAR_VALUE_PREFIX`), or a panel the parameter reveals has
+#: nothing to hide it again and the viewer is stuck - and the reset value's serialization is
+#: only attested for a string. So a non-string target is rejected rather than built without
+#: its reset.
+#: ponytail: lift this the moment a numeric parameter action is saved in Desktop and the
+#: clear-option's type tag read off it - issue #49 carries the exact steps.
+PARAMETER_ACTION_TARGET_TYPE = "string"
 
 # A data-source heading in DATA-MODEL.md: "## Data source: `sales.csv`" -> "sales.csv".
 _DATASOURCE_HEADING = re.compile(
@@ -780,7 +794,7 @@ def _field_types(
 def _validate_objects(
     objects: object, layout_ids: set[str], container_ids: set[str],
     views: dict[str, ViewZone], field_types: dict[str, dict[str, str]],
-    parameter_names: set[str], errors: list[str],
+    parameter_types: dict[str, str], errors: list[str],
 ) -> set[str]:
     """Validate the non-worksheet dashboard objects and return the zones they fill.
 
@@ -791,7 +805,7 @@ def _validate_objects(
             their own - CONTRACT.md §1.1).
         views: ``{element id: ViewZone}`` - the sheets a filter card may filter.
         field_types: ``{datasource: {field: type}}``.
-        parameter_names: The declared parameter names.
+        parameter_types: ``{declared parameter name: data type}``.
         errors: Accumulator for validation errors.
 
     Returns:
@@ -831,11 +845,11 @@ def _validate_objects(
             )
         elif kind == "parameter":
             parameter = str(dashboard_object.get("parameter", "")).strip()
-            if parameter not in parameter_names:
+            if parameter not in parameter_types:
                 errors.append(
                     f"{label}: 'parameter' is {parameter or 'missing'} - a parameter control "
                     f"names one declared parameter (declared: "
-                    f"{', '.join(sorted(parameter_names)) or 'none'})"
+                    f"{', '.join(sorted(parameter_types)) or 'none'})"
                 )
     return filled
 
@@ -894,7 +908,7 @@ def _validate_filter_card(
 
 
 def _validate_actions(
-    actions: object, known_ids: set[str], parameter_names: set[str],
+    actions: object, known_ids: set[str], parameter_types: dict[str, str],
     views: dict[str, ViewZone], field_types: dict[str, dict[str, str]],
     errors: list[str],
 ) -> None:
@@ -902,14 +916,15 @@ def _validate_actions(
 
     The **source** is always a *view* zone: an action runs off the marks the analyst clicks,
     and a text or filter zone has none. What a **target** is depends on the type: ``filter`` /
-    ``highlight`` target other view zones, a ``parameter`` action targets a declared parameter
-    (and needs the ``field`` whose value it writes there), and ``set`` / ``url`` actions target
-    a set / a URL that this schema does not model - those are left to the builder.
+    ``highlight`` target other view zones, and a ``parameter`` action targets a declared
+    parameter (and needs the ``field`` whose value it writes there). ``set`` / ``url`` are
+    rejected outright - see :data:`UNBUILDABLE_ACTION_TYPES`.
 
     Args:
         actions: The manifest's ``actions`` value.
         known_ids: Element ids an action may point at (the layout's zones).
-        parameter_names: Declared parameter names (the targets of a parameter action).
+        parameter_types: ``{declared parameter name: data type}`` - a parameter action's
+            targets, and the types :data:`PARAMETER_ACTION_TARGET_TYPE` is checked against.
         views: ``{element id: ViewZone}`` - the zones an action may run from or to.
         field_types: ``{datasource: {field: type}}``, for a parameter action's source field.
         errors: Accumulator for validation errors.
@@ -929,7 +944,13 @@ def _validate_actions(
             errors.append(f"{label}: needs a 'name'")
 
         action_type = str(action.get("type", "")).strip().lower()
-        if action_type not in ACTION_TYPES:
+        if action_type in UNBUILDABLE_ACTION_TYPES:
+            errors.append(
+                f"{label}: '{action_type}' actions are not emitted by this builder - a "
+                f"dashboard that needs one would open with the interaction missing. Express "
+                f"a drill as a 'parameter' action (CONTRACT.md section 6) instead"
+            )
+        elif action_type not in ACTION_TYPES:
             errors.append(
                 f"{label}: unknown action type '{action_type}' "
                 f"(expected one of: {', '.join(sorted(ACTION_TYPES))})"
@@ -984,24 +1005,37 @@ def _validate_actions(
                     f"{label}: target '{target}' is not a view - a {action_type} action "
                     f"acts on a worksheet's marks, not on a text or control zone"
                 )
-            elif action_type == "parameter" and target not in parameter_names:
+            elif action_type == "parameter" and target not in parameter_types:
                 errors.append(
                     f"{label}: target '{target}' is not a declared parameter "
-                    f"(declared: {', '.join(sorted(parameter_names)) or 'none'})"
+                    f"(declared: {', '.join(sorted(parameter_types)) or 'none'})"
+                )
+            elif (
+                action_type == "parameter"
+                and parameter_types[target] != PARAMETER_ACTION_TARGET_TYPE
+            ):
+                errors.append(
+                    f"{label}: target parameter '{target}' is "
+                    f"'{parameter_types[target]}' - a parameter action's target must be "
+                    f"'{PARAMETER_ACTION_TARGET_TYPE}', because only a string's reset value "
+                    f"has an attested serialization and without the reset a zone the "
+                    f"parameter reveals never hides again. Declare it as "
+                    f"'{PARAMETER_ACTION_TARGET_TYPE}' with a 'values' domain"
                 )
 
 
-def _validate_parameters(parameters: object, errors: list[str]) -> set[str]:
-    """Validate the parameters' names, types, and uniqueness.
+def _validate_parameters(parameters: object, errors: list[str]) -> dict[str, str]:
+    """Validate the parameters' names, types, current values, and uniqueness.
 
     Args:
         parameters: The manifest's ``parameters`` value.
         errors: Accumulator for validation errors.
 
     Returns:
-        The declared parameter names (what a parameter action may target).
+        ``{declared parameter name: data type}`` - what a parameter action or a parameter
+        control may target, and the type each one has.
     """
-    seen: set[str] = set()
+    seen: dict[str, str] = {}
     if not isinstance(parameters, list):
         errors.append("parameters: must be a list (use [] when the dashboard has none)")
         return seen
@@ -1017,15 +1051,23 @@ def _validate_parameters(parameters: object, errors: list[str]) -> set[str]:
             errors.append(f"{label}: needs a 'name'")
         elif name in seen:
             errors.append(f"{label}: duplicate parameter name '{name}'")
-        seen.add(name)
 
         data_type = str(parameter.get("data_type", "")).strip().lower()
+        seen[name] = data_type
         if not data_type:
             errors.append(f"{label}: needs a 'data_type' (string/integer/real/boolean/date)")
         elif data_type not in PARAMETER_DATA_TYPES:
             errors.append(
                 f"{label}: unknown data_type '{data_type}' "
                 f"(expected one of: {', '.join(sorted(PARAMETER_DATA_TYPES))})"
+            )
+
+        # A parameter *is* its current value: the value is the column's calculation, so
+        # without one the control opens on nothing and every calc reading it is undefined.
+        if parameter.get("current_value") is None:
+            errors.append(
+                f"{label}: needs a 'current_value' - the value the parameter opens on, and "
+                f"the value a parameter action resets it to"
             )
 
         # A parameter has one domain: a member list, a numeric range, or anything. Two
@@ -1139,10 +1181,10 @@ def validate_manifest(
 
     views = _view_zones(manifest_document.get("worksheets"))
     field_types = _field_types(manifest_document, data_model_text)
-    parameter_names = _validate_parameters(manifest_document.get("parameters", []), errors)
+    parameter_types = _validate_parameters(manifest_document.get("parameters", []), errors)
     filled |= _validate_objects(
         manifest_document.get("objects", []), zone_ids, container_ids, views, field_types,
-        parameter_names, errors,
+        parameter_types, errors,
     )
     _validate_visibility(visibility, manifest_document, errors)
 
@@ -1157,7 +1199,7 @@ def validate_manifest(
         )
 
     _validate_actions(
-        manifest_document.get("actions", []), zone_ids, parameter_names, views, field_types,
+        manifest_document.get("actions", []), zone_ids, parameter_types, views, field_types,
         errors,
     )
     return errors

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -554,7 +554,7 @@ def _plan_actions(
         kind = str(entry.get("type", "")).strip().lower()
         source = by_element.get(str(entry.get("source", "")).strip())
         if source is None or not (kind in features.ACTION_COMMANDS or kind == "parameter"):
-            continue  # 'set' / 'url' actions are vocabulary this builder does not emit yet
+            continue  # validate_manifest has already named this entry
         activation = features.ACTIVATIONS.get(
             str(entry.get("run_on", "")).strip().lower(), "on-select"
         )

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -30,9 +30,10 @@ from __future__ import annotations
 import hashlib
 import uuid
 import xml.etree.ElementTree as ET
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import NamedTuple
 
+import features
 import worksheet
 import zones
 from manifest import documented_field_types
@@ -179,6 +180,22 @@ def object_id(datasource_name: str, csv_name: str) -> str:
     return f"{csv_name}_{_hashed(f'obj:{datasource_name}:{csv_name}').upper()}"
 
 
+def action_name(index: int, seed: str) -> str:
+    """Return the ``name`` attribute of one dashboard action.
+
+    Tableau's own shape is ``[Action<n>_<32 upper-case hex>]``. The index makes it unique
+    even for two actions with the same caption and target; the hash makes it stable.
+
+    Args:
+        index: The action's 1-based position among all the workbook's actions.
+        seed: What the action does (its caption and endpoints).
+
+    Returns:
+        The bracketed action name.
+    """
+    return f"[Action{index}_{_hashed(f'action:{seed}')[:32].upper()}]"
+
+
 def simple_id(kind: str, name: str) -> str:
     """Return the braced, upper-case UUID a ``<simple-id>`` carries.
 
@@ -305,7 +322,8 @@ def _render_metadata_records(
 
 def _render_datasource(
     parent: ET.Element, name: str, csv_name: str, columns: list[Column], version: str,
-    derived: list[worksheet.FieldRef],
+    derived: list[worksheet.FieldRef], instances: list[worksheet.FieldRef],
+    parameters: list[features.Parameter],
 ) -> None:
     """Render one inline, live-connection datasource over a single CSV.
 
@@ -318,6 +336,11 @@ def _render_datasource(
         derived: Calculated and binned columns the worksheets introduce. They are not in
             the CSV, so they appear only among the UI-level columns - but they must appear
             *here* as well as in each worksheet, or Tableau drops them on save.
+        instances: Column-instances the datasource itself must declare. Only table calcs
+            need this: the calc lives on the instance, and a datasource that does not carry
+            it loses the field from the data pane on save.
+        parameters: Parameters this datasource's own calculations read - the datasource
+            declares the dependency, domain-less, the way Desktop writes it.
     """
     datasource = ET.SubElement(parent, "datasource", {
         "caption": name,
@@ -359,10 +382,21 @@ def _render_datasource(
         })
     for reference in derived:
         worksheet.render_column(datasource, reference)
+    for reference in instances:
+        worksheet.render_column_instance(datasource, reference)
     ET.SubElement(datasource, "layout", {
         "dim-ordering": "alphabetic", "measure-ordering": "alphabetic",
         "show-structure": "true",
     })
+    if parameters:
+        # A calculation here reads [Parameters].[x], so the datasource declares that
+        # dependency itself - between <layout> and <object-graph>, where Desktop writes it.
+        dependencies = ET.SubElement(
+            datasource, "datasource-dependencies",
+            {"datasource": features.PARAMETERS_DATASOURCE},
+        )
+        for parameter in parameters:
+            features.render_parameter_column(dependencies, parameter, with_domain=False)
 
     object_graph = ET.SubElement(datasource, "object-graph")
     objects = ET.SubElement(object_graph, "objects")
@@ -371,6 +405,214 @@ def _render_datasource(
     })
     properties = ET.SubElement(graph_object, "properties", {"context": ""})
     _render_relation(properties, name, csv_name, columns)          # location 3
+
+
+# --- Interactions (CONTRACT.md §6) ---------------------------------------------
+
+@dataclass
+class Interactions:
+    """Everything the manifest's ``objects`` and ``actions`` add to the workbook.
+
+    Resolved in one pass because the four outputs are the same few facts seen from different
+    elements: a quick filter is a zone *and* a worksheet filter *and* a dashboard-level
+    declaration, and an action is only renderable once every element id has been turned into
+    the sheet name Tableau addresses it by.
+
+    Attributes:
+        leaves: ``{element id: Leaf}`` for the control zones (filter cards, parameter
+            controls) - merged into the dashboard's leaf map.
+        declarations: ``{datasource name: [FieldRef]}`` - the fields a filter card needs the
+            *dashboard* to declare as well as the worksheet.
+        controlled_parameters: The parameters a control zone puts on the dashboard - the only
+            ones the dashboard declares. A parameter a *sheet* reads is that sheet's business
+            (Desktop drops it from the dashboard's declarations on save).
+        sheet_actions: The filter / highlight actions.
+        parameter_actions: The parameter actions.
+    """
+
+    leaves: dict[str, zones.Leaf] = field(default_factory=dict)
+    declarations: dict[str, list[worksheet.FieldRef]] = field(default_factory=dict)
+    controlled_parameters: list[features.Parameter] = field(default_factory=list)
+    sheet_actions: list[features.SheetAction] = field(default_factory=list)
+    parameter_actions: list[features.ParameterAction] = field(default_factory=list)
+
+
+def _plan_interactions(
+    manifest_document: dict,
+    plans: list[PlannedWorksheet],
+    parameters: list[features.Parameter],
+) -> Interactions:
+    """Resolve the manifest's control objects and actions against the planned worksheets.
+
+    Mutates the worksheet plans: a quick filter injects the filter it is the UI for, and a
+    parameter action's source field is added to the sheet's declared fields (an action
+    referencing an instance the worksheet never declared is one Tableau drops).
+
+    Args:
+        manifest_document: The parsed build manifest.
+        plans: The resolved worksheets (mutated).
+        parameters: The resolved parameters.
+
+    Returns:
+        The :class:`Interactions`.
+    """
+    interactions = Interactions()
+    by_element = {
+        str(planned.entry.get("element_id", "")).strip(): planned
+        for planned in plans if str(planned.entry.get("element_id", "")).strip()
+    }
+    by_sheet = {planned.plan.name: planned for planned in plans}
+    by_parameter = {parameter.name: parameter for parameter in parameters}
+
+    for entry in manifest_document.get("objects") or []:
+        if not isinstance(entry, dict):
+            continue
+        element_id = str(entry.get("element_id", "")).strip()
+        kind = str(entry.get("kind", "")).strip().lower()
+        if kind == "filter":
+            _plan_quick_filter(entry, element_id, by_sheet, interactions)
+        elif kind == "parameter":
+            parameter = by_parameter.get(str(entry.get("parameter", "")).strip())
+            if parameter is not None:
+                interactions.leaves[element_id] = zones.Leaf(
+                    kind=kind, param=parameter.reference,
+                    # The widget follows the domain: Desktop writes 'slider' for a range and
+                    # 'compact' for a member list, and rewrites the workbook otherwise.
+                    mode="slider" if parameter.domain_type == "range" else "compact",
+                    title=str(entry.get("title", "") or "").strip(),
+                )
+                interactions.controlled_parameters.append(parameter)
+
+    _plan_actions(manifest_document.get("actions") or [], by_element, by_parameter,
+                  interactions)
+    return interactions
+
+
+def _plan_quick_filter(
+    entry: dict, element_id: str, by_sheet: dict[str, PlannedWorksheet],
+    interactions: Interactions,
+) -> None:
+    """Resolve one filter card: its zone, its worksheet filter, and its declaration.
+
+    A card is injected into the *named* worksheet only. "Apply to all sheets using this data
+    source" is a Desktop-side choice the analyst makes on the built workbook - a manifest that
+    wants two sheets filtered declares two cards.
+
+    Args:
+        entry: The manifest ``objects`` entry.
+        element_id: The zone the card fills.
+        by_sheet: ``{sheet name: PlannedWorksheet}``.
+        interactions: The accumulator (mutated).
+    """
+    planned = by_sheet.get(str(entry.get("worksheet", "")).strip())
+    field_name = str(entry.get("field", "")).strip()
+    if planned is None or not field_name:
+        return  # validate_manifest has already named this entry
+    reference = planned.plan.resolver.reference(field_name)
+    if reference is None:
+        return
+
+    interactions.leaves[element_id] = zones.Leaf(
+        kind="filter",
+        param=planned.plan.reference_of(reference),
+        sheet=planned.plan.name,
+        mode=str(entry.get("mode", "")).strip(),
+        title=str(entry.get("title", "") or "").strip(),
+    )
+    # The card is the UI for a worksheet filter; without the filter there is nothing to
+    # control. A filter the manifest already declared on that field stays as it is - an
+    # explicit member list is a narrower filter than "all members", not a duplicate.
+    already_filtered = any(
+        existing.reference.instance_name == reference.instance_name
+        for existing in planned.plan.filters
+    )
+    if not already_filtered:
+        planned.plan.filters.append(
+            worksheet.FilterPlan(reference=reference, all_members=True)
+        )
+    interactions.declarations.setdefault(planned.datasource, []).append(reference)
+
+
+def _plan_actions(
+    entries: list, by_element: dict[str, PlannedWorksheet],
+    by_parameter: dict[str, features.Parameter], interactions: Interactions,
+) -> None:
+    """Resolve the manifest's actions into renderable ones, numbering them as it goes.
+
+    Args:
+        entries: The manifest's ``actions`` list.
+        by_element: ``{element id: PlannedWorksheet}`` - how an action's endpoints become
+            the sheet names Tableau addresses.
+        by_parameter: ``{parameter name: Parameter}``.
+        interactions: The accumulator (mutated).
+    """
+    index = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        caption = str(entry.get("name", "")).strip()
+        kind = str(entry.get("type", "")).strip().lower()
+        source = by_element.get(str(entry.get("source", "")).strip())
+        if source is None or not (kind in features.ACTION_COMMANDS or kind == "parameter"):
+            continue  # 'set' / 'url' actions are vocabulary this builder does not emit yet
+        activation = features.ACTIVATIONS.get(
+            str(entry.get("run_on", "")).strip().lower(), "on-select"
+        )
+        targets = entry.get("targets")
+        for target in targets if isinstance(targets, list) else [targets]:
+            target_name = str(target or "").strip()
+            index += 1
+            name = action_name(index, f"{caption}:{target_name}")
+            if kind == "parameter":
+                parameter = by_parameter.get(target_name)
+                reference = source.plan.resolver.reference(
+                    str(entry.get("field", "")).strip()
+                )
+                if parameter is None or reference is None:
+                    continue
+                # The action reads a field off the clicked mark, so the sheet has to declare
+                # it even when it is not on a shelf.
+                source.plan.declared.append(reference)
+                interactions.parameter_actions.append(features.ParameterAction(
+                    name=name, caption=caption, source=source.plan.name,
+                    source_field=source.plan.reference_of(reference),
+                    target_parameter=parameter.reference,
+                    clear_value=parameter.clear_value, activation=activation,
+                ))
+                continue
+            target_planned = by_element.get(target_name)
+            if target_planned is None:
+                continue
+            interactions.sheet_actions.append(features.SheetAction(
+                name=name, caption=caption, kind=kind, source=source.plan.name,
+                target=target_planned.plan.name, activation=activation,
+            ))
+
+
+def _parameters_read_by(
+    references: list[worksheet.FieldRef], parameters: list[features.Parameter]
+) -> list[features.Parameter]:
+    """Return the parameters any of the given fields' formulas reference, in declared order."""
+    formulas = " ".join(
+        reference.formula for reference in references if reference.formula
+    )
+    return [parameter for parameter in parameters if parameter.reference in formulas]
+
+
+def _attach_parameters(
+    plans: list[PlannedWorksheet], parameters: list[features.Parameter]
+) -> None:
+    """Give each worksheet the parameters its calculations read.
+
+    A calculated field's formula is the only place a worksheet can reference a parameter, so
+    the formulas are what decide it - no manifest key to keep in sync.
+
+    Args:
+        plans: The resolved worksheets (mutated).
+        parameters: The resolved parameters.
+    """
+    for planned in plans:
+        planned.plan.parameters = _parameters_read_by(planned.plan.all_refs, parameters)
 
 
 # --- Worksheets, dashboard, windows --------------------------------------------
@@ -432,7 +674,8 @@ def _render_dashboard(
     root: object,
     leaves: dict[str, zones.Leaf],
     tokens: worksheet.DesignTokens,
-) -> tuple[str, set[str]]:
+    interactions: Interactions,
+) -> zones.RenderedZones:
     """Render the dashboard: range-sized above a fixed floor, with the spec's zone tree.
 
     Args:
@@ -442,11 +685,13 @@ def _render_dashboard(
         root: The layout tree's ``root`` node.
         leaves: ``{element id: Leaf}`` - what fills each leaf zone.
         tokens: The design tokens, for the generated title zones.
+        interactions: The resolved control objects - what the dashboard must declare,
+            parameter controls included.
 
     Returns:
-        ``(root zone id, embedded sheet names)``. The root id is the dashboard window's
-        ``active`` target; :func:`_render_windows` hides exactly the embedded sheets, so a
-        sheet that is embedded nowhere keeps its tab instead of becoming unreachable.
+        The :class:`zones.RenderedZones`. The root id is the dashboard window's ``active``
+        target; :func:`_render_windows` hides exactly the embedded sheets, so a sheet that is
+        embedded nowhere keeps its tab instead of becoming unreachable.
     """
     dashboard = ET.SubElement(parent, "dashboard", {
         "enable-sort-zone-taborder": "true", "name": DASHBOARD_NAME,
@@ -463,7 +708,8 @@ def _render_dashboard(
         "minheight": str(MIN_DASHBOARD_HEIGHT), "minwidth": str(MIN_DASHBOARD_WIDTH),
         "sizing-mode": "range",
     })
-    root_zone_id, embedded = zones.render_zones(
+    _render_dashboard_declarations(dashboard, interactions)
+    rendered = zones.render_zones(
         ET.SubElement(dashboard, "zones"),
         root if isinstance(root, dict) else {"type": "vert", "children": []},
         {"width": int(width), "height": int(height)},
@@ -471,7 +717,52 @@ def _render_dashboard(
         tokens,
     )
     ET.SubElement(dashboard, "simple-id", {"uuid": simple_id("dashboard", DASHBOARD_NAME)})
-    return root_zone_id, embedded
+    return rendered
+
+
+def _render_dashboard_declarations(
+    dashboard: ET.Element, interactions: Interactions,
+) -> None:
+    """Declare the datasources and fields the dashboard's own control zones read.
+
+    A filter card or a parameter control is evaluated by the *dashboard*, not by the sheet it
+    filters, so a card whose field only the worksheet declares crashes Tableau on open. The
+    blocks go between ``<size>`` and ``<zones>`` - the XSD's order.
+
+    Args:
+        dashboard: The ``<dashboard>`` element.
+        interactions: The resolved control objects, including the parameters its control zones
+            put on the dashboard - the only parameters declared here.
+    """
+    if not (interactions.declarations or interactions.controlled_parameters):
+        return
+    declared = ET.SubElement(dashboard, "datasources")
+    for name in sorted(interactions.declarations):
+        ET.SubElement(
+            declared, "datasource", {"caption": name, "name": datasource_id(name)}
+        )
+    if interactions.controlled_parameters:
+        ET.SubElement(declared, "datasource", {"name": features.PARAMETERS_DATASOURCE})
+
+    for name in sorted(interactions.declarations):
+        dependencies = ET.SubElement(
+            dashboard, "datasource-dependencies", {"datasource": datasource_id(name)}
+        )
+        by_instance = {
+            reference.instance_name: reference
+            for reference in interactions.declarations[name]
+        }
+        for instance_name in sorted(by_instance):
+            reference = by_instance[instance_name]
+            worksheet.render_column(dependencies, reference)
+            worksheet.render_column_instance(dependencies, reference)
+    if interactions.controlled_parameters:
+        dependencies = ET.SubElement(
+            dashboard, "datasource-dependencies",
+            {"datasource": features.PARAMETERS_DATASOURCE},
+        )
+        for parameter in interactions.controlled_parameters:
+            features.render_parameter_column(dependencies, parameter)
 
 
 def _render_windows(
@@ -567,7 +858,7 @@ def _build_resolvers(
         ``{datasource name: resolver}``. Each resolver knows the datasource's federated id,
         its CSV's field types, and its calculated fields' formulas.
     """
-    calculated: dict[str, dict[str, tuple[str, str]]] = {}
+    calculated: dict[str, dict[str, worksheet.CalculatedField]] = {}
     for entry in manifest_document.get("calculated_fields", []) or []:
         if not isinstance(entry, dict):
             continue
@@ -576,9 +867,10 @@ def _build_resolvers(
         if not (name and source):
             continue
         # No 'type' means a numeric result - the overwhelmingly common calculated field.
-        calculated.setdefault(source, {})[name] = (
-            str(entry.get("formula", "")).strip(),
-            str(entry.get("type", "")).strip().lower() or "real",
+        calculated.setdefault(source, {})[name] = worksheet.CalculatedField(
+            formula=str(entry.get("formula", "")).strip(),
+            datatype=str(entry.get("type", "")).strip().lower() or "real",
+            number_format=str(entry.get("format", "")).strip(),
         )
 
     # The resolver only needs the role and the UI type from each DATA-MODEL.md type; passing
@@ -680,6 +972,121 @@ def _collect_derived_columns(
     return {source: list(columns.values()) for source, columns in derived.items()}
 
 
+def _collect_table_calc_instances(
+    plans: list[PlannedWorksheet],
+) -> dict[str, list[worksheet.FieldRef]]:
+    """Collect the table-calc column-instances each datasource must declare.
+
+    Args:
+        plans: The resolved worksheets.
+
+    Returns:
+        ``{datasource name: [FieldRef]}``, de-duplicated by instance name and in a stable
+        order. A plain instance is not included: only a table calc carries state (its type and
+        addressing) that the datasource has to remember.
+    """
+    instances: dict[str, dict[str, worksheet.FieldRef]] = {}
+    for planned in plans:
+        for reference in planned.plan.all_refs:
+            if reference.table_calc:
+                instances.setdefault(planned.datasource, {}).setdefault(
+                    reference.instance_name, reference
+                )
+    return {source: list(found.values()) for source, found in instances.items()}
+
+
+def _plan_zone_visibility(
+    manifest_document: dict, controlled: dict[str, str]
+) -> list[features.ZoneVisibility]:
+    """Qualify each ``visibility`` field against the datasource that declares it.
+
+    Args:
+        manifest_document: The parsed build manifest.
+        controlled: ``{zone id: calculated field name}`` from the layout walk.
+
+    Returns:
+        One :class:`features.ZoneVisibility` per controlled zone, in zone order. A field no
+        ``calculated_fields`` entry declares is dropped - ``validate_manifest`` has already
+        named it, and a datagraph pointing at a field Tableau cannot find hides the zone for
+        good.
+    """
+    owner: dict[str, str] = {}
+    for entry in manifest_document.get("calculated_fields") or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name", "")).strip()
+        source = str(entry.get("datasource", "")).strip()
+        if name and source:
+            owner.setdefault(name, source)
+
+    visibilities: list[features.ZoneVisibility] = []
+    for zone_id in sorted(controlled, key=int):
+        field_name = controlled[zone_id]
+        source = owner.get(field_name)
+        if source:
+            visibilities.append(features.ZoneVisibility(
+                zone_id=zone_id, field=f"[{datasource_id(source)}].[{field_name}]"
+            ))
+    return visibilities
+
+
+def _visibility_requests(node: object) -> list[tuple[dict, str]]:
+    """Collect ``(layout node, field name)`` for every node carrying a ``visibility`` key."""
+    if not isinstance(node, dict):
+        return []
+    requests = []
+    field_name = str(node.get("visibility", "") or "").strip()
+    if field_name:
+        requests.append((node, field_name))
+    for child in node.get("children") or []:
+        requests.extend(_visibility_requests(child))
+    return requests
+
+
+def _element_ids(node: dict) -> list[str]:
+    """Return the node's own element id first, then its descendants' - the search order."""
+    ids = []
+    element_id = str(node.get("id", "") or "").strip()
+    if element_id:
+        ids.append(element_id)
+    for child in node.get("children") or []:
+        if isinstance(child, dict):
+            ids.extend(_element_ids(child))
+    return ids
+
+
+def _attach_visibility_fields(layout: dict, plans: list[PlannedWorksheet]) -> None:
+    """Put every zone-visibility field on the Detail shelf of a sheet that can resolve it.
+
+    Dynamic Zone Visibility evaluates the field off the *view*: a boolean no sheet in the
+    dashboard places is one Tableau cannot read, and the zone silently never toggles - the
+    ``<datagraph>`` alone is not enough. A Desktop-saved DZV workbook puts the field on the
+    controlled sheet's Detail shelf, so that is the sheet preferred here; a controlled
+    container (or a controlled object zone) falls back to any sheet on the field's datasource,
+    which is all Tableau needs to evaluate it.
+
+    Args:
+        layout: The manifest's ``layout`` value.
+        plans: The resolved worksheets (mutated).
+    """
+    by_element = {
+        str(planned.entry.get("element_id", "")).strip(): planned
+        for planned in plans if str(planned.entry.get("element_id", "")).strip()
+    }
+    for node, field_name in _visibility_requests(layout.get("root")):
+        candidates = [by_element[element_id] for element_id in _element_ids(node)
+                      if element_id in by_element]
+        candidates += [planned for planned in plans if planned not in candidates]
+        for planned in candidates:
+            reference = planned.plan.resolver.reference(field_name)
+            if reference is None:
+                continue
+            if not any(existing.instance_name == reference.instance_name
+                       for existing in planned.plan.detail):
+                planned.plan.detail.append(reference)
+            break
+
+
 def render_workbook(
     manifest_document: dict,
     data_model_text: str,
@@ -715,21 +1122,52 @@ def render_workbook(
         "xmlns:user": "http://www.tableausoftware.com/xml/user",
     })
 
-    worksheet_entries = manifest_document.get("worksheets") or []
-    flags = FORMAT_CHANGE_FLAGS
-    if any(entry.get("sort") for entry in worksheet_entries):
-        flags = tuple(sorted(flags + (SORT_FORMAT_FLAG,)))
-
-    format_manifest = ET.SubElement(workbook, "document-format-change-manifest")
-    for flag in flags:
-        ET.SubElement(format_manifest, flag)
-
     field_types = documented_field_types(data_model_text)
     resolvers = _build_resolvers(manifest_document, field_types)
     plans = _plan_worksheets(manifest_document, resolvers)
+    parameters = features.plan_parameters(manifest_document.get("parameters"))
+    layout = manifest_document.get("layout")
+    if not isinstance(layout, dict):
+        layout = {}
+
+    interactions = _plan_interactions(manifest_document, plans, parameters)
+    # Before _attach_parameters: a visibility field's formula reads a parameter, and the sheet
+    # it lands on has to declare that parameter or Tableau cannot resolve the calculation.
+    _attach_visibility_fields(layout, plans)
+    _attach_parameters(plans, parameters)
     derived = _collect_derived_columns(manifest_document, resolvers, plans)
 
+    # The zone tree is rendered into a detached element first: whether the workbook carries a
+    # <datagraph> (and its four format flags) is only known once the layout has been walked,
+    # and the format manifest is the workbook's *first* child.
+    dashboards = ET.Element("dashboards")
+    rendered = _render_dashboard(
+        dashboards,
+        layout.get("canvas", {}),
+        layout.get("root"),
+        {
+            **_dashboard_leaves(plans, manifest_document.get("objects", [])),
+            **interactions.leaves,
+        },
+        tokens,
+        interactions,
+    )
+    visibilities = _plan_zone_visibility(manifest_document, rendered.visibility)
+
+    worksheet_entries = manifest_document.get("worksheets") or []
+    flags = FORMAT_CHANGE_FLAGS
+    if any(entry.get("sort") for entry in worksheet_entries):
+        flags = flags + (SORT_FORMAT_FLAG,)
+    if visibilities:
+        flags = flags + features.DZV_FORMAT_FLAGS
+    if interactions.parameter_actions:
+        flags = flags + features.PARAMETER_ACTION_FORMAT_FLAGS
+    format_manifest = ET.SubElement(workbook, "document-format-change-manifest")
+    for flag in sorted(flags):  # Tableau writes them alphabetically
+        ET.SubElement(format_manifest, flag)
+
     datasources = ET.SubElement(workbook, "datasources")
+    table_calcs = _collect_table_calc_instances(plans)
     for entry in manifest_document.get("datasources", []):
         csv_name = str(entry.get("csv", "")).strip()
         name = str(entry.get("name", "")).strip()
@@ -740,7 +1178,10 @@ def render_workbook(
             _columns_for(csv_headers.get(csv_name, []), field_types.get(csv_name, {})),
             version,
             derived.get(name, []),
+            table_calcs.get(name, []),
+            _parameters_read_by(derived.get(name, []), parameters),
         )
+    features.render_parameters_datasource(datasources, parameters, version)
 
     if any(planned.plan.spec.geographic for planned in plans):
         # A map needs its <mapsources> at *both* levels: the workbook's declares the source,
@@ -748,6 +1189,11 @@ def render_workbook(
         ET.SubElement(
             ET.SubElement(workbook, "mapsources"), "mapsource", {"name": worksheet.MAPSOURCE_NAME}
         )
+
+    features.render_actions(
+        workbook, DASHBOARD_NAME, interactions.sheet_actions,
+        interactions.parameter_actions,
+    )
 
     if plans:  # the XSD requires >=1 <worksheet>; omit the element otherwise
         worksheets = ET.SubElement(workbook, "worksheets")
@@ -757,18 +1203,13 @@ def render_workbook(
                 simple_id("worksheet", planned.plan.name),
             )
 
-    layout = manifest_document.get("layout")
-    if not isinstance(layout, dict):
-        layout = {}
-    root_zone_id, embedded = _render_dashboard(
-        ET.SubElement(workbook, "dashboards"),
-        layout.get("canvas", {}),
-        layout.get("root"),
-        _dashboard_leaves(plans, manifest_document.get("objects", [])),
-        tokens,
-    )
+    workbook.append(dashboards)
     _render_windows(
-        workbook, [planned.plan for planned in plans], root_zone_id, embedded
+        workbook, [planned.plan for planned in plans], rendered.root_zone_id,
+        rendered.embedded,
+    )
+    features.render_datagraph(
+        workbook, visibilities, simple_id("dashboard", DASHBOARD_NAME)
     )
 
     if target == TARGET_2026:

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -22,7 +22,11 @@ from __future__ import annotations
 import re
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import NamedTuple, Optional
+
+# A worksheet that reads a parameter has to declare it; :mod:`features` owns what a parameter
+# column looks like and imports nothing back, so no cycle.
+from features import PARAMETERS_DATASOURCE, Parameter, render_parameter_column
 
 # --- CDATA -------------------------------------------------------------------
 # ponytail: ElementTree cannot emit CDATA, and Tableau *requires* it around field
@@ -191,8 +195,40 @@ def is_aggregate_formula(formula: str) -> bool:
         True when the formula calls an aggregate function, so the field must reach a shelf
         un-aggregated. A row-level formula (``[quantity] * [unit_price]``) returns False and
         is treated like any other measure.
+
+    An **LOD expression** (``{FIXED [region]: SUM([revenue])}``) returns False even though it
+    contains ``SUM(``: an LOD produces one row-level value per its own grain, so Tableau
+    aggregates it again on the shelf (``SUM([Regional Revenue])``). Treating it as
+    pre-aggregated is what put the ``User`` derivation on it and made the shelf read one
+    arbitrary member's value.
     """
-    return bool(formula) and _AGGREGATE_CALL.search(formula) is not None
+    if not formula or "{" in formula:
+        return False
+    return _AGGREGATE_CALL.search(formula) is not None
+
+
+#: manifest ``table_calc`` -> the column-instance name's extra prefix. The keys are the
+#: XSD's ``TCType-ST`` enumeration (minus ``None``, which is "no table calc"); the prefixes
+#: are cosmetic identifiers - ``cum:sum:revenue:qk`` is what Tableau writes for a running
+#: total, and ``manifest.TABLE_CALCS`` reads this table so an unknown type fails validation
+#: rather than rendering a calc Tableau does not have.
+#: ponytail: only ``PctTotal`` -> ``pcto`` is attested (Desktop 2025.1 renamed ours on save).
+#: The rest are inferred; a wrong one costs nothing but a rewrite on open, and is fixed by
+#: reading the name out of a Desktop-saved workbook that uses that calc.
+TABLE_CALC_PREFIXES: dict[str, str] = {
+    "CumTotal": "cum",
+    "WindowTotal": "wnd",
+    "Difference": "diff",
+    "PctDiff": "pctdiff",
+    "PctValue": "pctval",
+    "PctTotal": "pcto",
+    "Rank": "rank",
+    "PctRank": "pctrank",
+}
+
+#: How a table calc walks the view. ``Rows`` is Tableau's default "Table (across)" addressing
+#: - the one a running total or percent-of-total means on a normal chart.
+TABLE_CALC_ORDERING = "Rows"
 
 
 #: manifest date_part -> (prefix, derivation). ``date`` is the exact date: no truncation,
@@ -233,6 +269,22 @@ def caption_for(field_name: str) -> str:
     return field_name.replace("_", " ").title()
 
 
+class CalculatedField(NamedTuple):
+    """One declared calculated field, as the resolver needs it.
+
+    Attributes:
+        formula: The Tableau formula.
+        datatype: The result's type (``real`` when the manifest declares none).
+        number_format: A ``default-format`` pattern for the column, or ``""``. Set on the
+            *column* rather than as a worksheet style rule, so every sheet that uses the
+            field - and the data pane - shows it the same way.
+    """
+
+    formula: str
+    datatype: str
+    number_format: str = ""
+
+
 @dataclass(frozen=True)
 class FieldRef:
     """One resolved shelf/encoding entry: the column, its instance, and how to name both.
@@ -246,8 +298,12 @@ class FieldRef:
         prefix: The instance-name prefix (``sum``, ``tmn``, ``none``, ...).
         derivation: The instance's ``derivation`` attribute.
         formula: A calculated field's formula, else ``""``.
+        number_format: A calculated field's ``default-format`` pattern, else ``""``.
         bin_size: Bin width when the entry asked for a binned column, else ``None``.
         bin_source: The measure a bin is computed from, else ``""``.
+        table_calc: A :data:`TABLE_CALC_PREFIXES` key when the entry asked for a table
+            calculation, else ``""``. A table calc lives on the *instance*, not on a column
+            of its own - the same measure can be plain on one shelf and cumulative on another.
     """
 
     field_name: str
@@ -258,8 +314,10 @@ class FieldRef:
     prefix: str
     derivation: str
     formula: str = ""
+    number_format: str = ""
     bin_size: Optional[float] = None
     bin_source: str = ""
+    table_calc: str = ""
 
     @property
     def column_name(self) -> str:
@@ -268,8 +326,11 @@ class FieldRef:
 
     @property
     def instance_name(self) -> str:
-        """str: The bracketed column-instance name (``[sum:revenue:qk]``)."""
-        return f"[{self.prefix}:{self.field_name}:{_TYPE_SUFFIX[self.instance_type]}]"
+        """str: The bracketed column-instance name (``[sum:revenue:qk]``, ``[cum:sum:...]``)."""
+        prefix = self.prefix
+        if self.table_calc:
+            prefix = f"{TABLE_CALC_PREFIXES[self.table_calc]}:{prefix}"
+        return f"[{prefix}:{self.field_name}:{_TYPE_SUFFIX[self.instance_type]}]"
 
     @property
     def caption(self) -> str:
@@ -288,7 +349,7 @@ class FieldResolver:
         datasource_id: The ``federated.*`` id every reference is qualified with.
         datasource_caption: The datasource's manifest name, as the view declares it.
         field_types: ``{field name: DATA-MODEL.md type}`` for the datasource's CSV.
-        calculated: ``{name: (formula, type)}`` for the datasource's calculated fields.
+        calculated: ``{name: CalculatedField}`` for the datasource's calculated fields.
         type_facts: ``{type: (role, column type)}`` - :mod:`twb`'s type table, passed in so
             this module stays free of a circular import.
     """
@@ -298,7 +359,7 @@ class FieldResolver:
         datasource_id: str,
         datasource_caption: str,
         field_types: dict[str, str],
-        calculated: dict[str, tuple[str, str]],
+        calculated: dict[str, CalculatedField],
         type_facts: dict[str, tuple[str, str]],
     ) -> None:
         self.datasource_id = datasource_id
@@ -322,6 +383,7 @@ class FieldResolver:
             The resolved :class:`FieldRef`, or ``None`` when the entry names no field
             (``manifest.validate_manifest`` has already rejected that case).
         """
+        table_calc = ""
         if isinstance(entry, dict):
             field_name = str(entry.get("field", "")).strip().strip("[]").strip()
             aggregation = _lower(entry.get("aggregation"))
@@ -332,13 +394,18 @@ class FieldResolver:
                 if isinstance(raw_bin, (int, float)) and not isinstance(raw_bin, bool)
                 else None
             )
+            raw_calc = entry.get("table_calc")
+            if isinstance(raw_calc, str) and raw_calc.strip() in TABLE_CALC_PREFIXES:
+                table_calc = raw_calc.strip()
         else:
             field_name = str(entry or "").strip().strip("[]").strip()
             aggregation, date_part, bin_size = "", "", None
         if not field_name:
             return None
 
-        formula, declared_type = self.calculated.get(field_name, ("", ""))
+        formula, declared_type, number_format = self.calculated.get(
+            field_name, CalculatedField("", "")
+        )
         datatype = declared_type or self.field_types.get(field_name, "string")
         role, column_type = self.type_facts.get(datatype, ("dimension", "nominal"))
 
@@ -384,6 +451,8 @@ class FieldResolver:
             prefix=prefix,
             derivation=derivation,
             formula=formula,
+            number_format=number_format,
+            table_calc=table_calc,
         )
 
     def references(self, entries: object) -> list[FieldRef]:
@@ -478,6 +547,8 @@ class FilterPlan:
         minimum: Lower bound of a range filter, or ``None``.
         maximum: Upper bound of a range filter, or ``None``.
         context: Whether Tableau evaluates it first.
+        all_members: Filter *on* the field with nothing excluded - the worksheet side of a
+            quick-filter card, whose whole job is to let the viewer do the excluding.
     """
 
     reference: FieldRef
@@ -485,6 +556,7 @@ class FilterPlan:
     minimum: Optional[str] = None
     maximum: Optional[str] = None
     context: bool = False
+    all_members: bool = False
 
 
 @dataclass(frozen=True)
@@ -502,6 +574,45 @@ class SortPlan:
     by: Optional[FieldRef] = None
     order: tuple[str, ...] = ()
     direction: str = "DESC"
+
+
+#: A reference line's ``formula`` - the aggregation of the field it draws at (XSD enum).
+REFERENCE_LINE_FORMULAS: frozenset[str] = frozenset({
+    "constant", "total", "sum", "min", "max", "average", "median", "quantiles",
+    "percentile", "stdev", "confidence", "medianconfidence",
+})
+
+#: How far a reference line's computation reaches (XSD enum).
+REFERENCE_LINE_SCOPES: frozenset[str] = frozenset({"per-cell", "per-pane", "per-table"})
+
+#: The confidence probability Desktop writes on every reference line (only the ``confidence``
+#: and ``percentile`` formulas read it; the rest carry it and ignore it).
+REFERENCE_LINE_PROBABILITY = "95"
+
+#: What a reference line labels itself with (XSD enum). ``custom`` is implied by a ``label``.
+REFERENCE_LINE_LABEL_TYPES: frozenset[str] = frozenset({
+    "none", "automatic", "value", "computation", "custom",
+})
+
+
+@dataclass(frozen=True)
+class ReferenceLinePlan:
+    """One resolved reference line: the measure it draws at, and how it computes and labels.
+
+    Attributes:
+        reference: The measure the line is drawn against (it is both the line's axis and its
+            value - a reference line always lives on the axis of the field it summarises).
+        formula: The aggregation drawn (``average``, ``median``, ...).
+        scope: ``per-cell`` / ``per-pane`` / ``per-table``.
+        label_type: What the line labels itself with; ``custom`` when :attr:`label` is set.
+        label: A custom label template (``<Computation>: <Value>``), or ``""``.
+    """
+
+    reference: FieldRef
+    formula: str = "average"
+    scope: str = "per-table"
+    label_type: str = "computation"
+    label: str = ""
 
 
 @dataclass
@@ -527,6 +638,18 @@ class WorksheetPlan:
         number_formats: ``(field, format pattern)`` pairs for the cell style rule.
         axis_titles: ``{"rows"|"columns": title}`` overrides.
         geo_role: A map's geographic semantic role, or ``""``.
+        reference_lines: Resolved reference lines, in manifest order.
+        parameters: Parameters the worksheet's calculations read - the view must declare them
+            or Tableau cannot resolve the calculation. Filled in by :mod:`twb`, which owns
+            the manifest's parameter list.
+        declared: Fields the worksheet must declare without placing them on the view - a
+            parameter action's source field, which is read off the clicked mark. Filled in by
+            :mod:`twb` when it resolves the actions.
+        detail: Fields pinned to the Detail shelf that no encoding names - the boolean a
+            zone's Dynamic Zone Visibility reads, which Tableau evaluates off the *view* of a
+            sheet in the dashboard. Filled in by :mod:`twb` from the layout's ``visibility``
+            keys. A DZV field is a single value (a parameter comparison), so it never splits
+            the marks.
     """
 
     name: str
@@ -536,6 +659,10 @@ class WorksheetPlan:
     rows: list[FieldRef] = field(default_factory=list)
     encodings: dict[str, FieldRef] = field(default_factory=dict)
     filters: list[FilterPlan] = field(default_factory=list)
+    reference_lines: list[ReferenceLinePlan] = field(default_factory=list)
+    parameters: list[Parameter] = field(default_factory=list)
+    declared: list[FieldRef] = field(default_factory=list)
+    detail: list[FieldRef] = field(default_factory=list)
     sort: Optional[SortPlan] = None
     tooltip: list[tuple[str, FieldRef]] = field(default_factory=list)
     number_formats: list[tuple[FieldRef, str]] = field(default_factory=list)
@@ -561,6 +688,9 @@ class WorksheetPlan:
                 references.append(self.sort.by)
         references += [reference for _, reference in self.tooltip]
         references += [reference for reference, _ in self.number_formats]
+        references += [line.reference for line in self.reference_lines]
+        references += self.declared
+        references += self.detail
         return references
 
 
@@ -596,6 +726,7 @@ def plan_worksheet(entry: dict, resolver: FieldResolver) -> WorksheetPlan:
         rows=resolver.references(shelves.get("rows")),
         encodings=encodings,
         filters=_plan_filters(entry.get("filters"), resolver),
+        reference_lines=_plan_reference_lines(entry.get("reference_lines"), resolver),
         sort=_plan_sort(entry.get("sort"), resolver),
         tooltip=_plan_tooltip(entry.get("tooltip"), resolver),
         number_formats=_plan_number_formats(entry.get("number_formats"), resolver),
@@ -638,6 +769,30 @@ def _plan_filters(entries: object, resolver: FieldResolver) -> list[FilterPlan]:
             context=entry.get("context") is True,
         ))
     return plans
+
+
+def _plan_reference_lines(
+    entries: object, resolver: FieldResolver
+) -> list[ReferenceLinePlan]:
+    """Resolve the ``reference_lines`` list into :class:`ReferenceLinePlan`s."""
+    if not isinstance(entries, list):
+        return []
+    lines: list[ReferenceLinePlan] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        reference = resolver.reference(entry)
+        if reference is None:
+            continue
+        label = str(entry.get("label", "")).strip()
+        lines.append(ReferenceLinePlan(
+            reference=reference,
+            formula=_lower(entry.get("formula")) or "average",
+            scope=_lower(entry.get("scope")) or "per-table",
+            label_type="custom" if label else (_lower(entry.get("label_type")) or "computation"),
+            label=label,
+        ))
+    return lines
 
 
 def _plan_sort(entry: object, resolver: FieldResolver) -> Optional[SortPlan]:
@@ -768,13 +923,35 @@ def _render_dependencies(parent: ET.Element, plan: WorksheetPlan) -> None:
         )
 
     for name in sorted(by_instance):
-        reference = by_instance[name]
-        ET.SubElement(dependencies, "column-instance", {
-            "column": reference.column_name,
-            "derivation": reference.derivation,
-            "name": name,
-            "pivot": "key",
-            "type": reference.instance_type,
+        render_column_instance(dependencies, by_instance[name])
+
+
+def render_column_instance(parent: ET.Element, reference: FieldRef) -> None:
+    """Render one ``<column-instance>`` - how a column is derived onto a shelf.
+
+    Used inside a worksheet's ``<datasource-dependencies>``, at the datasource level (where a
+    table calc's instance must also be declared) and in a dashboard's own dependencies.
+
+    Args:
+        parent: The element to append the instance to.
+        reference: The resolved field.
+    """
+    instance = ET.SubElement(parent, "column-instance", {
+        "column": reference.column_name,
+        "derivation": reference.derivation,
+        "name": reference.instance_name,
+        "pivot": "key",
+        "type": reference.instance_type,
+    })
+    if reference.table_calc:
+        # A table calc is a property of the instance: the same measure can be plain on one
+        # shelf and a running total on another.
+        # No 'aggregation': Desktop 2025.1 strips it on save (the aggregation is already the
+        # instance's own 'derivation'), and a workbook it rewrites on open is one whose calc
+        # may not be the calc that was asked for.
+        ET.SubElement(instance, "table-calc", {
+            "ordering-type": TABLE_CALC_ORDERING,
+            "type": reference.table_calc,
         })
 
 
@@ -796,6 +973,10 @@ def render_column(parent: ET.Element, reference: FieldRef, semantic_role: str = 
         "role": reference.role,
         "type": reference.column_type,
     }
+    if reference.number_format:
+        # On the column, not as a worksheet style rule: a ratio formatted as a percentage
+        # once is formatted that way on every sheet and in the data pane.
+        attributes["default-format"] = reference.number_format
     if semantic_role:
         attributes["semantic-role"] = semantic_role
     column = ET.SubElement(parent, "column", dict(sorted(attributes.items())))
@@ -842,15 +1023,24 @@ def _render_filters(parent: ET.Element, plan: WorksheetPlan) -> list[str]:
             # A context filter runs before FIXED LODs and every other filter.
             attributes["context"] = "true"
 
-        if entry.members:
-            _render_categorical(
-                ET.SubElement(
-                    parent, "filter",
-                    dict(sorted({"class": "categorical", **attributes}.items())),
-                ),
-                entry.reference.instance_name,
-                list(entry.members),
+        if entry.members or entry.all_members:
+            categorical = ET.SubElement(
+                parent, "filter",
+                dict(sorted({"class": "categorical", **attributes}.items())),
             )
+            if entry.all_members:
+                # "Every member, including ones added later" - the filter a quick-filter card
+                # controls. An enumerated member list would freeze today's domain into it.
+                ET.SubElement(categorical, "groupfilter", {
+                    "function": "level-members",
+                    "level": entry.reference.instance_name,
+                    "user:ui-enumeration": "all",
+                    "user:ui-marker": "enumerate",
+                })
+            else:
+                _render_categorical(
+                    categorical, entry.reference.instance_name, list(entry.members)
+                )
         else:
             range_filter = ET.SubElement(parent, "filter", dict(sorted({
                 "class": "quantitative", "included-values": "in-range", **attributes,
@@ -985,7 +1175,9 @@ def _render_panes(parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens)
     if plan.spec.dual and len(plan.rows) > 1:
         # Pane 0 is the shared default; panes 1..n each own one measure's axis, in the same
         # order the measures sit on Rows.
-        _render_pane(panes, plan, tokens, {}, plan.spec.mark_class)
+        # ponytail: a dual chart's reference lines go on the shared pane, not per axis - one
+        # line per measure needs the manifest to say which axis, which no spec has asked for.
+        _render_pane(panes, plan, tokens, {}, plan.spec.mark_class, True)
         for index, reference in enumerate(plan.rows):
             mark = (
                 plan.spec.pane_marks[index]
@@ -1000,17 +1192,19 @@ def _render_panes(parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens)
                 mark,
             )
         return
-    _render_pane(panes, plan, tokens, {}, plan.spec.mark_class)
+    _render_pane(panes, plan, tokens, {}, plan.spec.mark_class, True)
 
 
 def _render_pane(
     parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens,
-    attributes: dict, mark_class: str,
+    attributes: dict, mark_class: str, with_reference_lines: bool = False,
 ) -> None:
-    """Render one pane: its mark class, encodings, tooltip, label and mark style.
+    """Render one pane: its mark class, encodings, reference lines, tooltip, label and style.
 
     The child order is the XSD's ``PaneSpecification-G`` sequence - view, mark, encodings,
-    customized-tooltip, customized-label, style - not the order they were decided in.
+    reference-line, customized-tooltip, customized-label, style - not the order they were
+    decided in. (The legacy ``FEATURES.md`` puts ``reference-line`` in ``<view>``; the XSD and
+    Tableau's own output both put it here.)
     """
     pane = ET.SubElement(
         parent, "pane", dict(sorted({**attributes, **PANE_RELAXATION}.items()))
@@ -1030,11 +1224,15 @@ def _render_pane(
     if plan.spec.geographic:
         columns["geometry"] = plan.qualify(GENERATED_GEOMETRY)
 
-    if columns or plan.tooltip:
+    if columns or plan.tooltip or plan.detail:
         block = ET.SubElement(pane, "encodings")
         for name in ENCODING_ORDER:
             if name in columns:
                 ET.SubElement(block, name, {"column": columns[name]})
+        # Detail-shelf fields carry no visual role - <lod> is repeatable, so a zone's
+        # visibility field joins whatever the manifest put on Detail.
+        for reference in plan.detail:
+            ET.SubElement(block, "lod", {"column": plan.reference_of(reference)})
         # Every field the tooltip template names must also be registered as an encoding,
         # or Tableau has no value to substitute into it.
         for _, reference in plan.tooltip:
@@ -1042,6 +1240,8 @@ def _render_pane(
                 "column": plan.reference_of(reference)
             })
 
+    if with_reference_lines:
+        _render_reference_lines(pane, plan)
     if plan.tooltip:
         _render_tooltip(pane, plan, tokens)
     if plan.spec.kpi_card and "text" in plan.encodings:
@@ -1051,6 +1251,37 @@ def _render_pane(
         rule = ET.SubElement(style, "style-rule", {"element": "mark"})
         for attribute in ("mark-labels-show", "mark-labels-cull"):
             ET.SubElement(rule, "format", {"attr": attribute, "value": "true"})
+
+
+def _render_reference_lines(parent: ET.Element, plan: WorksheetPlan) -> None:
+    """Render the pane's reference lines.
+
+    A line's axis and value are the same field: a reference line summarises the measure whose
+    axis it is drawn on, and both references must be **fully qualified** (unlike the
+    unqualified ``level`` a filter carries).
+
+    Args:
+        parent: The ``<pane>`` element.
+        plan: The worksheet plan.
+    """
+    for index, line in enumerate(plan.reference_lines):
+        column = plan.reference_of(line.reference)
+        attributes = {
+            "axis-column": column,
+            "enable-instant-analytics": "true",
+            "formula": line.formula,
+            "id": f"refline{index}",
+            "label-type": line.label_type,
+            # Desktop writes the confidence probability on every reference line, whatever the
+            # formula, and adds it on save when it is missing.
+            "probability": REFERENCE_LINE_PROBABILITY,
+            "scope": line.scope,
+            "value-column": column,
+            "z-order": "1",
+        }
+        if line.label:
+            attributes["label"] = line.label
+        ET.SubElement(parent, "reference-line", dict(sorted(attributes.items())))
 
 
 def _render_tooltip(
@@ -1132,10 +1363,20 @@ def render_worksheet(parent: ET.Element, plan: WorksheetPlan, tokens: DesignToke
         "caption": plan.resolver.datasource_caption,
         "name": plan.resolver.datasource_id,
     })
+    if plan.parameters:
+        # A calculation that reads a parameter is unresolvable unless the view declares the
+        # Parameters datasource too - Tableau opens the sheet with the field greyed out.
+        ET.SubElement(datasources, "datasource", {"name": PARAMETERS_DATASOURCE})
     if plan.spec.geographic:
         ET.SubElement(
             ET.SubElement(view, "mapsources"), "mapsource", {"name": MAPSOURCE_NAME}
         )
+    if plan.parameters:
+        parameter_dependencies = ET.SubElement(
+            view, "datasource-dependencies", {"datasource": PARAMETERS_DATASOURCE}
+        )
+        for parameter in plan.parameters:
+            render_parameter_column(parameter_dependencies, parameter, with_domain=False)
     _render_dependencies(view, plan)
     filtered = _render_filters(view, plan)
     _render_sort(view, plan)

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -185,6 +185,29 @@ _AGGREGATE_CALL = re.compile(
 )
 
 
+def strip_lod_expressions(formula: str) -> str:
+    """Return the formula with every brace-delimited LOD expression removed.
+
+    Args:
+        formula: The calculation's Tableau formula.
+
+    Returns:
+        The formula with each ``{...}`` span (nesting included) replaced by a space, so what
+        is left is only what the formula computes *around* its LODs.
+    """
+    kept: list[str] = []
+    depth = 0
+    for character in formula:
+        if character == "{":
+            depth += 1
+            kept.append(" ")
+        elif character == "}":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            kept.append(character)
+    return "".join(kept)
+
+
 def is_aggregate_formula(formula: str) -> bool:
     """Return whether a calculated field's formula already aggregates.
 
@@ -192,19 +215,21 @@ def is_aggregate_formula(formula: str) -> bool:
         formula: The calculation's Tableau formula.
 
     Returns:
-        True when the formula calls an aggregate function, so the field must reach a shelf
-        un-aggregated. A row-level formula (``[quantity] * [unit_price]``) returns False and
-        is treated like any other measure.
+        True when the formula calls an aggregate function *outside* any LOD expression, so the
+        field must reach a shelf un-aggregated. A row-level formula
+        (``[quantity] * [unit_price]``) returns False and is treated like any other measure.
 
     An **LOD expression** (``{FIXED [region]: SUM([revenue])}``) returns False even though it
     contains ``SUM(``: an LOD produces one row-level value per its own grain, so Tableau
     aggregates it again on the shelf (``SUM([Regional Revenue])``). Treating it as
     pre-aggregated is what put the ``User`` derivation on it and made the shelf read one
-    arbitrary member's value.
+    arbitrary member's value. Only the aggregate *inside* the braces is discounted, though -
+    ``SUM([revenue]) / {FIXED : SUM([revenue])}`` aggregates and must not be re-aggregated,
+    which is the whole point of a percent-of-total calc.
     """
-    if not formula or "{" in formula:
+    if not formula:
         return False
-    return _AGGREGATE_CALL.search(formula) is not None
+    return _AGGREGATE_CALL.search(strip_lod_expressions(formula)) is not None
 
 
 #: manifest ``table_calc`` -> the column-instance name's extra prefix. The keys are the
@@ -214,7 +239,8 @@ def is_aggregate_formula(formula: str) -> bool:
 #: rather than rendering a calc Tableau does not have.
 #: ponytail: only ``PctTotal`` -> ``pcto`` is attested (Desktop 2025.1 renamed ours on save).
 #: The rest are inferred; a wrong one costs nothing but a rewrite on open, and is fixed by
-#: reading the name out of a Desktop-saved workbook that uses that calc.
+#: reading the name out of a Desktop-saved workbook that uses that calc - issue #50 carries
+#: the exact sheet-by-sheet steps.
 TABLE_CALC_PREFIXES: dict[str, str] = {
     "CumTotal": "cum",
     "WindowTotal": "wnd",

--- a/skills/tableau-build/scripts/zones.py
+++ b/skills/tableau-build/scripts/zones.py
@@ -13,10 +13,11 @@ The module is pure and stdlib-only: it takes the layout tree, the canvas, and a
 filesystem, no manifest parsing - that is :mod:`twb`'s job, and it is why the contract test
 can drive :func:`render_zones` directly.
 
-Not here: the *wiring* of a filter / parameter / button zone to the field, parameter or sheet
-behind it. A zone of the right type at the right place is what the layout owes; the
-dashboard-level ``<datasource-dependencies>`` and button actions that make one live belong to
-the features-and-actions ticket (#37).
+A filter card and a parameter control are rendered as real zones once the leaf carries the
+reference they need (:class:`Leaf`'s ``param`` / ``sheet`` / ``mode``); :mod:`twb` resolves
+those and emits the dashboard-level ``<datasource-dependencies>`` they also require. An image,
+a button and a standalone legend still reserve their box as an empty zone - see
+:data:`DEFERRED_KINDS`.
 """
 
 from __future__ import annotations
@@ -48,23 +49,32 @@ LEGEND_HEIGHT_PX = 22
 #: the whole reason the header is a horizontal container rather than a bare text zone.
 HEADER_TEXT_SHARE = 75.0
 
-#: manifest ``objects[].kind`` -> the zone's ``type-v2``, for the kinds a layout can render
-#: on its own: a text block and a spacer need nothing beyond their box and their text.
+#: manifest ``objects[].kind`` -> the zone's ``type-v2``. A text block and a spacer need
+#: nothing beyond their box; a filter card and a parameter control need the ``param`` the
+#: leaf carries (an unreferenced one falls back to :data:`EMPTY_ZONE_TYPE`).
 OBJECT_ZONE_TYPES: dict[str, str] = {
     "text": "text",
     "blank": "empty",
+    "filter": "filter",
+    "parameter": "paramctrl",
 }
 
-#: The other kinds. Each one's real zone type (``filter``, ``paramctrl``, ``bitmap``,
-#: ``dashboard-object``, ``color``) needs a reference the manifest does not carry yet - a
-#: filter's field plus the dashboard's own ``<datasource-dependencies>``, a parameter control's
-#: parameter, an image's filename (which the ``.twbx`` would also have to embed), a button's
-#: action, a legend's sheet and colour field - and Tableau does not treat those as optional.
-#: So the layout reserves the box as an empty zone, keeping the geometry the analyst approved,
-#: until the ticket that adds the wiring can emit the real zone.
-DEFERRED_KINDS: frozenset[str] = frozenset({
-    "filter", "parameter", "image", "button", "legend",
-})
+#: The default control mode per kind: a dimension filter card is a checkbox dropdown, a
+#: parameter control is the compact widget.
+DEFAULT_ZONE_MODES: dict[str, str] = {"filter": "checkdropdown", "parameter": "compact"}
+
+#: The modes a filter card may ask for. Only the two the legacy mode table documents for a
+#: *dimension* are here: a card renders the field's members, so a date or numeric range card
+#: (``daterange`` / ``range``) needs bounds the manifest expresses as a worksheet filter
+#: instead. ``manifest`` reads this table, so an unrenderable mode fails validation.
+FILTER_MODES: frozenset[str] = frozenset({"checkdropdown", "typeinlist"})
+
+#: The remaining kinds. Each one's real zone type (``bitmap``, ``dashboard-object``,
+#: ``color``) needs a reference the manifest does not carry - an image's filename (which the
+#: ``.twbx`` would also have to embed), a button's action, a standalone legend's sheet and
+#: colour field - and Tableau does not treat those as optional. So the layout reserves the box
+#: as an empty zone, keeping the geometry the analyst approved.
+DEFERRED_KINDS: frozenset[str] = frozenset({"image", "button", "legend"})
 
 #: The zone type of a leaf nothing fills, of a deferred kind, and of an unknown one.
 EMPTY_ZONE_TYPE = "empty"
@@ -122,6 +132,12 @@ class Leaf:
             dashboard (see :meth:`_ZoneWriter._content`).
         text: The text a ``text`` object zone displays.
         legend: The colour legend to stack below the content, or ``None`` for no legend.
+        param: What a ``filter`` / ``parameter`` zone controls - a qualified column-instance
+            (``[federated.x].[none:region:nk]``) or a qualified parameter
+            (``[Parameters].[Top N]``). Without it the kind falls back to an empty zone.
+        sheet: The worksheet a filter card filters (its ``name``); the card is the UI for that
+            sheet's own filter, so the two must agree.
+        mode: The control's mode, defaulting to :data:`DEFAULT_ZONE_MODES`.
     """
 
     worksheet: str = ""
@@ -129,6 +145,9 @@ class Leaf:
     title: str = ""
     text: str = ""
     legend: Optional[Legend] = None
+    param: str = ""
+    sheet: str = ""
+    mode: str = ""
 
 
 def render_zone_style(parent: ET.Element, margin: str) -> None:
@@ -185,6 +204,8 @@ class _ZoneWriter:
         embedded: The sheet names the tree places in a zone - what the caller hides in
             ``<windows>``, since hiding a sheet no zone shows leaves Tableau no tab to
             render it on.
+        visibility: ``{zone id: boolean field name}`` for every node carrying a
+            ``visibility`` key - what the workbook's ``<datagraph>`` wires up.
     """
 
     def __init__(
@@ -204,6 +225,7 @@ class _ZoneWriter:
         self._tokens = tokens
         self._last_id = 0
         self.embedded: set[str] = set()
+        self.visibility: dict[str, str] = {}
 
     # --- helpers ---------------------------------------------------------------
 
@@ -284,9 +306,10 @@ class _ZoneWriter:
             return  # validate_manifest already rejected it; keep the rest of the tree
 
         element_id = str(node.get("id") or "").strip()
+        visibility = str(node.get("visibility") or "").strip()
         children = node.get("children")
         if not (isinstance(children, list) and children):
-            self._leaf(parent, element_id, box, path)
+            self._leaf(parent, element_id, box, path, visibility)
             return
 
         orientation = "vert" if str(node.get("type", "")).strip().lower() == "vert" else "horz"
@@ -294,11 +317,17 @@ class _ZoneWriter:
             parent, box, f"{CONTAINER_PREFIXES[orientation]}-{element_id or path}",
             type_v2="layout-flow", param=orientation,
         )
+        self._record_visibility(container, visibility)
         for index, (child, child_box) in enumerate(
             zip(children, self._divide(box, orientation, child_sizes(children))), start=1
         ):
             self._node(container, child, child_box, f"{path}.{index}")
         render_zone_style(container, ZONE_MARGIN)
+
+    def _record_visibility(self, zone: ET.Element, field: str) -> None:
+        """Note that ``zone``'s visibility is controlled by the boolean field ``field``."""
+        if field:
+            self.visibility[zone.get("id")] = field
 
     def _divide(self, box: Box, orientation: str, sizes: list[float]) -> list[Box]:
         """Split ``box`` along the flow axis into one rectangle per proportion.
@@ -333,7 +362,10 @@ class _ZoneWriter:
 
     # --- leaves ------------------------------------------------------------------
 
-    def _leaf(self, parent: ET.Element, element_id: str, box: Box, path: str) -> None:
+    def _leaf(
+        self, parent: ET.Element, element_id: str, box: Box, path: str,
+        visibility: str = "",
+    ) -> None:
         """Render one leaf element, wrapping it when it carries a title or a legend.
 
         Args:
@@ -341,6 +373,9 @@ class _ZoneWriter:
             element_id: The leaf's element id (``""`` for an unnamed node).
             box: The rectangle the element occupies.
             path: Its position in the tree, the fallback friendly name.
+            visibility: The boolean field controlling the element's visibility, or ``""``.
+                A titled or legended element is controlled at its **wrapper**: hiding only the
+                content zone would leave its title and legend behind.
         """
         label = element_id or path
         leaf = self._leaves.get(element_id, Leaf())
@@ -348,7 +383,7 @@ class _ZoneWriter:
         legend_height = self._units_y(LEGEND_HEIGHT_PX) if leaf.legend else 0
 
         if not (title_height or legend_height):
-            self._content(parent, leaf, box, label)
+            self._record_visibility(self._content(parent, leaf, box, label), visibility)
             return
 
         # The extra zones stack inside the element's own box, so its siblings are untouched.
@@ -356,6 +391,7 @@ class _ZoneWriter:
             parent, box, f"{CONTAINER_PREFIXES['vert']}-{label}",
             type_v2="layout-flow", param="vert",
         )
+        self._record_visibility(wrapper, visibility)
         # A box too short for both fixed zones is squeezed, never overflowed: a zone written
         # past the wrapper's bottom edge would overlap the sibling below it.
         title_height = min(title_height, box.h)
@@ -373,7 +409,9 @@ class _ZoneWriter:
             )
         render_zone_style(wrapper, ZONE_MARGIN)
 
-    def _content(self, parent: ET.Element, leaf: Leaf, box: Box, label: str) -> None:
+    def _content(
+        self, parent: ET.Element, leaf: Leaf, box: Box, label: str
+    ) -> ET.Element:
         """Render the leaf's own zone: a sheet zone, an object zone, or a blank.
 
         A sheet's *own* title is always suppressed: Tableau draws it inside the zone, over
@@ -386,19 +424,38 @@ class _ZoneWriter:
             leaf: What fills the element.
             box: The rectangle for the content itself.
             label: The zone's friendly name.
+
+        Returns:
+            The zone element, so the caller can record what controls its visibility.
         """
         if leaf.worksheet:
             # A sheet zone is identified by its 'name' and carries no type-v2.
             zone = self._zone(parent, box, label, name=leaf.worksheet, show_title="false")
             self.embedded.add(leaf.worksheet)
-        else:
-            kind = leaf.kind.strip().lower()
+            render_zone_style(zone, ZONE_MARGIN)
+            return zone
+
+        kind = leaf.kind.strip().lower()
+        controlled = kind in DEFAULT_ZONE_MODES
+        if controlled and leaf.param:
+            # A filter card names the sheet it filters; a parameter control names nothing but
+            # the parameter, which every sheet reads the same value of.
             zone = self._zone(
-                parent, box, label, type_v2=OBJECT_ZONE_TYPES.get(kind, EMPTY_ZONE_TYPE),
+                parent, box, label, type_v2=OBJECT_ZONE_TYPES[kind],
+                mode=leaf.mode or DEFAULT_ZONE_MODES[kind], param=leaf.param,
+                name=leaf.sheet or None, show_title="false",
             )
+        else:
+            # A control with nothing to control would crash Tableau, so it reserves its box.
+            zone_type = (
+                EMPTY_ZONE_TYPE if controlled
+                else OBJECT_ZONE_TYPES.get(kind, EMPTY_ZONE_TYPE)
+            )
+            zone = self._zone(parent, box, label, type_v2=zone_type)
             if kind == "text" and leaf.text:
                 self._formatted_text(zone, leaf.text, bold=False)
         render_zone_style(zone, ZONE_MARGIN)
+        return zone
 
     def _title(self, parent: ET.Element, text: str, box: Box, label: str) -> None:
         """Render the element's header row: a fixed-height horizontal container holding the
@@ -457,13 +514,29 @@ class _ZoneWriter:
         run.text = text
 
 
+class RenderedZones(NamedTuple):
+    """What the caller needs back after the zone tree is written.
+
+    Attributes:
+        root_zone_id: The root zone's id - the dashboard window's ``<active>`` target.
+        embedded: The sheet names the tree placed in a zone, which the caller hides in
+            ``<windows>``.
+        visibility: ``{zone id: boolean field name}`` for the zones a ``visibility`` key
+            controls - the input to the workbook's ``<datagraph>``.
+    """
+
+    root_zone_id: str
+    embedded: set[str]
+    visibility: dict[str, str]
+
+
 def render_zones(
     parent: ET.Element,
     root: dict,
     canvas: dict,
     leaves: dict[str, Leaf],
     tokens: DesignTokens,
-) -> tuple[str, set[str]]:
+) -> RenderedZones:
     """Render a layout tree into a dashboard's ``<zones>``.
 
     Args:
@@ -474,8 +547,8 @@ def render_zones(
         tokens: The parsed :class:`worksheet.DesignTokens`, for title zone styling.
 
     Returns:
-        ``(root zone id, embedded sheet names)``. The root id is the dashboard window's
-        ``<active>`` target; the sheet names are the ones the caller hides in ``<windows>``.
+        The :class:`RenderedZones` triple.
     """
     writer = _ZoneWriter(canvas, leaves, tokens)
-    return writer.render_root(parent, root), writer.embedded
+    root_zone_id = writer.render_root(parent, root)
+    return RenderedZones(root_zone_id, writer.embedded, writer.visibility)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -325,7 +325,10 @@ def test_object_zone_fills_a_non_worksheet_zone():
     """Not every zone is a view - a filter card / text zone is declared under 'objects'."""
     document = _manifest()
     document["layout"]["root"]["children"].insert(0, {"id": "flt-region", "size": 10})
-    document["objects"] = [{"element_id": "flt-region", "kind": "filter"}]
+    document["objects"] = [{
+        "element_id": "flt-region", "kind": "filter",
+        "field": "region", "worksheet": "Revenue Trend",
+    }]
 
     assert _errors(document) == []
 
@@ -530,7 +533,7 @@ def test_parameter_action_targets_a_parameter_not_a_zone():
     ]
     document["actions"] = [
         {"name": "Pick measure", "type": "parameter", "source": "chart-trend",
-         "targets": ["Measure"]}
+         "targets": ["Measure"], "field": "region"}
     ]
 
     assert _errors(document) == []

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -529,7 +529,8 @@ def test_parameter_action_targets_a_parameter_not_a_zone():
     """A parameter action targets a declared parameter - not every action targets a zone."""
     document = _manifest()
     document["parameters"] = [
-        {"name": "Measure", "data_type": "string", "allowed_values": ["Revenue"]}
+        {"name": "Measure", "data_type": "string", "current_value": "Revenue",
+         "values": ["Revenue"]}
     ]
     document["actions"] = [
         {"name": "Pick measure", "type": "parameter", "source": "chart-trend",

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,1029 @@
+"""Contract test for tableau-build's interactive layer (issue #37, CONTRACT.md step 8, §6).
+
+A dashboard that renders but does nothing when you click it is the failure this file exists to
+prevent. Four groups of guarantees, one test per guarantee:
+
+* **datasource level** - a calculated field carries its ``default-format``, an aggregate
+  formula is *not* re-aggregated while an LOD *is*, a table calc lives on the column-instance,
+  a reference line sits in the pane, and every parameter is a column of the inline
+  ``Parameters`` datasource;
+* **workbook level** - filter / highlight / parameter actions in ``<actions>``, bound to real
+  sheet names, one action per target, with deterministic unique ids;
+* **dashboard level** - a quick-filter card and a parameter control render as real zones, the
+  dashboard declares the datasources and fields they read, and the filtered column reaches the
+  owning worksheet's ``<slices>``;
+* **Dynamic Zone Visibility** - a ``visibility`` field becomes a ``<datagraph>`` wired to the
+  controlled zone, plus the four document-format flags that go with it.
+
+Everything is driven through :func:`twb.render_workbook` (pure), with one end-to-end
+:func:`build.build_workbook` case so the whole path - manifest on disk to packaged ``.twbx`` -
+is covered too.
+"""
+
+import json
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import build
+import features
+import init
+import manifest
+import twb
+import worksheet
+
+TARGET_VERSION = "2024.2-2025.x"
+
+DATA_MODEL = """# Data Model
+
+## Acquisition
+
+- tier: csv (provided in data/)
+
+## Data source: `sales_orders.csv`
+
+| Field | Type | Role | Sample values | Description |
+|-------|------|------|---------------|-------------|
+| order_date | date | dimension | 2024-01-05 | Order date |
+| region | string | dimension | West | Sales region |
+| product_category | string | dimension | Technology | Product category |
+| revenue | real | measure | 1200.5 | Order revenue |
+| profit | real | measure | 120.5 | Order profit |
+"""
+
+CSV_HEADER = ["order_date", "region", "product_category", "revenue", "profit"]
+CSV_HEADERS = {"sales_orders.csv": CSV_HEADER}
+
+#: One CSV datasource, three calculated fields (aggregate / LOD / boolean-for-DZV) and two
+#: parameters (a member list and a range) - the datasource-level surface of the ticket.
+DATASOURCES = [{
+    "name": "sales_orders",
+    "csv": "sales_orders.csv",
+    "fields": [{"name": name, "type": datatype} for name, datatype in (
+        ("order_date", "date"), ("region", "string"), ("product_category", "string"),
+        ("revenue", "real"), ("profit", "real"),
+    )],
+}]
+
+CALCULATED_FIELDS = [
+    {"name": "Margin Pct", "formula": "SUM([profit]) / SUM([revenue])",
+     "datasource": "sales_orders", "type": "real", "format": "p0.0%"},
+    {"name": "Regional Revenue", "formula": "{FIXED [region]: SUM([revenue])}",
+     "datasource": "sales_orders", "type": "real"},
+    # The DZV switch: no region picked yet means there is nothing to break down, so the
+    # category panel stays hidden until the parameter action below writes a region.
+    {"name": "Show Breakdown", "formula": '[Parameters].[Selected Region] <> "All"',
+     "datasource": "sales_orders", "type": "boolean"},
+]
+
+PARAMETERS = [
+    {"name": "Selected Region", "data_type": "string", "current_value": "All",
+     "values": ["All", "East", "North", "West"]},
+    {"name": "Top N", "data_type": "integer", "current_value": 10,
+     "range": {"min": 5, "max": 50, "step": 5}, "format": "#,##0"},
+]
+
+WORKSHEETS = [
+    {"name": "Revenue KPI", "element_id": "kpi-revenue", "chart_type": "text",
+     "datasource": "sales_orders", "encodings": {"text": "Margin Pct"}},
+    {"name": "Revenue Trend", "element_id": "chart-trend", "chart_type": "line",
+     "datasource": "sales_orders",
+     "shelves": {"columns": [{"field": "order_date", "date_part": "month"}],
+                 "rows": ["revenue"]},
+     "reference_lines": [{"field": "revenue", "aggregation": "sum", "formula": "average",
+                          "scope": "per-table", "label": "<Computation>: <Value>"}]},
+    {"name": "Detail Table", "element_id": "chart-detail", "chart_type": "table",
+     "datasource": "sales_orders",
+     "shelves": {"rows": ["region"],
+                 "columns": [{"field": "revenue", "aggregation": "sum",
+                              "table_calc": "PctTotal"}]},
+     "encodings": {"text": "Regional Revenue"}},
+    {"name": "Category Mix", "element_id": "chart-category", "chart_type": "bar",
+     "datasource": "sales_orders",
+     "shelves": {"rows": ["product_category"],
+                 "columns": [{"field": "revenue", "aggregation": "sum"}]}},
+]
+
+OBJECTS = [
+    {"element_id": "flt-region", "kind": "filter", "field": "region",
+     "worksheet": "Revenue Trend"},
+    # 'Selected Region' gets no control: the parameter action sets it and clearing the
+    # selection resets it, so a control would only be a second way to break the chain.
+    {"element_id": "prm-topn", "kind": "parameter", "parameter": "Top N"},
+]
+
+#: One coherent interaction chain: click a point on the trend to filter and highlight the
+#: detail table, then click a region there to write it into 'Selected Region' - which reveals
+#: the category panel (DZV) *and* filters it to that region.
+ACTIONS = [
+    {"name": "Trend cross-filter", "type": "filter", "source": "chart-trend",
+     "targets": ["chart-detail"]},
+    {"name": "Highlight region", "type": "highlight", "source": "chart-trend",
+     "targets": ["chart-detail"], "run_on": "hover"},
+    {"name": "Breakdown filter", "type": "filter", "source": "chart-detail",
+     "targets": ["chart-category"]},
+    {"name": "Pick region", "type": "parameter", "source": "chart-detail",
+     "targets": ["Selected Region"], "field": "region"},
+]
+
+LAYOUT = {
+    "canvas": {"width": 1366, "height": 768},
+    "root": {"type": "vert", "children": [
+        {"type": "horz", "size": 12, "children": [
+            {"id": "flt-region", "size": 50},
+            {"id": "prm-topn", "size": 50},
+        ]},
+        {"id": "kpi-revenue", "size": 13},
+        {"id": "chart-trend", "size": 30},
+        {"id": "chart-detail", "size": 25},
+        # The last child is shown or hidden by the boolean calc - Dynamic Zone Visibility.
+        {"id": "chart-category", "size": 20, "visibility": "Show Breakdown"},
+    ]},
+}
+
+
+def _manifest(**overrides) -> dict:
+    """The features-rich manifest every test below reads, with optional overrides."""
+    document = {
+        "target_tableau_version": TARGET_VERSION,
+        "datasources": DATASOURCES,
+        "calculated_fields": CALCULATED_FIELDS,
+        "parameters": PARAMETERS,
+        "worksheets": WORKSHEETS,
+        "objects": OBJECTS,
+        "actions": ACTIONS,
+        "layout": LAYOUT,
+    }
+    document.update(overrides)
+    return document
+
+
+def _render(document=None) -> str:
+    """Render a manifest to ``.twb`` XML."""
+    return twb.render_workbook(
+        document if document is not None else _manifest(), DATA_MODEL, CSV_HEADERS
+    )
+
+
+def _errors(**overrides) -> list[str]:
+    """Validate a manifest against the data model and return the messages."""
+    return manifest.validate_manifest(_manifest(**overrides), DATA_MODEL, TARGET_VERSION)
+
+
+FEATURES_XML = _render()
+FEATURES_ROOT = ET.fromstring(FEATURES_XML)
+
+DATASOURCE_ID = twb.datasource_id("sales_orders")
+
+
+def _worksheet_element(name: str, root: ET.Element = FEATURES_ROOT) -> ET.Element:
+    """Return the ``<worksheet>`` with the given name."""
+    for element in root.findall("worksheets/worksheet"):
+        if element.get("name") == name:
+            return element
+    raise AssertionError(f"no worksheet named {name!r} in the rendered workbook")
+
+
+def _zone(friendly_name: str, root: ET.Element = FEATURES_ROOT) -> ET.Element:
+    """Return the dashboard zone with the given friendly name."""
+    for zone in root.find("dashboards/dashboard/zones").iter("zone"):
+        if zone.get("friendly-name") == friendly_name:
+            return zone
+    raise AssertionError(f"no zone named {friendly_name!r} in the dashboard")
+
+
+def test_the_features_manifest_validates():
+    """The schema accepts every new key, so a failure below is the assembler's."""
+    assert _errors() == []
+
+
+def test_the_same_manifest_rebuilds_byte_identical():
+    """Action names and datagraph guids are hash-derived, so a re-run is diff-free."""
+    assert _render() == FEATURES_XML
+
+
+# --- Calculated fields, LOD, formats (AC #1) ----------------------------------
+
+def test_a_calculated_fields_format_lands_on_its_column():
+    """A ratio without a format renders as 0.0834; the pattern belongs to the field, so it
+    is on the column rather than in one sheet's style rules."""
+    column = FEATURES_ROOT.find(
+        f"datasources/datasource[@name='{DATASOURCE_ID}']/column[@name='[Margin Pct]']"
+    )
+
+    assert column.get("default-format") == "p0.0%"
+    assert column.findtext(".") is not None  # the column exists with its calculation
+    assert column.find("calculation").get("formula") == "SUM([profit]) / SUM([revenue])"
+
+
+def test_a_calculated_field_without_a_format_carries_none():
+    """No format asked for, no attribute invented."""
+    column = FEATURES_ROOT.find(
+        f"datasources/datasource[@name='{DATASOURCE_ID}']/column[@name='[Regional Revenue]']"
+    )
+
+    assert "default-format" not in column.attrib
+
+
+def test_each_calculated_field_is_declared_exactly_once_per_datasource():
+    """A field declared twice is a field Tableau resolves twice - and renames on save."""
+    columns = FEATURES_ROOT.findall(
+        f"datasources/datasource[@name='{DATASOURCE_ID}']/column"
+    )
+    names = [column.get("name") for column in columns]
+
+    for name in ("[Margin Pct]", "[Regional Revenue]", "[Show Breakdown]"):
+        assert names.count(name) == 1, f"{name} declared {names.count(name)} times"
+
+
+@pytest.mark.parametrize("formula, aggregates", [
+    ("SUM([profit]) / SUM([revenue])", True),
+    ("AVG([revenue])", True),
+    ("[quantity] * [unit_price]", False),
+    ("{FIXED [region]: SUM([revenue])}", False),
+    ("{ INCLUDE [region] : AVG([revenue]) }", False),
+    ("SUM([revenue]) / {FIXED : SUM([revenue])}", False),
+    ("", False),
+])
+def test_is_aggregate_formula_reads_lods_as_row_level(formula, aggregates):
+    """An LOD contains SUM( but produces a row-level value, so it must be re-aggregated on
+    the shelf. Matching the SUM inside it is what put the User derivation on an LOD."""
+    assert worksheet.is_aggregate_formula(formula) is aggregates
+
+
+def test_an_aggregate_calculation_reaches_the_shelf_un_aggregated():
+    """SUM(SUM(profit)/SUM(revenue)) is an error Tableau refuses at load."""
+    instance = _worksheet_element("Revenue KPI").find(
+        "table/view/datasource-dependencies/column-instance[@column='[Margin Pct]']"
+    )
+
+    assert instance.get("derivation") == "User"
+    assert instance.get("name") == "[usr:Margin Pct:qk]"
+
+
+def test_an_lod_expression_is_re_aggregated_on_the_shelf():
+    """The bug this ticket fixes: an LOD is one value per its own grain, so the view sums it."""
+    instance = _worksheet_element("Detail Table").find(
+        "table/view/datasource-dependencies/column-instance[@column='[Regional Revenue]']"
+    )
+
+    assert instance.get("derivation") == "Sum"
+    assert instance.get("name") == "[sum:Regional Revenue:qk]"
+
+
+# --- Table calculations (AC #1) ------------------------------------------------
+
+def test_a_table_calc_lives_on_the_column_instance():
+    """The calc is a property of the instance: the same measure can be plain on one shelf and
+    a percent-of-total on another, so it introduces no column of its own."""
+    dependencies = _worksheet_element("Detail Table").find(
+        "table/view/datasource-dependencies"
+    )
+    instance = dependencies.find("column-instance[@name='[pcto:sum:revenue:qk]']")
+
+    # No 'aggregation': Desktop 2025.1 strips it, and the prefix is 'pcto' - both read off
+    # a Desktop-saved copy of this very workbook, which had rewritten ours.
+    assert instance.find("table-calc").attrib == {
+        "ordering-type": "Rows", "type": "PctTotal",
+    }
+    assert dependencies.find("column[@name='[pcto:sum:revenue:qk]']") is None
+    assert instance.get("column") == "[revenue]"
+
+
+def test_a_table_calcs_shelf_points_at_the_calculated_instance():
+    """A shelf naming the plain instance would draw the raw measure, not the running one."""
+    columns = _worksheet_element("Detail Table").findtext("table/cols")
+
+    assert columns == f"[{DATASOURCE_ID}].[pcto:sum:revenue:qk]"
+
+
+def test_the_datasource_also_declares_the_table_calcs_instance():
+    """A table calc the datasource does not carry is a field Tableau drops from the data pane
+    on save - the worksheet keeps working, the analyst's field list does not."""
+    instance = FEATURES_ROOT.find(
+        f"datasources/datasource[@name='{DATASOURCE_ID}']"
+        f"/column-instance[@name='[pcto:sum:revenue:qk]']"
+    )
+
+    assert instance.find("table-calc").get("type") == "PctTotal"
+
+
+def test_an_unknown_table_calc_is_rejected():
+    """The XSD enumerates the types; 'CumAvg' is one the legacy docs invented."""
+    sheets = json.loads(json.dumps(WORKSHEETS))
+    sheets[2]["shelves"]["columns"][0]["table_calc"] = "CumAvg"
+
+    assert any("CumAvg" in error for error in _errors(worksheets=sheets))
+
+
+# --- Reference lines (AC #1) ---------------------------------------------------
+
+def test_a_reference_line_is_a_pane_child_with_qualified_columns():
+    """The legacy FEATURES.md puts it in <view> with unqualified refs; the XSD and Tableau's
+    own output both put it in <pane> with fully qualified ones."""
+    pane = _worksheet_element("Revenue Trend").find("table/panes/pane")
+    line = pane.find("reference-line")
+
+    assert line is not None
+    assert line.get("axis-column") == f"[{DATASOURCE_ID}].[sum:revenue:qk]"
+    assert line.get("value-column") == line.get("axis-column")
+    assert line.get("formula") == "average"
+    assert line.get("scope") == "per-table"
+    assert line.get("id") == "refline0"
+    assert line.get("z-order") == "1"
+    assert line.get("enable-instant-analytics") == "true"
+
+
+def test_a_labelled_reference_line_is_label_type_custom():
+    """A label template only renders when the line says its labelling is custom."""
+    line = _worksheet_element("Revenue Trend").find("table/panes/pane/reference-line")
+
+    assert line.get("label-type") == "custom"
+    assert line.get("label") == "<Computation>: <Value>"
+
+
+def test_a_reference_line_comes_after_the_encodings_in_its_pane():
+    """PaneSpecification-G's sequence: a line before <encodings> fails the XSD."""
+    pane = _worksheet_element("Revenue Trend").find("table/panes/pane")
+    tags = [child.tag for child in pane]
+
+    assert tags == ["view", "mark", "reference-line"] or tags.index(
+        "reference-line"
+    ) > tags.index("mark")
+
+
+def test_a_reference_lines_field_is_declared_by_the_worksheet():
+    """A line drawn against an instance the view never declares draws nothing."""
+    dependencies = _worksheet_element("Revenue Trend").find(
+        "table/view/datasource-dependencies"
+    )
+
+    assert dependencies.find("column-instance[@name='[sum:revenue:qk]']") is not None
+
+
+@pytest.mark.parametrize("key, value", [
+    ("formula", "mean"), ("scope", "per-sheet"), ("label_type", "shouty"),
+])
+def test_a_reference_line_outside_the_schemas_enums_is_rejected(key, value):
+    """Each of the three is an XSD enumeration - a wrong value is a file Tableau refuses."""
+    sheets = json.loads(json.dumps(WORKSHEETS))
+    sheets[1]["reference_lines"][0][key] = value
+
+    assert any(value in error for error in _errors(worksheets=sheets))
+
+
+# --- Parameters (AC #1) --------------------------------------------------------
+
+def test_the_parameters_datasource_is_inline_connectionless_and_last():
+    """Tableau resolves [Parameters].[...] from a datasource that has no connection, after
+    the real ones."""
+    datasources = FEATURES_ROOT.findall("datasources/datasource")
+
+    assert datasources[-1].get("name") == features.PARAMETERS_DATASOURCE
+    assert datasources[-1].get("hasconnection") == "false"
+    assert datasources[-1].get("inline") == "true"
+    assert datasources[-1].find("aliases").get("enabled") == "yes"
+
+
+def test_a_list_parameter_declares_its_members_as_literals():
+    """A string member is quoted; an unquoted 'on' reads as a field reference."""
+    column = FEATURES_ROOT.find(
+        f"datasources/datasource[@name='{features.PARAMETERS_DATASOURCE}']"
+        f"/column[@name='[Selected Region]']"
+    )
+
+    assert column.get("param-domain-type") == "list"
+    assert column.get("value") == '"All"'
+    assert column.find("calculation").get("formula") == '"All"'
+    assert [member.get("value") for member in column.find("members")] == [
+        '"All"', '"East"', '"North"', '"West"',
+    ]
+
+
+def test_a_range_parameter_declares_its_bounds_and_granularity():
+    """Without a granularity the slider has no step, and Tableau rewrites the parameter."""
+    column = FEATURES_ROOT.find(
+        f"datasources/datasource[@name='{features.PARAMETERS_DATASOURCE}']"
+        f"/column[@name='[Top N]']"
+    )
+
+    assert column.get("param-domain-type") == "range"
+    assert column.get("default-format") == "#,##0"
+    assert column.attrib["datatype"] == "integer"
+    assert column.attrib["type"] == "quantitative"
+    assert column.attrib["role"] == features.PARAMETER_ROLE
+    assert column.find("range").attrib == {"granularity": "5", "max": "50", "min": "5"}
+
+
+@pytest.mark.parametrize("value, data_type, literal", [
+    ("on", "string", '"on"'),
+    (10, "integer", "10"),
+    (2.5, "real", "2.5"),
+    (True, "boolean", "true"),
+    ("2024-01-01", "date", "#2024-01-01#"),
+])
+def test_a_parameter_value_is_rendered_as_its_tableau_literal(value, data_type, literal):
+    """Each datatype has its own delimiters; the wrong ones make the value unparseable."""
+    assert features.parameter_literal(value, data_type) == literal
+
+
+def test_a_worksheet_declares_the_parameter_its_calculation_reads():
+    """A calculation reading a parameter the view does not declare is unresolvable, and
+    Tableau opens the sheet with the field greyed out."""
+    sheets = json.loads(json.dumps(WORKSHEETS))
+    sheets[0]["encodings"] = {"text": "Show Breakdown"}
+    view = _worksheet_element(
+        "Revenue KPI", ET.fromstring(_render(_manifest(worksheets=sheets)))
+    ).find("table/view")
+
+    assert view.find(
+        f"datasources/datasource[@name='{features.PARAMETERS_DATASOURCE}']"
+    ) is not None
+    declared = view.find(
+        f"datasource-dependencies[@datasource='{features.PARAMETERS_DATASOURCE}']"
+    )
+    assert declared.find("column[@name='[Selected Region]']") is not None
+    # No domain at the worksheet level: the parameter's members are the datasource's business.
+    assert declared.find("column[@name='[Selected Region]']/members") is None
+
+
+def test_the_datasource_declares_the_parameters_its_calculations_read():
+    """Desktop adds this dependency on save: a calculation in the datasource reads
+    [Parameters].[x], so the datasource declares the link - domain-less, between <layout> and
+    <object-graph>."""
+    datasource = FEATURES_ROOT.find(f"datasources/datasource[@name='{DATASOURCE_ID}']")
+    dependencies = datasource.find(
+        f"datasource-dependencies[@datasource='{features.PARAMETERS_DATASOURCE}']"
+    )
+
+    assert [column.get("name") for column in dependencies] == ["[Selected Region]"]
+    assert dependencies.find("column/members") is None
+    tags = [child.tag for child in datasource]
+    assert tags.index("layout") < tags.index("datasource-dependencies") < \
+        tags.index("object-graph")
+
+
+def test_a_worksheet_that_reads_no_parameter_declares_none():
+    """Every sheet declaring every parameter is noise Tableau rewrites on save."""
+    view = _worksheet_element("Revenue Trend").find("table/view")
+
+    assert view.find(
+        f"datasources/datasource[@name='{features.PARAMETERS_DATASOURCE}']"
+    ) is None
+    assert view.find(
+        f"datasource-dependencies[@datasource='{features.PARAMETERS_DATASOURCE}']"
+    ) is None
+
+
+def test_no_parameters_means_no_parameters_datasource():
+    """An empty inline datasource is a workbook the schema refuses."""
+    root = ET.fromstring(_render(_manifest(
+        parameters=[], objects=[OBJECTS[0]], actions=ACTIONS[:2],
+        layout=_layout_without_parameter_control(),
+        calculated_fields=CALCULATED_FIELDS[:2],
+        worksheets=_worksheets_without_dzv(),
+    )))
+
+    assert root.find(
+        f"datasources/datasource[@name='{features.PARAMETERS_DATASOURCE}']"
+    ) is None
+
+
+def _layout_without_parameter_control() -> dict:
+    """The layout with the parameter-control zone (and the DZV binding) dropped."""
+    layout = json.loads(json.dumps(LAYOUT))
+    layout["root"]["children"][0]["children"] = [{"id": "flt-region", "size": 100}]
+    layout["root"]["children"][-1].pop("visibility")
+    return layout
+
+
+def _worksheets_without_dzv() -> list[dict]:
+    """The worksheets, with nothing referencing the boolean DZV calculation."""
+    return json.loads(json.dumps(WORKSHEETS))
+
+
+@pytest.mark.parametrize("override, expected", [
+    ({"name": "Bad", "data_type": "money"}, "money"),
+    ({"name": "Bad", "data_type": "string", "values": []}, "values"),
+    ({"name": "Bad", "data_type": "integer", "range": {"min": 1}}, "range"),
+    ({"name": "Bad", "data_type": "integer", "values": [1], "range": {"min": 1, "max": 2}},
+     "both"),
+])
+def test_a_malformed_parameter_is_rejected(override, expected):
+    """Each message names the parameter and what is wrong with it."""
+    assert any(expected in error for error in _errors(parameters=[*PARAMETERS, override]))
+
+
+# --- Actions (AC #2) -----------------------------------------------------------
+
+def test_actions_sit_between_the_datasources_and_the_worksheets():
+    """WorkbookFile-CT's order: datasources, mapsources, actions, worksheets, dashboards."""
+    tags = [child.tag for child in FEATURES_ROOT]
+
+    assert tags.index("datasources") < tags.index("actions") < tags.index("worksheets")
+    assert tags.index("worksheets") < tags.index("dashboards") < tags.index("windows")
+
+
+def test_a_filter_action_targets_one_real_sheet_and_excludes_its_source():
+    """Targeting the dashboard instead would cross-filter every sheet on it, including the
+    ones the manifest never listed."""
+    action = FEATURES_ROOT.find("actions/action[@caption='Trend cross-filter']")
+    params = {param.get("name"): param.get("value") for param in action.iter("param")}
+
+    assert action.find("command").get("command") == "tsc:tsl-filter"
+    assert action.find("source").attrib == {
+        "dashboard": twb.DASHBOARD_NAME, "type": "sheet", "worksheet": "Revenue Trend",
+    }
+    assert action.find("activation").attrib == {"auto-clear": "true", "type": "on-select"}
+    assert params == {
+        "exclude": "Revenue Trend", "special-fields": "all", "target": "Detail Table",
+    }
+
+
+def test_a_highlight_action_brushes_on_hover():
+    """A highlight is tsc:brush over the shared field captions - a filter command would
+    remove the unselected marks instead of dimming them."""
+    action = FEATURES_ROOT.find("actions/action[@caption='Highlight region']")
+    params = {param.get("name"): param.get("value") for param in action.iter("param")}
+
+    assert action.find("command").get("command") == "tsc:brush"
+    assert action.find("activation").get("type") == "on-hover"
+    assert params == {
+        "exclude": "Revenue Trend", "field-captions": "all", "target": "Detail Table",
+    }
+
+
+def test_a_parameter_action_writes_a_field_into_a_parameter():
+    """The source field is a qualified column-instance and the target a qualified parameter;
+    an unqualified either end is an action Tableau drops on load."""
+    action = FEATURES_ROOT.find("actions/edit-parameter-action[@caption='Pick region']")
+    params = {param.get("name"): param.get("value") for param in action.find("params")}
+
+    assert action.find("source").get("worksheet") == "Detail Table"
+    assert action.find("agg-type").get("type") == "attr"
+    # Clearing the selection resets the parameter, so the panel it reveals hides itself again.
+    # The value is Tableau's own serialization: the prefix token, then *undelimited* text.
+    assert action.find("clear-option").attrib == {
+        "type": "assign-fixed-value", "value": "s:LROOT:All",
+    }
+    assert params == {
+        "source-field": f"[{DATASOURCE_ID}].[none:region:nk]",
+        "target-parameter": "[Parameters].[Selected Region]",
+    }
+
+
+def test_a_parameter_actions_source_field_is_declared_by_its_sheet():
+    """The action reads the field off the clicked mark, so the sheet has to declare it even
+    though nothing places it on a shelf."""
+    dependencies = _worksheet_element("Detail Table").find(
+        "table/view/datasource-dependencies"
+    )
+
+    assert dependencies.find("column-instance[@name='[none:region:nk]']") is not None
+
+
+def test_parameter_actions_come_after_the_sheet_actions():
+    """The XSD's <actions> sequence puts every <edit-parameter-action> last."""
+    tags = [child.tag for child in FEATURES_ROOT.find("actions")]
+
+    assert tags == ["action", "action", "action", "edit-parameter-action"]
+
+
+def test_action_names_are_unique_and_deterministic():
+    """Two actions sharing a name is a workbook Tableau repairs by dropping one."""
+    names = [
+        element.get("name") for element in FEATURES_ROOT.find("actions")
+    ]
+
+    assert len(set(names)) == len(names)
+    assert names == [
+        element.get("name")
+        for element in ET.fromstring(_render()).find("actions")
+    ]
+    assert all(name.startswith("[Action") and name.endswith("]") for name in names)
+
+
+def test_one_action_is_emitted_per_target():
+    """A two-target cross-filter is two actions, each excluding the same source."""
+    actions = json.loads(json.dumps(ACTIONS))
+    actions[0]["targets"] = ["chart-detail", "kpi-revenue"]
+    root = ET.fromstring(_render(_manifest(actions=actions)))
+
+    emitted = root.findall("actions/action[@caption='Trend cross-filter']")
+    targets = [
+        param.get("value") for action in emitted for param in action.iter("param")
+        if param.get("name") == "target"
+    ]
+    assert targets == ["Detail Table", "Revenue KPI"]
+
+
+def test_no_actions_means_no_actions_element():
+    """The schema requires at least one child, so an empty <actions/> is a file Tableau
+    refuses - not a workbook without interactivity."""
+    root = ET.fromstring(_render(_manifest(actions=[])))
+
+    assert root.find("actions") is None
+
+
+def test_an_action_whose_endpoint_is_not_a_view_is_rejected():
+    """An action runs off a worksheet's marks: a text or filter zone has none."""
+    actions = json.loads(json.dumps(ACTIONS))
+    actions[0]["targets"] = ["flt-region"]
+
+    assert any("not a view" in error for error in _errors(actions=actions))
+
+
+def test_an_action_with_an_unknown_run_on_is_rejected():
+    """'click' is not one of Tableau's two activations."""
+    actions = json.loads(json.dumps(ACTIONS))
+    actions[0]["run_on"] = "click"
+
+    assert any("run_on" in error for error in _errors(actions=actions))
+
+
+def test_a_parameter_action_without_a_field_is_rejected():
+    """Without a source field there is no value to write into the parameter."""
+    actions = json.loads(json.dumps(ACTIONS))
+    actions[-1].pop("field")
+
+    assert any("'field'" in error for error in _errors(actions=actions))
+
+
+# --- Quick filters and parameter controls (AC #3) ------------------------------
+
+def test_a_filter_card_zone_names_its_sheet_field_and_mode():
+    """A card is the UI for one sheet's filter, so it carries both ends."""
+    zone = _zone("flt-region")
+
+    assert zone.get("type-v2") == "filter"
+    assert zone.get("name") == "Revenue Trend"
+    assert zone.get("param") == f"[{DATASOURCE_ID}].[none:region:nk]"
+    assert zone.get("mode") == "checkdropdown"
+
+
+def test_a_filter_card_injects_the_filter_it_controls():
+    """Without a worksheet filter the card has nothing to control; an enumerated member list
+    would freeze today's domain into the workbook, so it is the all-members form."""
+    view = _worksheet_element("Revenue Trend").find("table/view")
+    filter_element = view.find(f"filter[@column='[{DATASOURCE_ID}].[none:region:nk]']")
+
+    assert filter_element.get("class") == "categorical"
+    assert filter_element.find("groupfilter").get("function") == "level-members"
+    assert filter_element.find("groupfilter").get("level") == "[none:region:nk]"
+
+
+def test_the_quick_filtered_column_reaches_the_slices():
+    """A filtered field missing from <slices> is a filter Tableau silently ignores (AC #3)."""
+    slices = _worksheet_element("Revenue Trend").find("table/view/slices")
+
+    assert [column.text for column in slices] == [f"[{DATASOURCE_ID}].[none:region:nk]"]
+
+
+def test_a_card_over_an_already_filtered_field_adds_no_second_filter():
+    """An explicit member list is a narrower filter than 'all members', not a duplicate -
+    two filters on one column is a worksheet Tableau cannot resolve."""
+    sheets = json.loads(json.dumps(WORKSHEETS))
+    sheets[1]["filters"] = [{"field": "region", "values": ["West"]}]
+    view = _worksheet_element(
+        "Revenue Trend", ET.fromstring(_render(_manifest(worksheets=sheets)))
+    ).find("table/view")
+
+    filters = view.findall(f"filter[@column='[{DATASOURCE_ID}].[none:region:nk]']")
+    assert len(filters) == 1
+    assert filters[0].find("groupfilter").get("function") == "member"
+
+
+def test_the_dashboard_declares_what_its_control_zones_read():
+    """A card whose field only the worksheet declares crashes Tableau on open (AC #3)."""
+    dashboard = FEATURES_ROOT.find("dashboards/dashboard")
+    declared = [
+        element.get("name") for element in dashboard.find("datasources")
+    ]
+    dependencies = dashboard.find(
+        f"datasource-dependencies[@datasource='{DATASOURCE_ID}']"
+    )
+
+    assert declared == [DATASOURCE_ID, features.PARAMETERS_DATASOURCE]
+    assert dependencies.find("column[@name='[region]']") is not None
+    assert dependencies.find("column-instance[@name='[none:region:nk]']") is not None
+    parameters = dashboard.find(
+        f"datasource-dependencies[@datasource='{features.PARAMETERS_DATASOURCE}']"
+    )
+    assert parameters.find("column[@name='[Top N]']/range") is not None
+    # Only the parameters a *control zone* puts on the dashboard: one a sheet's calculation
+    # reads is that sheet's declaration, and Desktop drops it from here on save.
+    assert [column.get("name") for column in parameters] == ["[Top N]"]
+
+
+def test_the_dashboards_declarations_come_before_its_zones():
+    """Dashboard-CT's sequence: style, size, datasources, datasource-dependencies, zones."""
+    tags = [child.tag for child in FEATURES_ROOT.find("dashboards/dashboard")]
+
+    assert tags == [
+        "style", "size", "datasources", "datasource-dependencies",
+        "datasource-dependencies", "zones", "simple-id",
+    ]
+
+
+def test_a_parameter_control_zone_names_its_parameter():
+    """The control is addressed by the qualified parameter, and nothing else."""
+    zone = _zone("prm-topn")
+
+    assert zone.get("type-v2") == "paramctrl"
+    assert zone.get("param") == "[Parameters].[Top N]"
+    # A range parameter's widget is a slider; Desktop rewrites 'compact' on save.
+    assert zone.get("mode") == "slider"
+    assert zone.get("name") is None  # a parameter is not a sheet's
+
+
+def test_a_control_kind_with_nothing_to_control_still_reserves_its_box():
+    """An image or a button needs a reference the manifest does not carry - the geometry the
+    analyst approved survives as an empty zone rather than a crash."""
+    document = _manifest(
+        objects=[*OBJECTS, {"element_id": "img-logo", "kind": "image"}],
+        layout=_layout_with_logo(),
+    )
+    root = ET.fromstring(_render(document))
+
+    assert _zone("img-logo", root).get("type-v2") == "empty"
+
+
+def _layout_with_logo() -> dict:
+    """The layout with an extra image zone in the control row."""
+    layout = json.loads(json.dumps(LAYOUT))
+    layout["root"]["children"][0]["children"].append({"id": "img-logo", "size": 20})
+    return layout
+
+
+@pytest.mark.parametrize("override, expected", [
+    ({"kind": "filter", "worksheet": "Revenue Trend"}, "'field'"),
+    ({"kind": "filter", "field": "region"}, "'worksheet'"),
+    ({"kind": "filter", "field": "region", "worksheet": "Nowhere"}, "Nowhere"),
+    ({"kind": "filter", "field": "nope", "worksheet": "Revenue Trend"}, "nope"),
+    ({"kind": "filter", "field": "revenue", "worksheet": "Revenue Trend"}, "real"),
+    ({"kind": "filter", "field": "region", "worksheet": "Revenue Trend",
+      "mode": "slider"}, "slider"),
+    ({"kind": "parameter"}, "parameter"),
+    ({"kind": "parameter", "parameter": "Nope"}, "Nope"),
+])
+def test_a_malformed_control_object_is_rejected(override, expected):
+    """Every message names the zone and the missing or wrong reference."""
+    objects = [{"element_id": "flt-region", **override}, OBJECTS[1]]
+
+    assert any(expected in error for error in _errors(objects=objects))
+
+
+# --- Dynamic Zone Visibility ---------------------------------------------------
+
+def test_the_datagraph_wires_the_boolean_field_to_the_controlled_zone():
+    """Two nodes and one edge per zone: the field's value output feeds the zone's visibility
+    input, and both nodes are listed against the execution subgraph or neither runs."""
+    graph = FEATURES_ROOT.find("datagraph/graph")
+    field_node = graph.find("nodes/single-value-field-node")
+    zone_node = graph.find("nodes/dashboard-zone-visibility-node")
+    edge = graph.find("edges/edge")
+
+    assert field_node.get("fieldname") == f"[{DATASOURCE_ID}].[Show Breakdown]"
+    assert edge.get("from") == field_node.get("value-output-guid")
+    assert edge.get("to") == zone_node.get("visibility-input-guid")
+
+    subgraph = graph.find("properties/default-execution-subgraph-guid").get("value")
+    pairs = graph.findall("node-execution-subgraphs/pair")
+    assert {pair.get("node-guid") for pair in pairs} == {
+        field_node.get("node-guid"), zone_node.get("node-guid"),
+    }
+    assert {pair.get("execution-subgraph-guid") for pair in pairs} == {subgraph}
+
+
+def test_the_visibility_field_is_on_the_controlled_sheets_detail_shelf():
+    """Tableau reads a DZV field off the *view*: with the datagraph alone the field is
+    unevaluable and the zone never toggles (the workbook opens, it just does nothing). A
+    Desktop-saved DZV workbook puts it on the controlled sheet's Detail shelf."""
+    view = _worksheet_element("Category Mix").find("table/view")
+    pane = _worksheet_element("Category Mix").find("table/panes/pane")
+    instance = f"[{DATASOURCE_ID}].[none:Show Breakdown:nk]"
+
+    assert view.find(
+        f"datasource-dependencies[@datasource='{DATASOURCE_ID}']"
+        f"/column-instance[@column='[Show Breakdown]']"
+    ) is not None
+    assert [lod.get("column") for lod in pane.findall("encodings/lod")] == [instance]
+    # ... and only there: every other sheet is left alone.
+    assert _worksheet_element("Revenue Trend").find("table/panes/pane/encodings/lod") is None
+    # The field's formula reads a parameter, so the sheet it landed on must declare it too -
+    # placing the field before the parameters are attached is what gets this wrong.
+    assert view.find(
+        f"datasource-dependencies[@datasource='{features.PARAMETERS_DATASOURCE}']"
+        f"/column[@name='[Selected Region]']"
+    ) is not None
+
+
+def test_the_visibility_node_points_at_the_dashboard_and_the_right_zone():
+    """The zone id is the *wrapper* of a titled element - hiding only the content zone would
+    leave its title and legend behind."""
+    zone_node = FEATURES_ROOT.find("datagraph/graph/nodes/dashboard-zone-visibility-node")
+
+    assert zone_node.get("dashboard-identifier") == FEATURES_ROOT.find(
+        "dashboards/dashboard/simple-id"
+    ).get("uuid")
+    assert zone_node.get("zone-id") == _zone("chart-category").get("id")
+
+
+def test_a_titled_element_is_controlled_at_its_wrapper():
+    """The wrapper holds the header row, the sheet and the legend; the datagraph must name it
+    rather than the sheet zone inside it."""
+    sheets = json.loads(json.dumps(WORKSHEETS))
+    sheets[3]["title"] = "Category mix"
+    root = ET.fromstring(_render(_manifest(worksheets=sheets)))
+    zone_node = root.find("datagraph/graph/nodes/dashboard-zone-visibility-node")
+
+    assert zone_node.get("zone-id") == _zone("V-chart-category", root).get("id")
+
+
+def test_the_dzv_format_flags_are_present_and_alphabetical():
+    """Tableau writes the format manifest alphabetically; out of order it rewrites the file."""
+    flags = [child.tag for child in FEATURES_ROOT.find("document-format-change-manifest")]
+
+    assert set(features.DZV_FORMAT_FLAGS) <= set(flags)
+    assert flags == sorted(flags)
+
+
+def test_a_non_string_parameter_keeps_the_attested_clear_option():
+    """Only a string parameter's reset serialization is attested; guessing the tag for the
+    others is what makes Desktop refuse to open the action editor at all."""
+    actions = json.loads(json.dumps(ACTIONS))
+    actions[-1]["targets"] = ["Top N"]
+    actions[-1]["field"] = "revenue"
+    root = ET.fromstring(_render(_manifest(actions=actions)))
+
+    assert root.find("actions/edit-parameter-action/clear-option").attrib == {
+        "type": "do-nothing", "value": features.CLEAR_VALUE_PREFIX,
+    }
+
+
+def test_a_parameter_action_brings_its_format_flags():
+    """Desktop 2025.1 loads <edit-parameter-action> against a schema that does not declare it
+    unless the format manifest announces ParameterAction - the workbook is refused outright,
+    which is how this was found."""
+    flags = [child.tag for child in FEATURES_ROOT.find("document-format-change-manifest")]
+
+    assert set(features.PARAMETER_ACTION_FORMAT_FLAGS) <= set(flags)
+
+
+def test_no_parameter_action_means_no_parameter_action_flags():
+    """A flag for a feature the file does not use makes Tableau migrate a workbook that needs
+    no migration."""
+    actions = [entry for entry in ACTIONS if entry["type"] != "parameter"]
+    root = ET.fromstring(_render(_manifest(actions=actions)))
+    flags = [child.tag for child in root.find("document-format-change-manifest")]
+
+    assert root.find("actions/edit-parameter-action") is None
+    assert not set(features.PARAMETER_ACTION_FORMAT_FLAGS) & set(flags)
+
+
+def test_no_visibility_means_no_datagraph_and_no_extra_flags():
+    """The flags announce a document feature: claiming one the file does not use makes
+    Tableau migrate a workbook that needs no migration."""
+    layout = json.loads(json.dumps(LAYOUT))
+    layout["root"]["children"][-1].pop("visibility")
+    root = ET.fromstring(_render(_manifest(layout=layout)))
+    flags = [child.tag for child in root.find("document-format-change-manifest")]
+
+    assert root.find("datagraph") is None
+    assert not set(features.DZV_FORMAT_FLAGS) & set(flags)
+
+
+def test_the_datagraph_comes_after_the_windows():
+    """WorkbookFile-CT puts <datagraph> after <windows>; anywhere else fails the XSD."""
+    tags = [child.tag for child in FEATURES_ROOT]
+
+    assert tags.index("windows") < tags.index("datagraph")
+
+
+@pytest.mark.parametrize("field_name, expected", [
+    ("Margin Pct", "boolean"),   # declared, but not a boolean
+    ("Nonexistent", "Nonexistent"),
+])
+def test_a_visibility_field_that_is_not_a_boolean_calc_is_rejected(field_name, expected):
+    """Tableau shows or hides a zone on one boolean value, and the builder qualifies the
+    field against the datasource that declares it."""
+    layout = json.loads(json.dumps(LAYOUT))
+    layout["root"]["children"][-1]["visibility"] = field_name
+
+    assert any(expected in error for error in _errors(layout=layout))
+
+
+# --- The validators, and the whole path ----------------------------------------
+
+def test_the_features_workbook_passes_the_semantic_validator(tmp_path):
+    """The legacy cross-reference checks, on a workbook with every feature switched on."""
+    import validate_twb
+
+    twb_path = tmp_path / "features.twb"
+    twb_path.write_text(FEATURES_XML, encoding="utf-8")
+
+    report = validate_twb.TwbValidator(str(twb_path)).validate()
+
+    assert not [
+        f"{result.name}: {result.details}" for result in report.results if not result.passed
+    ]
+
+
+def test_the_features_workbook_passes_the_xsd(tmp_path):
+    """Actions, parameters, reference lines and the datagraph are all schema-checked.
+
+    The 2024.2-2025.x target legitimately omits ``<explain-data>``, which the 2026.1 schema
+    requires - that one error is the documented version shift, not breakage.
+    """
+    pytest.importorskip("lxml")
+    import validate_twb_xsd
+
+    twb_path = tmp_path / "features.twb"
+    twb_path.write_text(FEATURES_XML, encoding="utf-8")
+
+    _, errors = validate_twb_xsd.validate(
+        twb_path, validate_twb_xsd.load_schema(validate_twb_xsd.XSD_PATH)
+    )
+
+    assert [error.message for error in errors if "explain-data" not in error.message] == []
+
+
+def test_the_whole_build_produces_a_twbx_that_keeps_its_interactivity(tmp_path):
+    """End to end (AC #4): a manifest on disk with a cross-filter, a highlight and a filter
+    card becomes a packaged .twbx whose .twb still carries them."""
+    (tmp_path / "STATE.md").write_text(
+        build.apply_status_updates(
+            init.render_state_md(TARGET_VERSION),
+            {"spec": "approved", "data": "approved"},
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "DATA-MODEL.md").write_text(DATA_MODEL, encoding="utf-8")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "sales_orders.csv").write_text(
+        ",".join(CSV_HEADER) + "\n2024-01-05,West,Technology,1200.5,120.5\n",
+        encoding="utf-8",
+    )
+    version_dir = tmp_path / build.VERSION_DIR / "v_1"
+    version_dir.mkdir(parents=True)
+    (version_dir / build.SPEC_FILENAME).write_text(
+        "# Implementation Spec: Sales\n\n"
+        "## Element Mapping\n\n"
+        "| id | tableau construct | justification |\n"
+        "|----|-------------------|---------------|\n"
+        "| kpi-revenue | Text mark, [Margin Pct] | - |\n\n"
+        "## Layout\n\nThe approved tree.\n\n"
+        f"```json\n{json.dumps(LAYOUT, indent=2)}\n```\n",
+        encoding="utf-8",
+    )
+    (version_dir / build.MANIFEST_FILENAME).write_text(
+        json.dumps(_manifest(), indent=2), encoding="utf-8"
+    )
+
+    result = build.build_workbook(tmp_path)
+
+    assert result.ok is True, result.message
+    packaged = next(version_dir.glob("*.twbx"))
+    with zipfile.ZipFile(packaged) as archive:
+        name = next(item for item in archive.namelist() if item.endswith(".twb"))
+        root = ET.fromstring(archive.read(name).decode("utf-8"))
+
+    assert [element.tag for element in root.find("actions")] == [
+        "action", "action", "action", "edit-parameter-action",
+    ]
+    zone_types = {zone.get("type-v2") for zone in root.iter("zone")}
+    assert {"filter", "paramctrl"} <= zone_types
+    assert root.find("datagraph") is not None
+
+
+def test_the_demo_manifest_template_documents_every_new_key():
+    """The template is what an agent authors a manifest from - a key it does not mention is
+    a feature no dashboard will ever use."""
+    template = (
+        Path(twb.__file__).resolve().parent.parent
+        / "references" / "BUILD-MANIFEST-TEMPLATE.md"
+    ).read_text(encoding="utf-8")
+
+    for key in (
+        "table_calc", "reference_lines", "visibility", "run_on", "data_type",
+        "current_value", "checkdropdown",
+    ):
+        assert key in template, f"BUILD-MANIFEST-TEMPLATE.md never mentions '{key}'"
+
+
+def test_the_manifest_template_example_validates():
+    """The template's worked example is what an agent copies from, so it has to be a manifest
+    the validator accepts - a documented key with a wrong shape is worse than no docs."""
+    template = (
+        Path(twb.__file__).resolve().parent.parent
+        / "references" / "BUILD-MANIFEST-TEMPLATE.md"
+    ).read_text(encoding="utf-8")
+
+    example = template.split("## Example", 1)[1].split("```json", 1)[1].split("```", 1)[0]
+
+    assert manifest.validate_manifest(
+        json.loads(example), DATA_MODEL, TARGET_VERSION
+    ) == []

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -244,12 +244,16 @@ def test_each_calculated_field_is_declared_exactly_once_per_datasource():
     ("[quantity] * [unit_price]", False),
     ("{FIXED [region]: SUM([revenue])}", False),
     ("{ INCLUDE [region] : AVG([revenue]) }", False),
-    ("SUM([revenue]) / {FIXED : SUM([revenue])}", False),
+    ("{FIXED [region]: SUM([revenue])} / 2", False),
+    ("SUM([revenue]) / {FIXED : SUM([revenue])}", True),
+    ("{FIXED : SUM([revenue])} - SUM([cost])", True),
+    ("{FIXED [a]: MAX({FIXED [b]: SUM([revenue])})}", False),
     ("", False),
 ])
 def test_is_aggregate_formula_reads_lods_as_row_level(formula, aggregates):
     """An LOD contains SUM( but produces a row-level value, so it must be re-aggregated on
-    the shelf. Matching the SUM inside it is what put the User derivation on an LOD."""
+    the shelf. Matching the SUM inside it is what put the User derivation on an LOD - but an
+    aggregate *outside* the braces still aggregates, so only the braced span is discounted."""
     assert worksheet.is_aggregate_formula(formula) is aggregates
 
 
@@ -505,15 +509,25 @@ def _worksheets_without_dzv() -> list[dict]:
 
 
 @pytest.mark.parametrize("override, expected", [
-    ({"name": "Bad", "data_type": "money"}, "money"),
-    ({"name": "Bad", "data_type": "string", "values": []}, "values"),
-    ({"name": "Bad", "data_type": "integer", "range": {"min": 1}}, "range"),
-    ({"name": "Bad", "data_type": "integer", "values": [1], "range": {"min": 1, "max": 2}},
-     "both"),
+    ({"name": "Bad", "data_type": "money", "current_value": 1}, "money"),
+    ({"name": "Bad", "data_type": "string", "current_value": "x", "values": []}, "values"),
+    ({"name": "Bad", "data_type": "integer", "current_value": 1, "range": {"min": 1}},
+     "range"),
+    ({"name": "Bad", "data_type": "integer", "current_value": 1, "values": [1],
+      "range": {"min": 1, "max": 2}}, "both"),
+    ({"name": "Bad", "data_type": "string", "values": ["x"]}, "current_value"),
 ])
 def test_a_malformed_parameter_is_rejected(override, expected):
     """Each message names the parameter and what is wrong with it."""
     assert any(expected in error for error in _errors(parameters=[*PARAMETERS, override]))
+
+
+def test_a_parameter_without_a_current_value_is_never_guessed_at():
+    """The value *is* the column's calculation, so a guessed one silently changes what every
+    calc reading the parameter computes. Validation demands it and the builder skips it."""
+    entry = {"name": "Bad", "data_type": "string", "values": ["x"]}
+
+    assert features.plan_parameters([entry]) == []
 
 
 # --- Actions (AC #2) -----------------------------------------------------------
@@ -649,6 +663,25 @@ def test_a_parameter_action_without_a_field_is_rejected():
     actions[-1].pop("field")
 
     assert any("'field'" in error for error in _errors(actions=actions))
+
+
+@pytest.mark.parametrize("action_type", sorted(manifest.UNBUILDABLE_ACTION_TYPES))
+def test_an_action_this_builder_cannot_emit_is_rejected(action_type):
+    """A 'set' or 'url' action that validated would build a dashboard whose interaction is
+    silently absent - worse than a manifest that fails and names the alternative."""
+    actions = json.loads(json.dumps(ACTIONS))
+    actions[0]["type"] = action_type
+
+    assert any(action_type in error for error in _errors(actions=actions))
+
+
+def test_a_parameter_action_targeting_a_non_string_parameter_is_rejected():
+    """Only a string's clear value has an attested serialization. A non-string target would
+    build an action that never resets - and a DZV panel it reveals would never hide again."""
+    actions = json.loads(json.dumps(ACTIONS))
+    actions[-1]["targets"] = ["Top N"]
+
+    assert any("Top N" in error and "string" in error for error in _errors(actions=actions))
 
 
 # --- Quick filters and parameter controls (AC #3) ------------------------------

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -42,14 +42,14 @@ INSET_Y = round(zones.ROOT_MARGIN_PX / CANVAS["height"] * zones.ZONE_SPACE)
 def _render(root, leaves=None, canvas=None, tokens=None):
     """Render one layout tree and return ``(<zones> element, root zone id, embedded)``."""
     container = ET.Element("zones")
-    root_id, embedded = zones.render_zones(
+    rendered = zones.render_zones(
         container,
         root,
         canvas or CANVAS,
         leaves or {},
         tokens or worksheet.DesignTokens(),
     )
-    return container, root_id, embedded
+    return container, rendered.root_zone_id, rendered.embedded
 
 
 def _tree(node):
@@ -412,10 +412,12 @@ def test_a_box_too_short_for_its_title_and_legend_is_squeezed_not_overflowed():
 
 @pytest.mark.parametrize("kind, type_v2", [
     ("text", "text"), ("blank", "empty"),
-    # Deferred to #37: each needs a reference the manifest does not carry yet, so the layout
-    # reserves the box rather than emitting a zone Tableau cannot resolve.
-    ("image", "empty"), ("filter", "empty"), ("legend", "empty"),
-    ("button", "empty"), ("parameter", "empty"),
+    # An image / button / standalone legend needs a reference the manifest does not carry, so
+    # the layout reserves the box rather than emitting a zone Tableau cannot resolve.
+    ("image", "empty"), ("legend", "empty"), ("button", "empty"),
+    # A filter card or a parameter control renders for real - but only once the leaf carries
+    # the 'param' it controls (see test_features.py); without one it also reserves its box.
+    ("filter", "empty"), ("parameter", "empty"),
     ("nonsense", "empty"),
 ])
 def test_object_kinds_map_to_their_zone_type(kind, type_v2):
@@ -495,8 +497,9 @@ LAYOUT_RICH_MANIFEST = {
     "objects": [
         {"element_id": "txt-title", "kind": "text", "text": "Sales Performance"},
         {"element_id": "img-logo", "kind": "image"},
-        {"element_id": "flt-region", "kind": "filter"},
-        {"element_id": "prm-target", "kind": "parameter"},
+        {"element_id": "flt-region", "kind": "filter",
+         "field": "region", "worksheet": "Revenue by Region"},
+        {"element_id": "prm-target", "kind": "parameter", "parameter": "Target"},
         {"element_id": "leg-region", "kind": "legend"},
         {"element_id": "btn-reset", "kind": "button"},
         {"element_id": "spc-gap", "kind": "blank"},
@@ -524,7 +527,10 @@ LAYOUT_RICH_MANIFEST = {
         },
     },
     "actions": [],
-    "parameters": [],
+    "parameters": [
+        {"name": "Target", "data_type": "real", "current_value": 100000,
+         "range": {"min": 0, "max": 500000, "step": 50000}},
+    ],
 }
 
 


### PR DESCRIPTION
Closes #37 — the interactive layer of `tableau-build` (CONTRACT.md step 8, §6).

## What lands

A new `skills/tableau-build/scripts/features.py` owns the three workbook-level
interactive constructs — the inline `Parameters` datasource, the `<actions>` block, and
the `<datagraph>` behind Dynamic Zone Visibility. It is pure and stdlib-only, and
generates **no ids**: action names and zone ids come from `twb.py`, so a rebuild stays
byte-identical.

Around it: table calcs on the column-instance, reference lines inside `<pane>`,
`default-format` on calculated fields, LOD formulas re-aggregated (an aggregate formula
is not), `filter` / `paramctrl` zones for control objects, the dashboard-level
declarations those zones need, and validation for every new manifest key.

## Acceptance criteria

- [x] Calculated fields / LOD / table calcs / reference lines / parameters emit valid
      datasource-level XML.
- [x] Filter, highlight and parameter actions are emitted in `<actions>` and reference
      real sheets, one action per target, with deterministic ids.
- [x] Dashboards with quick filters carry their own datasource declarations; the filtered
      column reaches the worksheet's `<slices>`.
- [x] A dashboard with a cross-filter and a highlight builds, validates, **and was verified
      by hand in Tableau Desktop 2025.1.10** — cross-filter, highlight, the parameter action
      and DZV all confirmed working ([noted on #37](https://github.com/laviDrori0702/tableau-dashboard-creator-skill/issues/37#issuecomment-5130125403)).
      The automated half is `test_the_whole_build_produces_a_twbx_that_keeps_its_interactivity`,
      which builds and opens a packaged `.twbx` in a tmp dir. **Not** `demo/` — that still holds
      v1 artifacts and gets regenerated under #30.

## The part worth reading: seven fidelity bugs the validators cannot catch

Both validators (semantic + XSD) passed a workbook Desktop then quietly rewrote — or
refused. Each of these was found by **saving a built workbook in Desktop and diffing the
XML**, and each is now locked by a test:

| symptom | cause |
|---|---|
| workbook refused to open | `<edit-parameter-action>` is gated on the `ParameterAction` / `ParameterActionClearSelection` format flags |
| DZV silently never toggled | the boolean field must be on the controlled sheet's **Detail shelf**, and that sheet must declare the parameter its formula reads — the `<datagraph>` alone is not enough |
| "internal error" opening the action editor | `<clear-option>` needs Tableau's own `s:LROOT:<value>` serialization for `assign-fixed-value` |
| calc rewritten on open | `PctTotal` instances are named `pcto:`, and `<table-calc>` carries no `aggregation` |
| control rewritten on open | a range parameter's widget is `mode='slider'`, not `compact` |
| reference line rewritten | Desktop writes `probability='95'` on every one |
| declarations rewritten | a dashboard declares only the parameters its control zones show; a datasource declares the parameters its own calculations read |

The lesson is in the docs now: for a new Tableau construct, a Desktop save-and-diff is
the only oracle — the XSD accepted all seven.

## Docs

`references/BUILD-MANIFEST-TEMPLATE.md` gains every new key, an Interactions section, and
a Dynamic Zone Visibility section: the single-value rule, both parameter shapes (a
two-value toggle with a control, or a parameter action's target compared against its
opening value), and an explicit ban on LOD visibility calcs — view-independent, yes, but
too hard to reason about or repair by hand.

## Narrowings from the code review

A two-axis review of this branch (standards + spec conformance) found five places where the
builder **accepted a manifest it could not honour and failed silently** — producing a workbook
that opens and is wrong. `fix(build): reject what the builder cannot deliver` turns each into
an error the analyst can act on, so three things that used to validate no longer do:

| what stopped validating | why it had to |
|---|---|
| `set` / `url` actions | They passed validation and `_plan_actions` skipped them — a specced drill built fine and simply had no drill. Now rejected, naming the parameter-action route. Deliberately harsher than #38's eventual per-piece refusal; [noted there](https://github.com/laviDrori0702/tableau-dashboard-creator-skill/issues/38#issuecomment-5130384745) as a stopgap to absorb. |
| a parameter action targeting a non-`string` parameter | Only a string's clear value has an attested serialization, so a non-string target built a `do-nothing` clear option — a DZV panel it revealed had nothing to hide it and the viewer was stuck, the exact failure the docs promised was impossible. Follow-up **#49** lifts this. |
| a parameter with no `current_value` | The value *is* the column's calculation. `plan_parameters` was guessing `values[0]` / `range.min`, so an omitted key built a parameter opening on a value nobody chose and silently changed every calc reading it. |

Plus one genuine bug, no narrowing: `is_aggregate_formula` read *any* formula containing `{` as
row-level, so `SUM([revenue]) / {FIXED : SUM([revenue])}` — an ordinary share-of-total calc —
reached the shelf with a second `SUM` around it, which Tableau refuses. A new
`strip_lod_expressions` discounts only the braced span, so an aggregate *outside* the braces
still counts.

## Follow-ups (not blocking)

- **#49** — attest the `<clear-option>` type tag for non-string parameters, and lift the
  narrowing above. Needs a Desktop save-and-diff, so it's `ready-for-human`.
- **#50** — attest the seven inferred `TABLE_CALC_PREFIXES` (only `PctTotal → pcto` was ever
  read off a real workbook). Same class of risk as the seven fidelity bugs above; the cost of a
  wrong prefix is a cosmetic rewrite on open, not a refused workbook.
- **#51** — Standards-axis cleanups deferred out of this PR: a `ValidationContext` for
  `manifest.py`'s 7-parameter signature, one shared layout-tree walk instead of three, and three
  `frozenset` aliases to delete. Zero behaviour change.

## Tests

`tests/test_features.py` is new: 90 tests, one per guarantee, plus an end-to-end
`build_workbook` case that opens the packaged `.twbx`. Full suite: **516 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

