### PR TITLE
feat(build): worksheet formatting - fit, brand palette, text marks, borders/lines/shading/alignment

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -53,6 +53,24 @@ A step may also have *optional reads* that enrich its output but never block it:
 > and the `STEPS` definition in `skills/tableau-route/scripts/route.py`. They are the prose and the
 > executable copy of the same graph and must stay identical.
 
+#### The two `DESIGN-TOKENS.md` sections `build` reads by name
+
+`brand` owns the file's shape, but `build` binds to two of its headings, so renaming either
+silently un-styles every workbook while both skills still pass their own checks:
+
+| heading | what `build` does with it |
+|---|---|
+| `## Typography` | The `- **Font family**:` and `- **Chart title**:` bullets become the worksheet font and title run. |
+| `### Chart series colors` | The ordered hex list becomes **every worksheet's colour palette**, emitted as an inline `<color-palette>` on the mark's colour encoding, plus the default mark colour for charts with nothing on Colour. |
+
+The palette needs **no data member values** — that was the open question that kept it unbuilt.
+A member-bound palette (`<map to='#…'><bucket>"West"</bucket>`) is impossible from a manifest,
+but an inline `<color-palette>` only lists colours *in order* and lets Tableau walk the field's
+domain against them. So profiling never has to pass distinct members to the manifest.
+
+Both headings are in `brand.DESIGN_TOKENS_REQUIRED_SECTIONS`; keep them there. Absent
+`DESIGN-TOKENS.md` ⇒ Tableau's own defaults, never an invented font or colour.
+
 ### 1.1 The `IMPLEMENTATION-SPEC.md` handoff (step 7 → step 8)
 
 `IMPLEMENTATION-SPEC.md` carries two machine-checked sections that `tableau-build` consumes; spec

--- a/skills/tableau-brand/scripts/brand.py
+++ b/skills/tableau-brand/scripts/brand.py
@@ -79,8 +79,11 @@ COMMIT_STATUSES: tuple[str, ...] = ("approved", "skipped")
 #: DESIGN-TOKENS sections every approved token file must have: the palette, the
 #: type, the spacing the step exists to capture, plus the fallback-disclosure
 #: section that flags every guessed value (CONTRACT acceptance criteria).
+#: ``Chart series colors`` is required by name because ``tableau-build`` reads that
+#: heading to build every worksheet's colour palette (CONTRACT.md §8) - a file that
+#: renames it still validates as "has Colors" and silently loses the brand's palette.
 DESIGN_TOKENS_REQUIRED_SECTIONS: tuple[str, ...] = (
-    "Colors", "Typography", "Spacing", "Fallback Decisions",
+    "Colors", "Chart series colors", "Typography", "Spacing", "Fallback Decisions",
 )
 
 #: Common but genuinely optional sections. Proposed while authoring, never required

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -40,15 +40,17 @@ stray field name or datasource id can leak into the analyst's workbook. Pick the
 `combo`, plus `heatmap` / `treemap` / `bullet` / `gantt` / `boxplot`).
 
 Several things the spec may ask for are **not** chart types — they are optional keys on any
-worksheet: `sort`, `filters`, `tooltip`, `reference_lines`, and `axis_titles` /
+worksheet: `sort`, `filters`, `tooltip`, `reference_lines`, `fit`, `format`, and `axis_titles` /
 `number_formats`; a running total or percent-of-total is a `table_calc` on the shelf entry. A
-*stacked* bar is a `bar` with a `color` encoding. Reach for a modifier before reaching for a
-new chart type.
+*stacked* bar is a `bar` with a `color` encoding, and a measure on the `text` encoding gives
+any chart mark labels. Reach for a modifier before reaching for a new chart type.
 
-Styling comes from `DESIGN-TOKENS.md` when the analyst ran `tableau-brand`: its font family
-and chart-title size/colour are applied to every worksheet automatically. When it is absent,
-Tableau's own defaults apply and nothing is invented. The manifest never carries fonts or
-colours.
+Styling comes from `DESIGN-TOKENS.md` when the analyst ran `tableau-brand`: its font family,
+chart-title size/colour and ordered `### Chart series colors` are applied to every worksheet
+automatically — the series colours ride along as an inline palette, so no data member values
+are needed. When it is absent, Tableau's own defaults apply and nothing is invented. The
+manifest carries no fonts or brand colours; its per-sheet `format` block covers only sheet
+furniture (borders, lines, shading, alignment).
 
 ## The build manifest
 

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -132,9 +132,15 @@ So:
 - a **measure** on `color` (a filled map, a heatmap) is a continuous ramp, and gets the first
   and last brand colours as its low and high ends;
 - a `dual-axis` / `combo` chart is coloured by the built-in Measure Names and takes the
-  categorical palette too.
+  categorical palette too;
+- a sheet with **nothing on `color`** (a plain bar, line, area, scatter, histogram, table) has
+  no domain to walk, so it takes the **first** brand colour as its flat mark colour. Otherwise
+  most of the workbook would still be Tableau's default blue, which is the single loudest tell
+  that a dashboard was generated.
 
-Tokens with no `### Chart series colors` section leave Tableau's default 10 in place.
+Tokens with no `### Chart series colors` section leave Tableau's default 10 in place. That
+heading is required by `tableau-brand`'s validator precisely because `build` binds to its name
+(CONTRACT.md §1).
 
 ## Interactions
 

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -50,7 +50,7 @@ Interaction ids (`int-*`) are actions, not zones, and never appear in the tree.
 | `text` | **KPI card** — empty shelves, a single `text` encoding, rendered as a big number. |
 | `table` | **Text table** — a dimension on each axis, the measure on `text`. |
 | `histogram` | A binned dimension: `{"field": "revenue", "bin": 500}` on `columns`, a `count` on `rows`. |
-| `dual-axis` | Exactly **two** measures on `rows`, overlaid on synchronised axes. |
+| `dual-axis` | Exactly **two** measures on `rows`, overlaid on synchronised axes. Both panes keep the `Automatic` mark, so a continuous date on `columns` draws **two lines** — pick `combo` when the two series should look different. |
 | `combo` | A dual axis with Bar marks on the first measure and Line on the second. |
 | `heatmap`, `treemap`, `bullet`, `gantt`, `boxplot` | The corresponding mark class. |
 
@@ -70,8 +70,19 @@ A shelf entry may also carry `table_calc` — a quick table calculation over the
 One of `CumTotal`, `WindowTotal`, `Difference`, `PctDiff`, `PctValue`, `PctTotal`, `Rank`,
 `PctRank`; it computes across the table (Tableau's "Table (across)" addressing).
 
+**A histogram's `bin` is a width, not a bin count** — Tableau slices `0–500`, `500–1000`, …
+Derive it from the field's range so the chart lands at roughly **10–25 bars**: a revenue that
+runs 10k–50k wants `bin: 2000`, not the `500` from this document's example (which gives ~80
+slivers). The `Sample values` column of `DATA-MODEL.md` is the only range signal available
+today — nothing computes the width for you.
+
 Encodings the builder emits: `color`, `size`, `shape`, `text`, `lod`, `wedge-size`,
 `geometry`, `tooltip`. Any other name is a validation error, not a silent drop.
+
+**A field on `text` is a request for mark labels**, on any chart type — `{"text": {"field":
+"revenue", "aggregation": "sum"}}` on a bar gives labelled bars, and it is also what makes a
+`number_formats` entry *visible*, since a cell format reaches a chart only through its labels.
+On `chart_type: "text"` the same encoding is the KPI card's big number instead.
 
 ## Optional worksheet keys (the modifiers)
 
@@ -84,6 +95,8 @@ Encodings the builder emits: `color`, `size`, `shape`, `text`, `lod`, `wedge-siz
 | `number_formats` | `[{"field": "revenue", "format": "$#,##0"}]` | Cell number format for that field. |
 | `reference_lines` | `[{"field": "revenue", "aggregation": "sum", "formula": "average", "scope": "per-table", "label": "<Computation>: <Value>"}]` | A line drawn at an aggregate of the measure. `formula` from `constant`/`total`/`sum`/`min`/`max`/`average`/`median`/`quantiles`/`percentile`/`stdev`/`confidence`/`medianconfidence` (default `average`); `scope` from `per-cell`/`per-pane`/`per-table` (default `per-table`). A `label` string is used verbatim; without one, `label_type` from `none`/`automatic`/`value`/`computation`/`custom` (default `computation`). |
 | `title` | `"Revenue by region"` | Puts a styled text zone above the sheet's zone in the dashboard and suppresses the sheet's own title. Omit to keep Tableau's sheet title. |
+| `fit` | `"entire-view"` | How the sheet fills its zone: `entire-view` (the default), `standard`, `fit-width`, `fit-height`. |
+| `format` | `{"shading": "#FFFFFF", "borders": "none", "gridlines": "#E5E8E8", "zero_lines": "none", "align": "center", "vertical_align": "top"}` | Format Shading / Borders / Lines / Alignment. Every colour is a `#rrggbb`; `borders`, `gridlines` and `zero_lines` also take `"none"` to turn the border or line off. `align` is `left`/`center`/`right`, `vertical_align` is `top`/`center`/`bottom`. |
 
 An `objects` entry of `kind: "text"` takes its content the same way: `{"element_id":
 "txt-title", "kind": "text", "text": "Sales Performance"}`.
@@ -91,9 +104,37 @@ An `objects` entry of `kind: "text"` takes its content the same way: `{"element_
 Every modifier's field is resolved as strictly as a shelf field — a filter on a field the
 data model does not document is rejected, not silently dropped.
 
-**Styling comes from `DESIGN-TOKENS.md`, not the manifest.** When it exists, its font family
-and chart-title size/colour are applied to every worksheet; when it does not, Tableau's own
-defaults apply. Nothing in the manifest sets fonts or colours.
+### Fit defaults to Entire View
+
+A dashboard zone is a fixed box, and Tableau's own default (`standard`) leaves the chart at
+its natural size floating in that box's whitespace. So every sheet is emitted at **Entire
+View** unless it says otherwise — except `chart_type: "table"`, which defaults to `standard`
+because a text table is meant to **scroll**: squeezing 200 rows into a zone renders them as
+unreadable slivers. Any sheet with more rows than its zone can show wants `"fit": "standard"`
+too. The fit is written on both the sheet's own tab and the dashboard's copy of it.
+
+### Colour: typography *and* the palette come from `DESIGN-TOKENS.md`
+
+**Nothing in the manifest sets fonts or colours** *except* the per-sheet `format` block above
+(borders, lines, shading, alignment — sheet furniture, not brand identity). When
+`DESIGN-TOKENS.md` exists, its font family, chart-title size/colour **and its ordered
+`### Chart series colors`** are applied to every worksheet; when it does not, Tableau's own
+defaults apply.
+
+The palette needs **no data member values**, which is what previously blocked it. A palette
+that binds hexes to concrete members (`<map to='#…'><bucket>"West"</bucket>`) is unbuildable
+from a manifest — the builder never sees the data — but it does not have to be: the mark's
+colour encoding carries an inline `<color-palette>` listing the brand's colours *in order*,
+and Tableau walks the field's domain against them exactly as it does with its own default 10.
+So:
+
+- a **dimension** on `color` (a stacked bar, a pie, a treemap) takes the whole ordered palette;
+- a **measure** on `color` (a filled map, a heatmap) is a continuous ramp, and gets the first
+  and last brand colours as its low and high ends;
+- a `dual-axis` / `combo` chart is coloured by the built-in Measure Names and takes the
+  categorical palette too.
+
+Tokens with no `### Chart series colors` section leave Tableau's default 10 in place.
 
 ## Interactions
 
@@ -214,6 +255,8 @@ None of that is expressible in the manifest, and none of it needs to be.
         "rows": [{"field": "revenue", "aggregation": "sum"}]
       },
       "encodings": {"color": "region"},
+      "fit": "entire-view",
+      "format": {"shading": "#FFFFFF", "borders": "none", "gridlines": "#E5E8E8"},
       "filters": [{"field": "region", "values": ["West", "East"], "context": true}],
       "sort": {"field": "region", "direction": "DESC",
                "by": {"field": "revenue", "aggregation": "sum"}},

--- a/skills/tableau-build/scripts/manifest.py
+++ b/skills/tableau-build/scripts/manifest.py
@@ -95,10 +95,10 @@ AGGREGATIONS = frozenset({
 DATE_PARTS = frozenset(DATE_PART_DERIVATIONS)
 ENCODING_NAMES = frozenset(ENCODING_ORDER)
 
-#: How a sheet may be told to fill its zone, and the ``format`` block's keys and alignment
-#: values - all read off the builder's own tables, same reason as :data:`CHART_TYPES`.
+#: How a sheet may be told to fill its zone, and the ``format`` block's alignment values -
+#: both read off the builder's own tables, same reason as :data:`CHART_TYPES`. The block's
+#: key set is the builder's :data:`SHEET_FORMAT_KEYS`, used directly.
 FITS = frozenset(FIT_ZOOMS)
-FORMAT_KEYS = SHEET_FORMAT_KEYS
 FORMAT_ALIGNMENTS: dict[str, frozenset[str]] = {
     "align": TEXT_ALIGNMENTS, "vertical_align": VERTICAL_ALIGNMENTS,
 }
@@ -668,15 +668,15 @@ def _validate_sheet_format(label: str, block: object, errors: list[str]) -> None
     if not isinstance(block, dict):
         errors.append(
             f"{label}: 'format' must be an object "
-            f"(keys: {', '.join(sorted(FORMAT_KEYS))})"
+            f"(keys: {', '.join(sorted(SHEET_FORMAT_KEYS))})"
         )
         return
 
     for key, value in block.items():
-        if key not in FORMAT_KEYS:
+        if key not in SHEET_FORMAT_KEYS:
             errors.append(
                 f"{label}: unknown format key '{key}' "
-                f"(expected one of: {', '.join(sorted(FORMAT_KEYS))})"
+                f"(expected one of: {', '.join(sorted(SHEET_FORMAT_KEYS))})"
             )
             continue
         text = value.strip().lower() if isinstance(value, str) else ""

--- a/skills/tableau-build/scripts/manifest.py
+++ b/skills/tableau-build/scripts/manifest.py
@@ -37,10 +37,15 @@ from worksheet import (
     CHART_SPECS,
     DATE_PART_DERIVATIONS,
     ENCODING_ORDER,
+    FIT_ZOOMS,
+    NO_FORMAT,
     REFERENCE_LINE_FORMULAS,
     REFERENCE_LINE_LABEL_TYPES,
     REFERENCE_LINE_SCOPES,
+    SHEET_FORMAT_KEYS,
     TABLE_CALC_PREFIXES,
+    TEXT_ALIGNMENTS,
+    VERTICAL_ALIGNMENTS,
 )
 from zones import FILTER_MODES
 
@@ -89,6 +94,17 @@ AGGREGATIONS = frozenset({
 #: dropped silently, and Tableau shows no sign of the missing encoding.
 DATE_PARTS = frozenset(DATE_PART_DERIVATIONS)
 ENCODING_NAMES = frozenset(ENCODING_ORDER)
+
+#: How a sheet may be told to fill its zone, and the ``format`` block's keys and alignment
+#: values - all read off the builder's own tables, same reason as :data:`CHART_TYPES`.
+FITS = frozenset(FIT_ZOOMS)
+FORMAT_KEYS = SHEET_FORMAT_KEYS
+FORMAT_ALIGNMENTS: dict[str, frozenset[str]] = {
+    "align": TEXT_ALIGNMENTS, "vertical_align": VERTICAL_ALIGNMENTS,
+}
+
+#: A colour value in a ``format`` block: a hex, or ``none`` for "no such border/line".
+_FORMAT_COLOR = re.compile(r"^#[0-9a-fA-F]{6}$")
 
 #: Table calculations a shelf entry may ask for, and the parameter data types / action
 #: activations the builder can emit - all read off the builder's own tables.
@@ -625,6 +641,60 @@ def _validate_modifiers(label: str, worksheet: dict, errors: list[str]) -> None:
             errors.append(
                 f"{label}: 'sort' has neither 'by' (the measure to sort on) nor 'order' "
                 f"(an explicit member list) - one of the two is required"
+            )
+
+    fit = worksheet.get("fit")
+    if isinstance(fit, str) and fit.strip().lower() not in FITS:
+        errors.append(
+            f"{label}: unknown fit '{fit}' (expected one of: {', '.join(sorted(FITS))})"
+        )
+
+    _validate_sheet_format(label, worksheet.get("format"), errors)
+
+
+def _validate_sheet_format(label: str, block: object, errors: list[str]) -> None:
+    """Reject a ``format`` block the builder would render as nothing.
+
+    A misspelled key or a colour Tableau cannot parse is the worst kind of formatting bug:
+    the workbook opens, nothing is wrong with it, and the sheet simply is not formatted.
+
+    Args:
+        label: The worksheet's error label.
+        block: The worksheet's ``format`` value, if any.
+        errors: Accumulator for validation errors.
+    """
+    if block is None:
+        return
+    if not isinstance(block, dict):
+        errors.append(
+            f"{label}: 'format' must be an object "
+            f"(keys: {', '.join(sorted(FORMAT_KEYS))})"
+        )
+        return
+
+    for key, value in block.items():
+        if key not in FORMAT_KEYS:
+            errors.append(
+                f"{label}: unknown format key '{key}' "
+                f"(expected one of: {', '.join(sorted(FORMAT_KEYS))})"
+            )
+            continue
+        text = value.strip().lower() if isinstance(value, str) else ""
+        if not text:
+            errors.append(f"{label}: format.{key} needs a value")
+        elif key in FORMAT_ALIGNMENTS:
+            if text not in FORMAT_ALIGNMENTS[key]:
+                errors.append(
+                    f"{label}: format.{key} '{value}' is not an alignment "
+                    f"(expected one of: {', '.join(sorted(FORMAT_ALIGNMENTS[key]))})"
+                )
+        elif not _FORMAT_COLOR.match(text) and not (
+            # A border or a line can be turned off; a background cannot be shaded "none".
+            text == NO_FORMAT and key != "shading"
+        ):
+            errors.append(
+                f"{label}: format.{key} '{value}' is not a '#rrggbb' colour"
+                + ("" if key == "shading" else f" nor '{NO_FORMAT}'")
             )
 
 

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -765,6 +765,27 @@ def _render_dashboard_declarations(
             features.render_parameter_column(dependencies, parameter)
 
 
+def _render_zoom(
+    parent: ET.Element, plan: worksheet.WorksheetPlan, wrapped: bool = True
+) -> None:
+    """Render a sheet's fit as a ``<zoom>``, in or under a ``<viewpoint>``.
+
+    Standard fit is the *absence* of a zoom, so a sheet that keeps it (a scrolling text table)
+    gets no viewpoint at all rather than a zoom Tableau would have to interpret.
+
+    Args:
+        parent: The ``<window>`` the viewpoint belongs to, or the ``<viewpoint>`` itself.
+        plan: The worksheet whose fit is being written.
+        wrapped: Whether the ``<viewpoint>`` still has to be created (a worksheet window owns
+            one; the dashboard window's ``<viewpoints>`` list already named it per sheet).
+    """
+    zoom_type = plan.zoom_type
+    if not zoom_type:
+        return
+    viewpoint = ET.SubElement(parent, "viewpoint") if wrapped else parent
+    ET.SubElement(viewpoint, "zoom", {"type": zoom_type})
+
+
 def _render_windows(
     parent: ET.Element,
     plans: list[worksheet.WorksheetPlan],
@@ -782,7 +803,6 @@ def _render_windows(
             renders no tab for it, so the analyst opens a workbook with nothing in it.
     """
     windows = ET.SubElement(parent, "windows", {"source-height": "30"})
-    worksheet_names = [plan.name for plan in plans]
 
     for plan in plans:
         attributes = {"class": "worksheet", "name": plan.name}
@@ -810,18 +830,19 @@ def _render_windows(
                 ET.SubElement(right_strip, "card", {
                     "pane-specification-id": pane_id, "param": column, "type": card_type,
                 })
+        # The sheet's own fit, on its own tab. Without it Tableau opens every tab on Standard
+        # and the analyst reviews 15 charts sitting in whitespace.
+        _render_zoom(window, plan)
         ET.SubElement(window, "simple-id", {"uuid": simple_id("window", plan.name)})
 
     dashboard_window = ET.SubElement(windows, "window", {
         "class": "dashboard", "maximized": "true", "name": DASHBOARD_NAME,
     })
     viewpoints = ET.SubElement(dashboard_window, "viewpoints")
-    for name in worksheet_names:
-        # Never a self-closing viewpoint: without entire-view zoom the sheet does not fill
-        # its allocated space.
-        ET.SubElement(
-            ET.SubElement(viewpoints, "viewpoint", {"name": name}),
-            "zoom", {"type": "entire-view"},
+    for plan in plans:
+        # The same fit again, this time as the dashboard sees the embedded sheet.
+        _render_zoom(
+            ET.SubElement(viewpoints, "viewpoint", {"name": plan.name}), plan, wrapped=False
         )
     ET.SubElement(dashboard_window, "active", {"id": root_zone_id})
     ET.SubElement(

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import re
 import xml.etree.ElementTree as ET
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import Callable, NamedTuple, Optional
 
 # A worksheet that reads a parameter has to declare it; :mod:`features` owns what a parameter
@@ -686,12 +686,9 @@ class ReferenceLinePlan:
     label: str = ""
 
 
-#: What a ``format`` block may carry, and the horizontal / vertical alignments it accepts.
-#: ``manifest`` reads all three, so a typo'd key or value fails validation instead of
+#: The horizontal / vertical alignments a ``format`` block accepts. ``manifest`` reads these
+#: (and :data:`SHEET_FORMAT_KEYS`), so a typo'd key or value fails validation instead of
 #: silently rendering an unformatted sheet.
-SHEET_FORMAT_KEYS: frozenset[str] = frozenset({
-    "shading", "borders", "gridlines", "zero_lines", "align", "vertical_align",
-})
 TEXT_ALIGNMENTS: frozenset[str] = frozenset({"left", "center", "right"})
 VERTICAL_ALIGNMENTS: frozenset[str] = frozenset({"top", "center", "bottom"})
 
@@ -730,6 +727,12 @@ class SheetFormat:
     zero_lines: str = ""
     align: str = ""
     vertical_align: str = ""
+
+
+#: What a ``format`` block may carry - derived from the dataclass, because
+#: :func:`_plan_sheet_format` splats the surviving keys straight into ``SheetFormat(**values)``
+#: and a hand-kept copy that drifts is a TypeError.
+SHEET_FORMAT_KEYS: frozenset[str] = frozenset(field.name for field in fields(SheetFormat))
 
 
 @dataclass
@@ -885,12 +888,12 @@ def _plan_fit(value: object, chart_type: str) -> str:
     return "standard" if chart_type in STANDARD_FIT_CHART_TYPES else DEFAULT_FIT
 
 
-def _plan_sheet_format(entry: object) -> SheetFormat:
+def _plan_sheet_format(block: object) -> SheetFormat:
     """Resolve the ``format`` block into a :class:`SheetFormat`, ignoring unknown keys."""
-    if not isinstance(entry, dict):
+    if not isinstance(block, dict):
         return SheetFormat()
     values = {
-        key: _lower(value) for key, value in entry.items() if key in SHEET_FORMAT_KEYS
+        key: _lower(value) for key, value in block.items() if key in SHEET_FORMAT_KEYS
     }
     return SheetFormat(**values)
 
@@ -1343,9 +1346,10 @@ def _add_palette(add: AddRule, plan: WorksheetPlan, tokens: DesignTokens) -> Non
     """Add the brand palette to whatever the worksheet colours its marks by.
 
     The colours ride along inline (see :class:`DesignTokens`), so no data member has to be
-    known. Two shapes, decided by what is on Colour: a *dimension* takes the whole ordered
+    known. Three shapes, decided by what is on Colour: a *dimension* takes the whole ordered
     palette and Tableau walks the domain against it; a *measure* is a continuous ramp, and a
-    ramp has two ends - the first and last brand colours, low to high.
+    ramp has two ends - the first and last brand colours, low to high; *nothing* on Colour has
+    no domain at all, so it gets the brand's first colour as the flat mark colour.
 
     Args:
         add: ``_render_style``'s rule accumulator.
@@ -1363,7 +1367,11 @@ def _add_palette(add: AddRule, plan: WorksheetPlan, tokens: DesignTokens) -> Non
         field_reference = plan.reference_of(reference)
         quantitative = reference.instance_type == "quantitative"
     else:
-        return  # nothing is colour-encoded, so there is no palette to apply
+        # Nothing on Colour, so there is no domain to walk - but the marks still have *a*
+        # colour, and Tableau's is its default blue. The brand's first series colour is what
+        # keeps a plain bar or line from reading as "generated" too.
+        add("mark", "format", {"attr": "mark-color", "value": tokens.series_colors[0]})
+        return
 
     colors = tokens.series_colors
     if quantitative:

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import re
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
-from typing import NamedTuple, Optional
+from typing import Callable, NamedTuple, Optional
 
 # A worksheet that reads a parameter has to declare it; :mod:`features` owns what a parameter
 # column looks like and imports nothing back, so no cycle.
@@ -80,21 +80,33 @@ _HEX = re.compile(r"#[0-9a-fA-F]{3,8}\b")
 _SIZE = re.compile(r"(\d+)\s*px", re.IGNORECASE)
 
 
+#: The name the worksheet's inline brand palette is declared and referenced under.
+BRAND_PALETTE_NAME = "Brand"
+
+_SERIES_HEADING = re.compile(r"^#+\s*.*series colors", re.IGNORECASE)
+
+
 @dataclass(frozen=True)
 class DesignTokens:
     """The slice of DESIGN-TOKENS.md a worksheet body can actually apply.
 
-    Tableau styles a *worksheet* with a font family, a title run, and cell/axis formats.
-    The palette's series colours are deliberately not mapped onto marks: a colour palette
-    binds hex values to concrete data members (``<map to='#...'><bucket>"West"</bucket>``),
-    and the builder does not know the data's members. Colour therefore stays with Tableau's
-    default palette and the tokens drive type.
+    Tableau styles a *worksheet* with a font family, a title run, cell/axis formats, and the
+    palette its marks are coloured from.
+
+    **How the palette gets its colours without knowing the data's members.** A palette that
+    binds hex values to concrete members (``<map to='#...'><bucket>"West"</bucket>``) is
+    unbuildable from a manifest - the builder never sees the data. It does not have to be: an
+    ``<encoding>`` may carry an inline ``<color-palette>``, which lists the colours *in order*
+    and leaves Tableau to walk the field's domain against them, exactly as it does with its own
+    default 10. So the brand's ordered series colours *are* the palette, member values are
+    never needed, and a coloured chart is on-brand instead of on Tableau-default.
 
     Attributes:
         font_family: Body font for the whole worksheet.
         title_size: Chart-title point size.
         title_color: Chart-title colour, lower-cased hex.
         kpi_size: Point size for a KPI card's big number.
+        series_colors: The brand's ordered chart-series colours, lower-cased hex.
         present: Whether a DESIGN-TOKENS.md was actually supplied.
     """
 
@@ -102,16 +114,18 @@ class DesignTokens:
     title_size: int = DEFAULT_TITLE_SIZE
     title_color: str = DEFAULT_TITLE_COLOR
     kpi_size: int = DEFAULT_KPI_SIZE
+    series_colors: tuple[str, ...] = ()
     present: bool = False
 
 
 def parse_design_tokens(tokens_text: str) -> DesignTokens:
-    """Read the typography tokens out of a DESIGN-TOKENS.md.
+    """Read the typography and palette tokens out of a DESIGN-TOKENS.md.
 
     The parse is tolerant by design (the file is prose an agent authored from a template):
     it looks for the ``- **Font family**:`` and ``- **Chart title**:`` bullets and takes the
-    first font name / px size / hex colour on each. Anything it cannot find keeps its
-    Tableau default.
+    first font name / px size / hex colour on each, and reads every hex under the
+    ``### Chart series colors`` heading as the ordered palette. Anything it cannot find keeps
+    its Tableau default.
 
     Args:
         tokens_text: The contents of a ``DESIGN-TOKENS.md`` (``""`` when absent).
@@ -123,8 +137,19 @@ def parse_design_tokens(tokens_text: str) -> DesignTokens:
         return DesignTokens()
 
     font, title_size, title_color = DEFAULT_FONT, DEFAULT_TITLE_SIZE, DEFAULT_TITLE_COLOR
+    series_colors: list[str] = []
+    in_series = False
     for raw_line in tokens_text.splitlines():
         line = raw_line.strip()
+        if line.startswith("#"):
+            # The palette is a *section*, not a bullet: the template asks for an ordered list
+            # and every author formats that differently (one comma-separated run, a bullet
+            # each), so every hex until the next heading is a series colour.
+            in_series = _SERIES_HEADING.match(line) is not None
+            continue
+        if in_series:
+            series_colors += [match.group(0).lower() for match in _HEX.finditer(line)]
+            continue
         if not line.startswith("-"):
             continue
         label, _, value = line.lstrip("- ").partition(":")
@@ -148,6 +173,7 @@ def parse_design_tokens(tokens_text: str) -> DesignTokens:
         title_size=title_size,
         title_color=title_color,
         kpi_size=max(title_size + 8, DEFAULT_KPI_SIZE),
+        series_colors=tuple(series_colors),
         present=True,
     )
 
@@ -556,6 +582,25 @@ LEGEND_ENCODINGS: tuple[str, ...] = ("color", "size", "shape")
 #: The pane attribute every snippet carries.
 PANE_RELAXATION = {"selection-relaxation-option": "selection-relaxation-allow"}
 
+#: manifest ``fit`` -> the ``<zoom>`` type the sheet's viewpoint carries (the XSD's
+#: ``VisualDoc-ZoomType-ST``). ``standard`` is Tableau's un-zoomed default and writes no
+#: ``<zoom>`` at all - it is the *absence* of a fit, not a value of one.
+FIT_ZOOMS: dict[str, str] = {
+    "standard": "",
+    "entire-view": "entire-view",
+    "fit-width": "fit-width",
+    "fit-height": "fit-height",
+}
+
+#: What a sheet fits to when the manifest says nothing. Entire View, because a dashboard zone
+#: is a fixed box: Standard leaves the chart at its natural size, floating in the zone's
+#: whitespace, which is what made every generated sheet look unfinished.
+DEFAULT_FIT = "entire-view"
+
+#: Chart types that keep Standard fit by default - a text table is meant to *scroll*, and
+#: squeezing 200 rows into a zone renders it as unreadable slivers.
+STANDARD_FIT_CHART_TYPES = frozenset({"table"})
+
 #: Tableau's line break inside a formatted-text run: AE ligature + tab. Not ``\n``.
 TOOLTIP_BREAK = "\u00c6\t"
 
@@ -641,6 +686,52 @@ class ReferenceLinePlan:
     label: str = ""
 
 
+#: What a ``format`` block may carry, and the horizontal / vertical alignments it accepts.
+#: ``manifest`` reads all three, so a typo'd key or value fails validation instead of
+#: silently rendering an unformatted sheet.
+SHEET_FORMAT_KEYS: frozenset[str] = frozenset({
+    "shading", "borders", "gridlines", "zero_lines", "align", "vertical_align",
+})
+TEXT_ALIGNMENTS: frozenset[str] = frozenset({"left", "center", "right"})
+VERTICAL_ALIGNMENTS: frozenset[str] = frozenset({"top", "center", "bottom"})
+
+#: The one non-colour value a shading / borders / lines key takes: "there is no such line".
+#: Tableau hides a line by turning its display off, not by colouring it the background.
+NO_FORMAT = "none"
+
+#: What a bordered cell looks like when the format names a colour but no width - Desktop's own
+#: hairline.
+BORDER_STYLE = "solid"
+BORDER_WIDTH = "1"
+
+
+@dataclass(frozen=True)
+class SheetFormat:
+    """One worksheet's Format Borders / Lines / Shading / Alignment settings.
+
+    These are the four Desktop format panes that make a workbook look designed rather than
+    generated, and each is a handful of ``<style-rule>`` formats on the worksheet. A border or a
+    line takes a hex or :data:`NO_FORMAT` (there is no such border); shading takes a hex only -
+    a background cannot be shaded "none". The alignments are the same ``cell`` formats a KPI
+    card centres itself with.
+
+    Attributes:
+        shading: The pane's background colour (Format > Shading).
+        borders: The cell border colour, or :data:`NO_FORMAT` for a borderless sheet.
+        gridlines: The gridline colour, or :data:`NO_FORMAT` to hide them.
+        zero_lines: The zero-line colour, or :data:`NO_FORMAT` to hide it.
+        align: Horizontal cell alignment (``left`` / ``center`` / ``right``).
+        vertical_align: Vertical cell alignment (``top`` / ``center`` / ``bottom``).
+    """
+
+    shading: str = ""
+    borders: str = ""
+    gridlines: str = ""
+    zero_lines: str = ""
+    align: str = ""
+    vertical_align: str = ""
+
+
 @dataclass
 class WorksheetPlan:
     """Everything one worksheet needs, resolved once and rendered from twice.
@@ -663,6 +754,8 @@ class WorksheetPlan:
         tooltip: ``(label, field)`` pairs for a custom tooltip template.
         number_formats: ``(field, format pattern)`` pairs for the cell style rule.
         axis_titles: ``{"rows"|"columns": title}`` overrides.
+        fit: How the sheet fills its zone - a :data:`FIT_ZOOMS` key.
+        sheet_format: The resolved Format Borders / Lines / Shading / Alignment block.
         geo_role: A map's geographic semantic role, or ``""``.
         reference_lines: Resolved reference lines, in manifest order.
         parameters: Parameters the worksheet's calculations read - the view must declare them
@@ -693,6 +786,8 @@ class WorksheetPlan:
     tooltip: list[tuple[str, FieldRef]] = field(default_factory=list)
     number_formats: list[tuple[FieldRef, str]] = field(default_factory=list)
     axis_titles: dict[str, str] = field(default_factory=dict)
+    fit: str = DEFAULT_FIT
+    sheet_format: SheetFormat = field(default_factory=SheetFormat)
     geo_role: str = ""
 
     def qualify(self, name: str) -> str:
@@ -702,6 +797,11 @@ class WorksheetPlan:
     def reference_of(self, reference: FieldRef) -> str:
         """Return the qualified column-instance reference for a resolved field."""
         return self.resolver.qualify(reference.instance_name)
+
+    @property
+    def zoom_type(self) -> str:
+        """str: The sheet's ``<zoom>`` type; ``""`` for Standard fit, which writes no zoom."""
+        return FIT_ZOOMS.get(self.fit, FIT_ZOOMS[DEFAULT_FIT])
 
     @property
     def all_refs(self) -> list[FieldRef]:
@@ -731,7 +831,8 @@ def plan_worksheet(entry: dict, resolver: FieldResolver) -> WorksheetPlan:
         The plan; an unknown chart type falls back to the plain ``bar`` spec, which
         ``manifest.validate_manifest`` has already rejected before the assembler runs.
     """
-    spec = CHART_SPECS.get(str(entry.get("chart_type", "")).strip().lower(), ChartSpec())
+    chart_type = str(entry.get("chart_type", "")).strip().lower()
+    spec = CHART_SPECS.get(chart_type, ChartSpec())
     shelves = entry.get("shelves") if isinstance(entry.get("shelves"), dict) else {}
     raw_encodings = entry.get("encodings") if isinstance(entry.get("encodings"), dict) else {}
     axis_titles = entry.get("axis_titles") if isinstance(entry.get("axis_titles"), dict) else {}
@@ -761,8 +862,37 @@ def plan_worksheet(entry: dict, resolver: FieldResolver) -> WorksheetPlan:
             for shelf, title in axis_titles.items()
             if isinstance(title, str) and title.strip()
         },
+        fit=_plan_fit(entry.get("fit"), chart_type),
+        sheet_format=_plan_sheet_format(entry.get("format")),
         geo_role=str(entry.get("geo_role", "")).strip() if spec.geographic else "",
     )
+
+
+def _plan_fit(value: object, chart_type: str) -> str:
+    """Resolve the ``fit`` key, defaulting per chart type.
+
+    Args:
+        value: The manifest's ``fit`` value, if any.
+        chart_type: The worksheet's chart type, which decides the default.
+
+    Returns:
+        A :data:`FIT_ZOOMS` key. An unknown value cannot reach here from a validated manifest
+        and falls back to the default rather than emitting a zoom Tableau has no case for.
+    """
+    requested = _lower(value)
+    if requested in FIT_ZOOMS:
+        return requested
+    return "standard" if chart_type in STANDARD_FIT_CHART_TYPES else DEFAULT_FIT
+
+
+def _plan_sheet_format(entry: object) -> SheetFormat:
+    """Resolve the ``format`` block into a :class:`SheetFormat`, ignoring unknown keys."""
+    if not isinstance(entry, dict):
+        return SheetFormat()
+    values = {
+        key: _lower(value) for key, value in entry.items() if key in SHEET_FORMAT_KEYS
+    }
+    return SheetFormat(**values)
 
 
 def _plan_filters(entries: object, resolver: FieldResolver) -> list[FilterPlan]:
@@ -1127,6 +1257,11 @@ def _render_sort(parent: ET.Element, plan: WorksheetPlan) -> None:
     })
 
 
+#: ``_render_style``'s rule accumulator, as the helpers that feed it see it:
+#: ``add(element, tag, attributes[, palette colours])``.
+AddRule = Callable[..., None]
+
+
 def _render_style(parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens) -> None:
     """Render the worksheet's ``<style>``, one style-rule per element, alphabetically.
 
@@ -1134,10 +1269,10 @@ def _render_style(parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens)
     other way produces a diff on first open. Rules are collected into a dict keyed by
     element and then sorted, so a new rule cannot be added in the wrong place.
     """
-    rules: dict[str, list[tuple[str, dict]]] = {}
+    rules: dict[str, list[tuple[str, dict, tuple[str, ...]]]] = {}
 
-    def add(element: str, tag: str, attributes: dict) -> None:
-        rules.setdefault(element, []).append((tag, attributes))
+    def add(element: str, tag: str, attributes: dict, colors: tuple[str, ...] = ()) -> None:
+        rules.setdefault(element, []).append((tag, attributes, colors))
 
     if tokens.present:
         add("worksheet", "format", {"attr": "font-family", "value": tokens.font_family})
@@ -1168,9 +1303,8 @@ def _render_style(parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens)
             "value": pattern,
         })
 
-    if plan.spec.kpi_card:
-        add("cell", "format", {"attr": "text-align", "value": "center"})
-        add("cell", "format", {"attr": "vertical-align", "value": "center"})
+    _add_palette(add, plan, tokens)
+    _add_sheet_format(add, plan)
 
     if plan.spec.geographic:
         add("map", "format", {"attr": "washout", "value": "0.0"})
@@ -1191,8 +1325,104 @@ def _render_style(parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens)
     style = ET.SubElement(parent, "style")
     for element in sorted(rules):
         rule = ET.SubElement(style, "style-rule", {"element": element})
-        for tag, attributes in rules[element]:
-            ET.SubElement(rule, tag, attributes)
+        for tag, attributes, colors in rules[element]:
+            node = ET.SubElement(rule, tag, attributes)
+            if colors:
+                # A ramp is an ordered palette; a categorical one is 'regular'.
+                palette = ET.SubElement(node, "color-palette", {
+                    "custom": "true",
+                    "name": BRAND_PALETTE_NAME,
+                    "type": ("ordered-sequential"
+                             if attributes.get("type") == "interpolated" else "regular"),
+                })
+                for color in colors:
+                    ET.SubElement(palette, "color").text = color
+
+
+def _add_palette(add: AddRule, plan: WorksheetPlan, tokens: DesignTokens) -> None:
+    """Add the brand palette to whatever the worksheet colours its marks by.
+
+    The colours ride along inline (see :class:`DesignTokens`), so no data member has to be
+    known. Two shapes, decided by what is on Colour: a *dimension* takes the whole ordered
+    palette and Tableau walks the domain against it; a *measure* is a continuous ramp, and a
+    ramp has two ends - the first and last brand colours, low to high.
+
+    Args:
+        add: ``_render_style``'s rule accumulator.
+        plan: The worksheet plan.
+        tokens: The design tokens.
+    """
+    if not tokens.series_colors:
+        return
+    if plan.spec.dual:
+        # A dual chart colours its two measures apart by Measure Names - a dimension, whatever
+        # the measures are.
+        field_reference, quantitative = plan.qualify(MEASURE_NAMES), False
+    elif "color" in plan.encodings:
+        reference = plan.encodings["color"]
+        field_reference = plan.reference_of(reference)
+        quantitative = reference.instance_type == "quantitative"
+    else:
+        return  # nothing is colour-encoded, so there is no palette to apply
+
+    colors = tokens.series_colors
+    if quantitative:
+        colors = (colors[0], colors[-1])
+    # ponytail: XSD-legal, but only Desktop can confirm it keeps the palette on save rather
+    # than rewriting it (the `custom` flag and the name<->`palette` pairing are inferred from
+    # the schema, not read out of a Desktop-saved workbook). Issue #52 carries the steps; a
+    # wrong guess costs a rewrite on open, not a broken workbook.
+    add("mark", "encoding", {
+        "attr": "color",
+        "field": field_reference,
+        "palette": BRAND_PALETTE_NAME,
+        "type": "interpolated" if quantitative else "palette",
+    }, colors)
+
+
+def _add_sheet_format(add: AddRule, plan: WorksheetPlan) -> None:
+    """Add the Format Borders / Lines / Shading / Alignment rules the manifest asked for.
+
+    A KPI card centres itself unless the format says otherwise - its whole treatment is one big
+    centred number, and an explicit ``align`` is the analyst overruling that.
+
+    ponytail: every attribute here is in the XSD's ``StyleAttribute-ST``, but which *element*
+    Desktop hangs each one off is inferred (``text-align`` / ``vertical-align`` on ``cell`` are
+    the exceptions - the KPI card has round-tripped them). Issue #52 carries the save-and-diff
+    steps; the cost of a wrong pairing is a format that does not show, not a broken workbook.
+
+    Args:
+        add: ``_render_style``'s rule accumulator.
+        plan: The worksheet plan.
+    """
+    sheet_format = plan.sheet_format
+
+    if sheet_format.shading:
+        add("pane", "format", {"attr": "background-color", "value": sheet_format.shading})
+
+    if sheet_format.borders == NO_FORMAT:
+        add("cell", "format", {"attr": "border-style", "value": NO_FORMAT})
+        add("cell", "format", {"attr": "border-width", "value": "0"})
+    elif sheet_format.borders:
+        add("cell", "format", {"attr": "border-color", "value": sheet_format.borders})
+        add("cell", "format", {"attr": "border-style", "value": BORDER_STYLE})
+        add("cell", "format", {"attr": "border-width", "value": BORDER_WIDTH})
+
+    for element, value in (
+        ("gridline", sheet_format.gridlines), ("zeroline", sheet_format.zero_lines)
+    ):
+        if value == NO_FORMAT:
+            add(element, "format", {"attr": "display", "value": "false"})
+        elif value:
+            add(element, "format", {"attr": "stroke-color", "value": value})
+
+    centred = "center" if plan.spec.kpi_card else ""
+    for attribute, value in (
+        ("text-align", sheet_format.align or centred),
+        ("vertical-align", sheet_format.vertical_align or centred),
+    ):
+        if value:
+            add("cell", "format", {"attr": attribute, "value": value})
 
 
 def _render_panes(parent: ET.Element, plan: WorksheetPlan, tokens: DesignTokens) -> None:
@@ -1272,7 +1502,11 @@ def _render_pane(
         _render_tooltip(pane, plan, tokens)
     if plan.spec.kpi_card and "text" in plan.encodings:
         _render_big_number(pane, plan, tokens)
-    if plan.spec.label_marks:
+    # A field on Text *is* the request for mark labels, on any chart type - a bar with SUM on
+    # Text means labelled bars. It is also what makes 'number_formats' visible: the cell format
+    # only reaches a chart through its labels, which is why a styled bar with no label showed
+    # nothing for its format.
+    if plan.spec.label_marks or "text" in plan.encodings:
         style = ET.SubElement(pane, "style")
         rule = ET.SubElement(style, "style-rule", {"element": "mark"})
         for attribute in ("mark-labels-show", "mark-labels-cull"):

--- a/tests/fixtures/charts/area.xml
+++ b/tests/fixtures/charts/area.xml
@@ -20,6 +20,9 @@
           <aggregation value="true" />
         </view>
         <style>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/bar-filtered.xml
+++ b/tests/fixtures/charts/bar-filtered.xml
@@ -38,6 +38,9 @@
           <aggregation value="true" />
         </view>
         <style>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/bar-formatted.xml
+++ b/tests/fixtures/charts/bar-formatted.xml
@@ -1,4 +1,4 @@
-<worksheet name="Pie">
+<worksheet name="Bar Formatted">
       <layout-options>
         <title>
           <formatted-text>
@@ -20,20 +20,25 @@
           <aggregation value="true" />
         </view>
         <style>
-          <style-rule element="mark">
-            <encoding attr="color" field="[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]" palette="Brand" type="palette">
-              <color-palette custom="true" name="Brand" type="regular">
-                <color>#1b4f72</color>
-                <color>#2e86c1</color>
-                <color>#48c9b0</color>
-                <color>#f39c12</color>
-              </color-palette>
-            </encoding>
+          <style-rule element="cell">
+            <format attr="border-style" value="none" />
+            <format attr="border-width" value="0" />
+            <format attr="text-align" value="center" />
+            <format attr="vertical-align" value="bottom" />
+          </style-rule>
+          <style-rule element="gridline">
+            <format attr="stroke-color" value="#e5e8e8" />
+          </style-rule>
+          <style-rule element="pane">
+            <format attr="background-color" value="#ffffff" />
           </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />
             <format attr="display-field-labels" scope="rows" value="false" />
+          </style-rule>
+          <style-rule element="zeroline">
+            <format attr="display" value="false" />
           </style-rule>
         </style>
         <panes>
@@ -41,23 +46,11 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Pie" />
-            <encodings>
-              <color column="[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]" />
-              <size column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
-              <text column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
-              <wedge-size column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
-            </encodings>
-            <style>
-              <style-rule element="mark">
-                <format attr="mark-labels-show" value="true" />
-                <format attr="mark-labels-cull" value="true" />
-              </style-rule>
-            </style>
+            <mark class="Automatic" />
           </pane>
         </panes>
-        <rows />
-        <cols />
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]</cols>
       </table>
-      <simple-id uuid="{A9839A3B-54AA-55D6-9FD6-0CA1784A553F}" />
+      <simple-id uuid="{0C51BAFA-9B17-5A66-935C-9842E49B1AD0}" />
     </worksheet>

--- a/tests/fixtures/charts/bar-formatted.xml
+++ b/tests/fixtures/charts/bar-formatted.xml
@@ -29,6 +29,9 @@
           <style-rule element="gridline">
             <format attr="stroke-color" value="#e5e8e8" />
           </style-rule>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="pane">
             <format attr="background-color" value="#ffffff" />
           </style-rule>

--- a/tests/fixtures/charts/bar-labelled.xml
+++ b/tests/fixtures/charts/bar-labelled.xml
@@ -1,4 +1,4 @@
-<worksheet name="Pie">
+<worksheet name="Bar Labelled">
       <layout-options>
         <title>
           <formatted-text>
@@ -20,15 +20,8 @@
           <aggregation value="true" />
         </view>
         <style>
-          <style-rule element="mark">
-            <encoding attr="color" field="[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]" palette="Brand" type="palette">
-              <color-palette custom="true" name="Brand" type="regular">
-                <color>#1b4f72</color>
-                <color>#2e86c1</color>
-                <color>#48c9b0</color>
-                <color>#f39c12</color>
-              </color-palette>
-            </encoding>
+          <style-rule element="cell">
+            <format attr="text-format" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" value="$#,##0" />
           </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
@@ -41,12 +34,9 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Pie" />
+            <mark class="Automatic" />
             <encodings>
-              <color column="[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]" />
-              <size column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
               <text column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
-              <wedge-size column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
             </encodings>
             <style>
               <style-rule element="mark">
@@ -56,8 +46,8 @@
             </style>
           </pane>
         </panes>
-        <rows />
-        <cols />
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]</cols>
       </table>
-      <simple-id uuid="{A9839A3B-54AA-55D6-9FD6-0CA1784A553F}" />
+      <simple-id uuid="{9CEC14CA-6F15-5502-AE64-DA486DD4311A}" />
     </worksheet>

--- a/tests/fixtures/charts/bar-labelled.xml
+++ b/tests/fixtures/charts/bar-labelled.xml
@@ -23,6 +23,9 @@
           <style-rule element="cell">
             <format attr="text-format" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" value="$#,##0" />
           </style-rule>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/bar-sorted.xml
+++ b/tests/fixtures/charts/bar-sorted.xml
@@ -21,6 +21,9 @@
           <aggregation value="true" />
         </view>
         <style>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/bar-stacked.xml
+++ b/tests/fixtures/charts/bar-stacked.xml
@@ -22,6 +22,16 @@
           <aggregation value="true" />
         </view>
         <style>
+          <style-rule element="mark">
+            <encoding attr="color" field="[federated.b2993893834e8f0306a282d0a717d7a9].[none:region:nk]" palette="Brand" type="palette">
+              <color-palette custom="true" name="Brand" type="regular">
+                <color>#1b4f72</color>
+                <color>#2e86c1</color>
+                <color>#48c9b0</color>
+                <color>#f39c12</color>
+              </color-palette>
+            </encoding>
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/bar-styled.xml
+++ b/tests/fixtures/charts/bar-styled.xml
@@ -26,6 +26,9 @@
           <style-rule element="cell">
             <format attr="text-format" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" value="$#,##0" />
           </style-rule>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />
@@ -38,6 +41,15 @@
               <breakdown value="auto" />
             </view>
             <mark class="Automatic" />
+            <encodings>
+              <text column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
+            </encodings>
+            <style>
+              <style-rule element="mark">
+                <format attr="mark-labels-show" value="true" />
+                <format attr="mark-labels-cull" value="true" />
+              </style-rule>
+            </style>
           </pane>
         </panes>
         <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>

--- a/tests/fixtures/charts/bar.xml
+++ b/tests/fixtures/charts/bar.xml
@@ -20,6 +20,9 @@
           <aggregation value="true" />
         </view>
         <style>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/calculated-field.xml
+++ b/tests/fixtures/charts/calculated-field.xml
@@ -22,6 +22,9 @@
           <aggregation value="true" />
         </view>
         <style>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/combo.xml
+++ b/tests/fixtures/charts/combo.xml
@@ -26,6 +26,16 @@
             <encoding attr="space" class="0" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]" field-type="quantitative" fold="true" scope="rows" synchronized="true" type="space" />
             <format attr="display" class="0" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]" scope="rows" value="false" />
           </style-rule>
+          <style-rule element="mark">
+            <encoding attr="color" field="[federated.b2993893834e8f0306a282d0a717d7a9].[:Measure Names]" palette="Brand" type="palette">
+              <color-palette custom="true" name="Brand" type="regular">
+                <color>#1b4f72</color>
+                <color>#2e86c1</color>
+                <color>#48c9b0</color>
+                <color>#f39c12</color>
+              </color-palette>
+            </encoding>
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/custom-tooltip.xml
+++ b/tests/fixtures/charts/custom-tooltip.xml
@@ -21,6 +21,9 @@
           <aggregation value="true" />
         </view>
         <style>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/dual-axis.xml
+++ b/tests/fixtures/charts/dual-axis.xml
@@ -26,6 +26,16 @@
             <encoding attr="space" class="0" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]" field-type="quantitative" fold="true" scope="rows" synchronized="true" type="space" />
             <format attr="display" class="0" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]" scope="rows" value="false" />
           </style-rule>
+          <style-rule element="mark">
+            <encoding attr="color" field="[federated.b2993893834e8f0306a282d0a717d7a9].[:Measure Names]" palette="Brand" type="palette">
+              <color-palette custom="true" name="Brand" type="regular">
+                <color>#1b4f72</color>
+                <color>#2e86c1</color>
+                <color>#48c9b0</color>
+                <color>#f39c12</color>
+              </color-palette>
+            </encoding>
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/histogram.xml
+++ b/tests/fixtures/charts/histogram.xml
@@ -22,6 +22,9 @@
           <aggregation value="true" />
         </view>
         <style>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/kpi-card.xml
+++ b/tests/fixtures/charts/kpi-card.xml
@@ -22,6 +22,9 @@
             <format attr="text-align" value="center" />
             <format attr="vertical-align" value="center" />
           </style-rule>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/line.xml
+++ b/tests/fixtures/charts/line.xml
@@ -20,6 +20,9 @@
           <aggregation value="true" />
         </view>
         <style>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/map.xml
+++ b/tests/fixtures/charts/map.xml
@@ -26,6 +26,14 @@
           <style-rule element="map">
             <format attr="washout" value="0.0" />
           </style-rule>
+          <style-rule element="mark">
+            <encoding attr="color" field="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:profit:qk]" palette="Brand" type="interpolated">
+              <color-palette custom="true" name="Brand" type="ordered-sequential">
+                <color>#1b4f72</color>
+                <color>#f39c12</color>
+              </color-palette>
+            </encoding>
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/scatter.xml
+++ b/tests/fixtures/charts/scatter.xml
@@ -22,6 +22,9 @@
           <aggregation value="true" />
         </view>
         <style>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/fixtures/charts/text-table.xml
+++ b/tests/fixtures/charts/text-table.xml
@@ -22,6 +22,9 @@
           <aggregation value="true" />
         </view>
         <style>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
           <style-rule element="worksheet">
             <format attr="font-family" value="Open Sans" />
             <format attr="display-field-labels" scope="cols" value="false" />

--- a/tests/test_brand.py
+++ b/tests/test_brand.py
@@ -32,6 +32,7 @@ FULL_TOKENS = (
     "## Source\nbranding/branding.md\n\n"
     "## Typography\nFont: Tableau Medium.\n\n"
     "## Colors\nBlue #2e75b6.\n\n"
+    "### Chart series colors\n1. #2e75b6\n2. #f39c12\n\n"
     "## Spacing\nCard padding 8px.\n\n"
     "## Dashboard Sizing\nRange, min 1100x800, max Flex.\n\n"
     "## Fallback Decisions\nNone — all values came from the brand source.\n"
@@ -41,12 +42,13 @@ FULL_TOKENS = (
 CORE_ONLY_TOKENS = (
     "# Design Tokens\n\n"
     "## Colors\nBlue #2e75b6.\n\n"
+    "### Chart series colors\n1. #2e75b6\n2. #f39c12\n\n"
     "## Typography\nFont: Tableau Medium.\n\n"
     "## Spacing\nCard padding 8px.\n\n"
     "## Fallback Decisions\nNone.\n"
 )
 
-# Missing required sections (has Colors but no Typography/Spacing/Fallbacks).
+# Missing required sections (has Colors but no series colours/Typography/Spacing/Fallbacks).
 INCOMPLETE_TOKENS = "# Design Tokens\n\n## Colors\nBlue #2e75b6.\n"
 
 
@@ -185,7 +187,20 @@ def test_validate_tokens_required_core():
     ok, missing_required, _ = brand.validate_design_tokens(INCOMPLETE_TOKENS)
 
     assert ok is False
-    assert set(missing_required) == {"Typography", "Spacing", "Fallback Decisions"}
+    assert set(missing_required) == {
+        "Chart series colors", "Typography", "Spacing", "Fallback Decisions",
+    }
+
+
+def test_validate_tokens_rejects_a_renamed_chart_series_heading():
+    """``tableau-build`` reads ``### Chart series colors`` by name to build every worksheet's
+    palette, so a file that renames it must fail here rather than silently un-style the
+    workbook (CONTRACT.md §1)."""
+    renamed = FULL_TOKENS.replace("### Chart series colors", "### Series palette")
+
+    ok, missing_required, _ = brand.validate_design_tokens(renamed)
+
+    assert ok is False and missing_required == ["Chart series colors"]
 
 
 def test_validate_tokens_recommended_are_optional():

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -648,6 +648,51 @@ def test_a_stray_table_does_not_donate_field_names():
     assert "2024-01-05" not in manifest.documented_fields(with_preview)["sales_orders.csv"]
 
 
+def test_unknown_fit_is_rejected():
+    """'Entire View' is the label, not the value - a fit Tableau has no zoom for would
+    silently leave the sheet on Standard."""
+    document = _manifest()
+    document["worksheets"][0]["fit"] = "Entire View"
+
+    errors = _errors(document)
+
+    assert any("unknown fit 'Entire View'" in error for error in errors)
+    assert any("entire-view" in error for error in errors)
+
+
+@pytest.mark.parametrize("block,expected", [
+    ({"shading": "#FFFFFF"}, None),
+    ({"borders": "none", "gridlines": "#EEEEEE"}, None),
+    ({"align": "center", "vertical_align": "top"}, None),
+    ({"shading": "white"}, "format.shading 'white' is not a '#rrggbb' colour"),
+    ({"shading": "none"}, "format.shading 'none' is not a '#rrggbb' colour"),
+    ({"gridlines": "off"}, "format.gridlines 'off' is not a '#rrggbb' colour nor 'none'"),
+    ({"align": "middle"}, "format.align 'middle' is not an alignment"),
+    ({"borders": ""}, "format.borders needs a value"),
+    ({"border": "#DDDDDD"}, "unknown format key 'border'"),
+])
+def test_format_block_values_are_checked(block, expected):
+    """A misspelled format key or an unparseable colour is the worst formatting bug: the
+    workbook opens, nothing complains, and the sheet simply is not formatted."""
+    document = _manifest()
+    document["worksheets"][0]["format"] = block
+
+    errors = _errors(document)
+
+    if expected is None:
+        assert errors == []
+    else:
+        assert any(expected in error for error in errors), errors
+
+
+def test_format_must_be_an_object():
+    """A bare colour string on 'format' names no pane to apply it to."""
+    document = _manifest()
+    document["worksheets"][0]["format"] = "#FFFFFF"
+
+    assert any("'format' must be an object" in error for error in _errors(document))
+
+
 def test_load_manifest_reports_bad_json(tmp_path):
     """Unparseable JSON fails fast with the file named, not a stack trace."""
     path = tmp_path / build.MANIFEST_FILENAME
@@ -976,6 +1021,21 @@ def test_every_viewpoint_has_entire_view_zoom():
     ]
     for viewpoint in viewpoints:
         assert viewpoint.find("zoom").get("type") == "entire-view"
+
+
+def test_each_worksheet_window_carries_its_own_fit():
+    """The sheet's own tab needs the fit too, or the analyst reviews it on Standard (#44).
+
+    The dashboard's viewpoints only govern the embedded copy; a reviewer opening the tab sees
+    the worksheet window, and without a zoom there Tableau fits it to nothing.
+    """
+    fits = {
+        window.get("name"): window.find("viewpoint/zoom").get("type")
+        for window in _render().findall("windows/window")
+        if window.get("class") == "worksheet"
+    }
+
+    assert fits == {"Revenue KPI": "entire-view", "Revenue Trend": "entire-view"}
 
 
 def test_every_worksheet_has_a_matching_window():

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -64,6 +64,14 @@ DESIGN_TOKENS = """# Design Tokens
 
 - **Font family**: Open Sans
 - **Chart title**: 14px, 600, #7F56D9
+
+## Colors
+
+### Chart series colors
+`#1B4F72`, `#2E86C1`, `#48C9B0`, `#F39C12`
+
+### Text
+- Dark (titles): #1C2833
 """
 
 
@@ -158,6 +166,24 @@ CHART_CASES: list[tuple[str, dict]] = [
     ("calculated-field", _sheet(
         "Calculated Field", "bar",
         shelves={"columns": ["region"], "rows": ["Margin Pct"]},
+    )),
+    # Issue #44: a measure on Text is mark labels on any chart type, and it is what makes a
+    # number format visible - the cell format only reaches a chart through its labels.
+    ("bar-labelled", _sheet(
+        "Bar Labelled", "bar",
+        shelves={"columns": ["product_category"], "rows": ["revenue"]},
+        encodings={"text": {"field": "revenue", "aggregation": "sum"}},
+        number_formats=[{"field": "revenue", "format": "$#,##0"}],
+    )),
+    # Issue #44: Format Borders / Lines / Shading / Alignment, plus a non-default fit.
+    ("bar-formatted", _sheet(
+        "Bar Formatted", "bar",
+        shelves={"columns": ["product_category"], "rows": ["revenue"]},
+        fit="fit-width",
+        format={
+            "shading": "#FFFFFF", "borders": "none", "gridlines": "#E5E8E8",
+            "zero_lines": "none", "align": "center", "vertical_align": "bottom",
+        },
     )),
 ]
 
@@ -757,6 +783,157 @@ def test_style_rules_are_alphabetical_by_element():
         for style in element.findall(".//style"):
             elements = [rule.get("element") for rule in style.findall("style-rule")]
             assert elements == sorted(elements), element.get("name")
+
+
+# --- Worksheet formatting (issue #44) ------------------------------------------
+
+def _mark_encoding(sheet_name: str) -> ET.Element:
+    """Return a sheet's worksheet-level mark colour encoding (its palette)."""
+    return _worksheet_element(sheet_name).find(
+        "table/style/style-rule[@element='mark']/encoding"
+    )
+
+
+def test_the_brand_palette_needs_no_member_values():
+    """The decision this ticket asked for: an inline <color-palette> orders the brand's hexes
+    and Tableau walks the domain against them, so a palette needs no data members at all."""
+    encoding = _mark_encoding("Bar Stacked")
+
+    assert encoding.get("attr") == "color"
+    assert encoding.get("type") == "palette"
+    assert encoding.get("field").endswith("[none:region:nk]")
+    palette = encoding.find("color-palette")
+    assert palette.get("type") == "regular"
+    assert [color.text for color in palette] == [
+        "#1b4f72", "#2e86c1", "#48c9b0", "#f39c12",
+    ]
+    # Nothing binds a member: the encoding carries the palette and no <map to=.../> at all.
+    assert encoding.find("map") is None
+
+
+def test_a_measure_on_colour_gets_a_two_ended_ramp():
+    """A continuous field cannot take a categorical palette - a ramp has a low and a high."""
+    encoding = _mark_encoding("Map")
+
+    assert encoding.get("type") == "interpolated"
+    palette = encoding.find("color-palette")
+    assert palette.get("type") == "ordered-sequential"
+    assert [color.text for color in palette] == ["#1b4f72", "#f39c12"]
+
+
+@pytest.mark.parametrize("sheet_name", ["Dual Axis", "Combo"])
+def test_dual_charts_colour_their_measure_names_from_the_brand(sheet_name):
+    """Their colour field is the built-in Measure Names, which is still a dimension."""
+    encoding = _mark_encoding(sheet_name)
+    assert encoding.get("field").endswith("[:Measure Names]")
+    assert encoding.get("type") == "palette"
+
+
+def test_an_uncoloured_chart_gets_no_palette():
+    """A plain bar has nothing on Colour, so a palette rule would style nothing."""
+    assert _mark_encoding("Bar") is None
+
+
+def test_no_series_colours_means_tableau_default_10():
+    """Tokens that carry only typography must not invent a palette."""
+    root = ET.fromstring(_render(tokens="## Typography\n\n- **Font family**: Open Sans\n"))
+    assert _worksheet_element("Bar Stacked", root).find(
+        "table/style/style-rule[@element='mark']"
+    ) is None
+
+
+def test_a_measure_on_text_labels_the_marks_of_any_chart_type():
+    """A bar with SUM on Text is labelled bars - and the labels are what make its
+    number_format visible, which is why a styled bar used to look identical to a plain one."""
+    element = _worksheet_element("Bar Labelled")
+    rule = element.find("table/panes/pane/style/style-rule[@element='mark']")
+    shown = {fmt.get("attr"): fmt.get("value") for fmt in rule.findall("format")}
+
+    assert shown["mark-labels-show"] == "true"
+    assert element.find("table/panes/pane/encodings/text") is not None
+    cell = element.find("table/style/style-rule[@element='cell']/format")
+    assert cell.get("attr") == "text-format"
+    assert cell.get("value") == "$#,##0"
+
+
+def test_borders_lines_shading_and_alignment_come_off_the_manifest():
+    """The four Desktop format panes, each a style rule the manifest asked for."""
+    element = _worksheet_element("Bar Formatted")
+    formats = {
+        (rule.get("element"), fmt.get("attr")): fmt.get("value")
+        for rule in element.findall("table/style/style-rule")
+        for fmt in rule.findall("format")
+    }
+
+    assert formats[("pane", "background-color")] == "#ffffff"
+    assert formats[("cell", "border-style")] == "none"
+    assert formats[("cell", "border-width")] == "0"
+    assert formats[("gridline", "stroke-color")] == "#e5e8e8"
+    assert formats[("zeroline", "display")] == "false"
+    assert formats[("cell", "text-align")] == "center"
+    assert formats[("cell", "vertical-align")] == "bottom"
+
+
+def test_a_colour_border_gets_a_width_and_a_style():
+    """'borders: #hex' has to say how wide and how solid, or Tableau draws nothing."""
+    document = _manifest([_sheet(
+        "Bordered", "bar",
+        shelves={"columns": ["region"], "rows": ["revenue"]},
+        format={"borders": "#DDDDDD"},
+    )])
+    element = _worksheet_element("Bordered", ET.fromstring(_render(document)))
+    formats = {
+        fmt.get("attr"): fmt.get("value")
+        for fmt in element.findall("table/style/style-rule[@element='cell']/format")
+    }
+
+    assert formats == {
+        "border-color": "#dddddd", "border-style": "solid", "border-width": "1",
+    }
+
+
+def test_a_kpi_card_still_centres_itself_and_an_explicit_align_wins():
+    """Centring is the KPI treatment, not a default worth losing - but the analyst overrules."""
+    kpi_formats = {
+        fmt.get("attr"): fmt.get("value")
+        for fmt in _worksheet_element("Kpi Card").findall(
+            "table/style/style-rule[@element='cell']/format"
+        )
+    }
+    assert kpi_formats == {"text-align": "center", "vertical-align": "center"}
+
+    document = _manifest([_sheet("Left KPI", "text", encodings={"text": "revenue"},
+                                 format={"align": "left"})])
+    element = _worksheet_element("Left KPI", ET.fromstring(_render(document)))
+    overruled = {
+        fmt.get("attr"): fmt.get("value")
+        for fmt in element.findall("table/style/style-rule[@element='cell']/format")
+    }
+    assert overruled == {"text-align": "left", "vertical-align": "center"}
+
+
+def test_every_sheet_fits_its_zone_and_a_text_table_still_scrolls():
+    """Entire View by default (a zone is a fixed box), Standard where the sheet is meant to
+    scroll, and the manifest overrides either."""
+    zooms = {}
+    for window in ALL_CHARTS_ROOT.findall("windows/window"):
+        if window.get("class") != "worksheet":
+            continue
+        zoom = window.find("viewpoint/zoom")
+        zooms[window.get("name")] = None if zoom is None else zoom.get("type")
+
+    assert zooms["Bar"] == "entire-view"
+    assert zooms["Text Table"] is None, "a text table keeps Standard fit"
+    assert zooms["Bar Formatted"] == "fit-width", "the manifest's own fit"
+
+    # The dashboard's copy of each sheet fits the same way.
+    dashboard = {
+        viewpoint.get("name"): viewpoint.find("zoom")
+        for viewpoint in ALL_CHARTS_ROOT.findall("windows/window/viewpoints/viewpoint")
+    }
+    assert dashboard["Bar"].get("type") == "entire-view"
+    assert dashboard["Text Table"] is None
+    assert dashboard["Bar Formatted"].get("type") == "fit-width"
 
 
 # --- Legends -------------------------------------------------------------------

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -106,11 +106,14 @@ CHART_CASES: list[tuple[str, dict]] = [
             {"field": "order_date", "min": "2025-03-03", "max": "2025-04-22"},
         ],
     )),
+    # The text encoding is what makes the number_format visible: without labelled marks a
+    # styled bar renders identically to a plain one, which is the #35 symptom.
     ("bar-styled", _sheet(
         "Bar Styled", "bar",
         shelves={"columns": ["product_category"], "rows": ["revenue"]},
         axis_titles={"rows": "Revenue per category"},
         number_formats=[{"field": "revenue", "format": "$#,##0"}],
+        encodings={"text": {"field": "revenue", "aggregation": "sum"}},
     )),
     ("bar-stacked", _sheet(
         "Bar Stacked", "bar",
@@ -829,9 +832,15 @@ def test_dual_charts_colour_their_measure_names_from_the_brand(sheet_name):
     assert encoding.get("type") == "palette"
 
 
-def test_an_uncoloured_chart_gets_no_palette():
-    """A plain bar has nothing on Colour, so a palette rule would style nothing."""
+def test_an_uncoloured_chart_gets_the_brand_colour_and_no_palette():
+    """A plain bar has no domain to walk, so a palette would style nothing - but its marks
+    still have a colour, and Tableau's default blue is what makes a chart look generated."""
     assert _mark_encoding("Bar") is None
+
+    rule = _worksheet_element("Bar").find("table/style/style-rule[@element='mark']")
+    assert [(fmt.get("attr"), fmt.get("value")) for fmt in rule.findall("format")] == [
+        ("mark-color", "#1b4f72"),
+    ]
 
 
 def test_no_series_colours_means_tableau_default_10():


### PR DESCRIPTION
Closes #44.

Every chart template in the #35 review workbook rendered correctly but looked like a
Tableau default. This branch makes the builder emit formatting.

## Acceptance criteria

| # | criterion | how |
|---|---|---|
| 1 | Fit emitted, Entire View default, documented per-sheet override | new `fit` worksheet key -> the viewpoint's `<zoom type>`. The actual gap was that the fit was only ever on the dashboard's `<viewpoints>` copy, never on the sheet's own window; `_render_zoom` now writes both. `table` defaults to Standard, which is *no* `<zoom>` at all. |
| 2 | A recorded palette decision, plus an implementation or explicit deferral | **A palette needs no member values.** A member-bound palette (`<map to='#…'><bucket>"West"</bucket>`) is unbuildable from a manifest, but an inline `<color-palette>` only lists colours *in order* and lets Tableau walk the field's domain against them — so profiling never has to pass distinct members through. Recorded in `CONTRACT.md` §1 and `BUILD-MANIFEST-TEMPLATE.md`, and implemented. |
| 3 | A chart template with a measure on the text mark, with a golden | `_render_pane` shows mark labels for `label_marks or "text" in encodings`, i.e. any chart type — which is also the fix for the invisible-`number_formats` symptom. New golden `bar-labelled`; `bar-styled` given a text encoding so its `$#,##0` finally shows. |
| 4 | Borders / lines / shading / alignment from the manifest, with goldens | new `format` worksheet key -> `SheetFormat`, rendered as `pane` background, `cell` borders, `gridline` / `zeroline` stroke and display, `cell` text/vertical alignment. New golden `bar-formatted`. |
| 5 | `BUILD-MANIFEST-TEMPLATE.md` documents every new key | `fit`, `format`, the palette decision, the text-encoding rule, histogram bin-width guidance and the dual-axis/combo lookalike. |

## How the palette lands

- **dimension** on Colour -> the full ordered palette, `type='palette'` / `regular`
- **measure** on Colour -> a two-ended ramp, `type='interpolated'` / `ordered-sequential`
- **dual / combo** -> coloured by the built-in Measure Names, categorical
- **nothing** on Colour -> the brand's *first* colour as a flat `mark-color`. Without this last
  case the palette reached only 5 of 15 sheets and the rest stayed Tableau's default blue,
  which is the whole complaint in §2.

Because `build` binds to the `### Chart series colors` heading by name, that section is now
required by `tableau-brand`'s validator — a renamed heading used to pass as "has Colors" and
silently un-style every workbook.

## Scope notes

- `fit-width` / `fit-height` are also accepted and validated. §1 only asked for Standard vs
  Entire View; these are the other two XSD zoom values and cost two dict lines.
- #44's two "also worth folding in" items — a computed histogram bin width, and dual-axis vs
  combo looking alike — are **documented, not implemented**. The bin width belongs in
  `tableau-data` profiling (`DATA-MODEL.md` carries no min/max today), so it is a profiling +
  handoff-format change rather than a builder one.
- Two `ponytail:` comments mark constructs that are XSD-legal but only Desktop can attest
  (the `<color-palette>` `custom` flag, and which element Desktop hangs each format attribute
  off). **Issue #52** carries the save-and-diff steps.

## Tests

`542 passed`. 2 new golden cases, 16 goldens regenerated (the diff is uniform: one
`mark-color` rule per uncoloured sheet), ~16 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
