### PR TITLE
feat(build): spec-conformance validator, three-validator gate, unsupported-construct policy

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -173,9 +173,9 @@ The case of a filename encodes its role, so a skill can tell handoff artifacts f
 its *own* next stage, never read by another skill. Today there are two, both `tableau-build`'s:
 `mock-version/v_N/build-manifest.json`, the machine-readable translation of
 `IMPLEMENTATION-SPEC.md` + `DATA-MODEL.md` that the workbook generator consumes; and
-`mock-version/v_N/dashboard.twb`, the unpackaged workbook the two validators read before it is
-zipped into the deliverable `.twbx` (it stays on disk after a failed build so the XML can be
-inspected). Because nothing downstream reads them, they are not handoffs and take the lowercase
+`mock-version/v_N/dashboard.twb`, the unpackaged workbook the validation gate's three validators
+read before it is zipped into the deliverable `.twbx` (it stays on disk after a failed gate so
+the XML can be inspected). Because nothing downstream reads them, they are not handoffs and take the lowercase
 casing; they are versioned with the deliverable they produce (§4.3). A skill may add one only
 for a stage boundary inside itself.
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,15 @@ Each step is owned by exactly one skill, reads a known set of artifacts, and wri
 | 5 | `tableau-plan`   | Blueprint: screen size, slots, KPIs, charts, filters, interactions (stable ids) | `DATA-MODEL.md` (+ `PRD.md`, `DESIGN-TOKENS.md`) → `DASHBOARD-PLAN.md` | no |
 | 6 | `tableau-mock`   | Interactive HTML demo from real sample data | `DASHBOARD-PLAN.md`, `data/*.csv` → `mock-version/v_N/mock.html` | no |
 | 7 | `tableau-spec`   | Map every mock element to a concrete Tableau construct | `mock.html`, `DASHBOARD-PLAN.md` → `mock-version/v_N/IMPLEMENTATION-SPEC.md` | no |
-| 8 | `tableau-build` *(views in development)* | Generate the version-aware, XSD-validated workbook | `IMPLEMENTATION-SPEC.md`, `DATA-MODEL.md`, `data/*.csv` → `mock-version/v_N/dashboard.twbx` | no |
+| 8 | `tableau-build` *(experimental)* | Generate the version-aware, XSD-validated workbook | `IMPLEMENTATION-SPEC.md`, `DATA-MODEL.md`, `data/*.csv` → `mock-version/v_N/dashboard.twbx` | no |
 
 > **`tableau-route`** is the compass, not a step: it reads `STATE.md` and reports the single next skill to run. It only recommends — it never runs another skill for you.
 
-> **Status — step 8 is landing in pieces.** Steps 1–7 (`init` → `spec`) are complete. `tableau-build` today derives and validates the build manifest and assembles a workbook that Tableau opens: datasources (live, with the CSVs packaged into the `.twbx`), a dashboard sized from the approved mock, windows, and version targeting, checked by both validators on every build. The worksheet bodies (shelves, encodings, marks) and the dashboard's zone tree are the remaining piece, so the views are still empty. Tableau has announced a **native skill** for generating a workbook from a spec — when it ships we intend to integrate it as the build step rather than maintain a parallel generator, so the exact shape of step 8 may change.
+> **Status — step 8 is experimental, and we want your bug reports.** All eight steps are feature-complete: `tableau-build` derives and validates the build manifest, then assembles a full workbook — datasources (live, with the CSVs packaged into the `.twbx`), worksheets with shelves, encodings and marks across 15 chart patterns, the dashboard's zone tree at the approved mock's geometry, filter/highlight/parameter actions, calculated fields, and worksheet formatting — gated by three validators (semantic, XSD schema, and spec conformance) before anything is packaged.
+>
+> It is marked **experimental** because the validators are not Tableau. Individual constructs are attested against workbooks saved by Tableau Desktop 2025.1, but a generated workbook has not yet been proven across the range of dashboards real analysts will ask for. Tableau's XML is unforgiving and it fails quietly: a workbook can pass every validator and still be silently rewritten, or refused, on open — so the only authority on fidelity is Desktop itself. **If Tableau Desktop reports an error on a generated workbook, or a view renders differently from the mock it was specced from, please [open an issue](../../issues/new) with the error text and the `build-manifest.json` that produced it.** Each report becomes a permanent fix in the builder's templates rather than a one-off patch, so it improves every workbook generated afterwards.
+>
+> One forward-looking note: Tableau has announced a **native skill** for generating a workbook from a spec. When it ships we intend to integrate it as the build step rather than maintain a parallel generator, so the exact shape of step 8 may change.
 
 Skippable steps (`intake`, `brand`) let you go straight from a scaffolded project to planning with sensible fallbacks (the raw request text; neutral styling).
 
@@ -145,7 +149,7 @@ If you used the old single skill: the workflow now lives in this plugin. Install
 - **No box shadows** — not natively supported in Tableau.
 - **Container hierarchy** must follow Tableau's zone model (layout-basic → layout-flow → sheets).
 - **Fallback-driven choices are disclosed** — when a skill uses a Tableau default for missing input, it says so.
-- **`tableau-build` still emits empty views** — the workbook it produces opens cleanly and carries the data, but the shelves/encodings are the remaining piece (see the status note above); always review the generated workbook in Tableau Desktop before publishing.
+- **`tableau-build` is experimental** — the workbook passes three validators before it is packaged, but validators are not Tableau: always open the generated workbook in Tableau Desktop and review it against the mock before publishing, and please report anything Desktop rejects or redraws (see the status note above).
 
 ## Contributing
 

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -109,13 +109,29 @@ invented zone is caught rather than silently built.
    python "${CLAUDE_SKILL_DIR}/scripts/build.py" build "<project-dir>"
    ```
 
-   This assembles `dashboard.twb`, runs both validators over it, and packages
-   `dashboard.twbx` with the CSVs. `[BUILT]` means both validators are green — a `[WARN]`
+   This assembles `dashboard.twb`, runs the **validation gate** over it, and packages
+   `dashboard.twbx` with the CSVs. `[BUILT]` means all three validators are green — a `[WARN]`
    line about a missing `explain-data` element is the expected version shift when the target
    is `2024.2-2025.x` (the 2026.1 schema requires an element that older Tableau must not
    carry), not a problem. `[INVALID]` leaves the `.twb` on disk unpackaged: read the named
    errors, fix the manifest, and re-run. Never hand-patch the generated XML — the assembler
    is the fix's home.
+
+   **The gate is what the analyst's trust rests on**, so never present a workbook that has
+   not passed it. It is three validators under one verdict, each error prefixed with the one
+   that raised it: `[semantic]` (is the XML internally consistent?), `[schema]` (does it match
+   the XSD?) and `[conformance]` (does the workbook agree with the manifest — every layout
+   element became a zone, every zone names a real sheet, every declared worksheet is built,
+   placed, and has a window). Only the third can see something *missing*: what is absent is
+   absent consistently, so the first two happily pass a workbook that dropped a chart. To
+   re-run the gate over a `.twb` already on disk — the revalidate half of a fix — use:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/build.py" gate "<project-dir>"
+   ```
+
+   It repackages the `.twbx` when the gate passes and deletes it when it does not, so
+   `commit` can never approve a workbook that failed.
 
 6. **Commit** — only after the analyst approves:
 
@@ -171,10 +187,17 @@ invented zone is caught rather than silently built.
   visibility field at all: it splits the marks and the zone stops toggling. The Detail-shelf
   placement the field needs, the parameter declarations and the format flags are the builder's
   job.
-- **An image / button / legend object reserves its box, empty.** Each of those zone types needs
-  a reference the manifest does not carry (a filename, an action, a sheet + colour field), and
-  Tableau does not treat those as optional — so the layout keeps the geometry until the wiring
-  lands. `filter`, `parameter`, `text` and `blank` objects render fully today.
+- **An unsupported construct is refused by name, never silently.** An image / button / legend
+  object needs a reference the manifest does not carry (a filename, an action, a sheet + colour
+  field) and Tableau does not treat those as optional, so the layout **reserves its box as an
+  empty zone** — the approved geometry holds and everything else builds. `filter`, `parameter`,
+  `text` and `blank` objects render fully today. The gate emits a `[WARN]` naming each gap:
+  relay it to the analyst with both ways forward — **either** they build that one object in
+  Tableau Desktop and save a reference `.twb` for the repo (the permanent fix: a snippet under
+  `references/snippets/` and a template in the builder), **or** say the word and you hand-write
+  that one block into the `.twb` and prove it with `build.py gate` (the move-on fix, good for
+  this workbook only). Ask which; never pick silently, and never let the analyst discover the
+  gap as a blank rectangle in Desktop.
 
 > The full `STATE.md` schema and the ordering / staleness / versioning rules live in
 > `CONTRACT.md` at the repo root. This skill restates only its own slice; `build.py`,

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -103,6 +103,14 @@ invented zone is caught rather than silently built.
    from a manifest that does not validate. When it prints `[OK]`, present the manifest
    summary (worksheets, layout zones, actions) for approval.
 
+   An `[INVALID]` naming an **unknown `chart_type`** is not a typo but a construct the
+   builder has no template for. Unlike an object kind it cannot be reduced to an empty box —
+   a worksheet with no template renders nothing — so validation refuses fail-fast, before any
+   XML exists. Say so plainly and offer the same two ways forward as any other gap (see the
+   unsupported-construct note below): the closest supported chart type for now, plus either a
+   reference `.twb` from Desktop or a hand-written block. Never silently substitute a
+   different chart type — the spec is what the analyst approved.
+
 5. **Build the workbook:**
 
    ```bash

--- a/skills/tableau-build/scripts/build.py
+++ b/skills/tableau-build/scripts/build.py
@@ -19,14 +19,21 @@ filesystem:
 
 4. **Assembly** - ``build`` turns the validated manifest into the deliverable: the XML comes
    from :mod:`twb` (pure, correct by construction), and this module supplies the CSV header
-   rows it needs, runs both migrated validators over the result, and packages the ``.twb``
+   rows it needs, runs the **validation gate** over the result, and packages the ``.twb``
    plus the CSVs into a ``.twbx``.
+5. **The gate** (:func:`run_gate`) - all three validators as one verdict: :mod:`validate_twb`
+   (is the XML internally consistent?), :mod:`validate_twb_xsd` (does it match the schema?)
+   and :mod:`validate_conformance` (does it agree with the manifest the analyst approved?).
+   A workbook that fails any of them is left on disk **unpackaged**, so the analyst is never
+   handed a ``.twbx`` that did not pass. Constructs the builder has no template for are named
+   as warnings rather than silently emptied.
 
 The module is pure and stdlib-only (it does **not** import the router) so the contract test
 can call its functions directly, exactly like ``spec.py``. The CLI exposes ``precheck``
 (before authoring - reports the target ``v_N`` and the inputs), ``validate`` (the manifest
-schema check), ``build`` (manifest -> validated ``.twbx``), and ``commit`` (after approval).
-Program output goes to stdout; diagnostics through ``logging``.
+schema check), ``build`` (manifest -> gated ``.twbx``), ``gate`` (re-run the gate over the
+``.twb`` on disk, for the fix loop), and ``commit`` (after approval). Program output goes to
+stdout; diagnostics through ``logging``.
 
 Keep ``STEP_ORDER`` in lock-step with CONTRACT.md §1.
 """
@@ -40,6 +47,7 @@ import json
 import logging
 import re
 import sys
+import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -656,6 +664,173 @@ def _xsd_errors(twb_path: Path, target_tableau_version: str) -> tuple[list[str],
     return fatal, warnings
 
 
+#: The three validators of the gate, in the order they run: the XML's internal consistency,
+#: its agreement with the schema, and its agreement with the manifest (CONTRACT.md §8 gate).
+GATE_VALIDATORS: tuple[str, ...] = ("semantic", "schema", "conformance")
+
+
+@dataclass(frozen=True)
+class GateReport:
+    """The verdict of all three validators over one built workbook.
+
+    Attributes:
+        results: ``{validator name: errors}`` for each of :data:`GATE_VALIDATORS`.
+        warnings: Non-fatal notes - a skipped XSD check, the documented version shift, and
+            each unsupported construct the build reserved a box for but did not draw.
+    """
+
+    results: dict[str, list[str]]
+    warnings: list[str]
+
+    @property
+    def ok(self) -> bool:
+        """True when every validator passed."""
+        return not any(self.results.values())
+
+    @property
+    def errors(self) -> list[str]:
+        """Every error, prefixed with the validator that raised it."""
+        return [
+            f"[{name}] {message}"
+            for name in GATE_VALIDATORS for message in self.results.get(name, [])
+        ]
+
+
+def _conformance_errors(twb_path: Path, document: dict) -> list[str]:
+    """Run the spec-conformance validator over a built workbook.
+
+    Args:
+        twb_path: The workbook XML to check.
+        document: The manifest it was built from.
+
+    Returns:
+        One message per disagreement between the two; empty when they agree.
+    """
+    import validate_conformance  # same scripts/ dir, stdlib-only
+
+    try:
+        root = ET.parse(twb_path).getroot()
+    except ET.ParseError as error:
+        # The semantic validator reports the parse error itself; do not double-report it.
+        logger.warning(f"Conformance check skipped: {twb_path} is not parseable ({error}).")
+        return []
+    return validate_conformance.conformance_errors(root, document)
+
+
+def run_gate(
+    twb_path: Path, document: dict, target_tableau_version: str
+) -> GateReport:
+    """Run all three validators over a built workbook and return one verdict.
+
+    This is the gate the analyst is never shown a workbook without passing: the semantic
+    validator (is the XML internally consistent?), the XSD validator (does it match the
+    schema?), and the conformance validator (does it agree with the manifest the analyst
+    approved?). Only the third can see a *missing* sheet or zone - what is absent is absent
+    consistently, so the first two pass a workbook that quietly dropped one.
+
+    Args:
+        twb_path: The workbook XML to check.
+        document: The manifest it was built from.
+        target_tableau_version: STATE.md's target (CONTRACT.md §2).
+
+    Returns:
+        A :class:`GateReport`.
+    """
+    import validate_conformance  # same scripts/ dir, stdlib-only
+
+    xsd_errors, warnings = _xsd_errors(twb_path, target_tableau_version)
+    return GateReport(
+        results={
+            "semantic": _semantic_errors(twb_path),
+            "schema": xsd_errors,
+            "conformance": _conformance_errors(twb_path, document),
+        },
+        # The unsupported-construct policy: a reserved-but-empty box is named here, never
+        # left for the analyst to discover as a blank rectangle in Desktop.
+        warnings=warnings + validate_conformance.unsupported_notes(document),
+    )
+
+
+def gate(project_dir: Path | str) -> BuildResult:
+    """Re-run the validation gate over the workbook already on disk.
+
+    The revalidate half of the fix loop: after a hand-written block is added to the ``.twb``
+    (the unsupported-construct escape hatch), this proves it before the ``.twbx`` is
+    repackaged. A passing gate repackages; a failing one leaves the package alone.
+
+    Args:
+        project_dir: The analyst's project directory.
+
+    Returns:
+        A :class:`BuildResult`, whose ``errors`` are the gate's.
+    """
+    project_root = Path(project_dir)
+    validation = validate(project_root)
+    if not validation.ok:
+        return BuildResult(False, validation.errors, validation.version)
+
+    version_dir = project_root / VERSION_DIR / validation.version
+    twb_path = version_dir / TWB_FILENAME
+    twb_relative = f"{VERSION_DIR}/{validation.version}/{TWB_FILENAME}"
+    if not twb_path.exists():
+        return BuildResult(
+            False,
+            [
+                f"'{twb_relative}' does not exist - run 'build.py build' to assemble the "
+                f"workbook before gating it."
+            ],
+            validation.version,
+        )
+
+    document, _ = load_manifest(version_dir / MANIFEST_FILENAME)
+    target = read_target_tableau_version(
+        (project_root / STATE_FILENAME).read_text(encoding="utf-8-sig")
+    )
+    # Drop the previous package first: 'commit' approves on the .twbx's existence, so one
+    # left behind by an earlier passing build would be approved despite this gate failing.
+    (version_dir / WORKBOOK_FILENAME).unlink(missing_ok=True)
+
+    report = run_gate(twb_path, document, target)
+    if not report.ok:
+        return BuildResult(
+            False, report.errors, validation.version, twb_relative,
+            warnings=report.warnings,
+        )
+
+    create_twbx(twb_path, _packaged_csvs(project_root, document))
+    return BuildResult(
+        ok=True,
+        errors=[],
+        version=validation.version,
+        twb_path=twb_relative,
+        twbx_path=f"{VERSION_DIR}/{validation.version}/{WORKBOOK_FILENAME}",
+        warnings=report.warnings,
+    )
+
+
+def _packaged_csvs(project_root: Path, document: dict) -> list[Path]:
+    """Return the CSVs the manifest binds to, in manifest order and de-duplicated.
+
+    Only those: an unrelated file in ``data/`` has no business shipping inside the analyst's
+    deliverable.
+
+    Args:
+        project_root: The analyst's project directory.
+        document: The build manifest.
+
+    Returns:
+        Absolute paths of the CSVs to package.
+    """
+    on_disk = {
+        (project_root / relative).name: project_root / relative
+        for relative in _sample_csvs(project_root)
+    }
+    wanted = [
+        str(source.get("csv", "")).strip() for source in document.get("datasources", [])
+    ]
+    return [on_disk[name] for name in dict.fromkeys(wanted) if name in on_disk]
+
+
 def build_workbook(project_dir: Path | str) -> BuildResult:
     """Assemble, validate, and package the workbook from the validated manifest.
 
@@ -720,16 +895,14 @@ def build_workbook(project_dir: Path | str) -> BuildResult:
     target = read_target_tableau_version(
         (project_root / STATE_FILENAME).read_text(encoding="utf-8-sig")
     )
-    errors = _semantic_errors(twb_path)
-    xsd_errors, warnings = _xsd_errors(twb_path, target)
-    errors += xsd_errors
-    if errors:
-        # Leave the .twb for inspection, but never package a workbook that failed a check.
-        return BuildResult(False, errors, version, twb_relative, warnings=warnings)
+    report = run_gate(twb_path, document, target)
+    if not report.ok:
+        # Leave the .twb for inspection, but never package a workbook that failed the gate.
+        return BuildResult(
+            False, report.errors, version, twb_relative, warnings=report.warnings
+        )
 
-    # Only the CSVs the manifest actually binds to: an unrelated file in data/ has no
-    # business shipping inside the analyst's deliverable.
-    create_twbx(twb_path, [on_disk[name] for name in dict.fromkeys(wanted)])
+    create_twbx(twb_path, _packaged_csvs(project_root, document))
     logger.info(f"Built {twb_relative} and its .twbx from the validated manifest.")
     return BuildResult(
         ok=True,
@@ -737,7 +910,7 @@ def build_workbook(project_dir: Path | str) -> BuildResult:
         version=version,
         twb_path=twb_relative,
         twbx_path=f"{VERSION_DIR}/{version}/{WORKBOOK_FILENAME}",
-        warnings=warnings,
+        warnings=report.warnings,
     )
 
 
@@ -854,17 +1027,27 @@ def format_validation(result: ValidationResult) -> str:
     return "\n".join(lines)
 
 
-def format_build(result: BuildResult) -> str:
-    """Render a :class:`BuildResult` as the assembly report."""
+def format_build(result: BuildResult, verb: str = "build") -> str:
+    """Render a :class:`BuildResult` as the assembly / gate report.
+
+    Args:
+        result: The outcome to render.
+        verb: What was attempted, for the failure line (``build`` or ``gate``).
+
+    Returns:
+        A plain-ASCII block with the single pass/fail summary of all three validators.
+    """
     # Plain ASCII only (see format_precheck).
     lines: list[str]
     if result.ok:
         lines = [
             f"[BUILT] {result.twbx_path}",
-            f"  workbook xml : {result.twb_path} (semantic + XSD validated)",
+            f"  gate: all {len(GATE_VALIDATORS)} validators passed "
+            f"({', '.join(GATE_VALIDATORS)}).",
+            f"  workbook xml : {result.twb_path}",
         ]
     else:
-        lines = ["[INVALID] the workbook did not build:"]
+        lines = [f"[INVALID] the workbook did not {verb} - the validation gate failed:"]
         lines += [f"  - {error}" for error in result.errors]
         if result.twb_path:
             lines.append(f"  the XML is at {result.twb_path} for inspection; nothing packaged.")
@@ -908,6 +1091,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         ("precheck", "Report whether build may run, what it reads, and where it writes."),
         ("validate", "Schema-check the build manifest against DATA-MODEL.md and the layout."),
         ("build", "Assemble, validate, and package the workbook from the manifest."),
+        ("gate", "Re-run all three validators over the .twb on disk, then repackage."),
         ("commit", "Approve the build in STATE.md (never bumps current_version)."),
     ):
         sub = subparsers.add_parser(name, help=help_text)
@@ -932,6 +1116,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         build_result = build_workbook(project_dir)
         print(format_build(build_result))
         return 0 if build_result.ok else 2
+
+    if args.command == "gate":
+        gate_result = gate(project_dir)
+        print(format_build(gate_result, verb="pass the gate"))
+        return 0 if gate_result.ok else 2
 
     commit_result = commit(project_dir)
     print(format_commit(commit_result))

--- a/skills/tableau-build/scripts/build.py
+++ b/skills/tableau-build/scripts/build.py
@@ -54,6 +54,7 @@ from pathlib import Path
 from typing import Optional
 
 import twb
+import validate_conformance  # stdlib-only, same scripts/ dir (unlike the two lazy imports)
 from manifest import load_manifest, placed_layout_ids, validate_manifest
 
 logger = logging.getLogger(__name__)
@@ -596,6 +597,9 @@ class BuildResult:
             failure, so the XML can be inspected).
         twbx_path: Project-relative path of the package; ``""`` when nothing was packaged.
         warnings: Non-fatal notes (a skipped XSD check, the documented version shift).
+        gated: Whether the validation gate actually ran. A failure *before* it - an invalid
+            manifest, a missing CSV, no ``.twb`` to gate - must not be reported as a failed
+            gate, or the analyst debugs the wrong thing.
     """
 
     ok: bool
@@ -604,6 +608,7 @@ class BuildResult:
     twb_path: str = ""
     twbx_path: str = ""
     warnings: list[str] = field(default_factory=list)
+    gated: bool = False
 
 
 def _semantic_errors(twb_path: Path) -> list[str]:
@@ -665,7 +670,7 @@ def _xsd_errors(twb_path: Path, target_tableau_version: str) -> tuple[list[str],
 
 
 #: The three validators of the gate, in the order they run: the XML's internal consistency,
-#: its agreement with the schema, and its agreement with the manifest (CONTRACT.md §8 gate).
+#: its agreement with the schema, and its agreement with the manifest.
 GATE_VALIDATORS: tuple[str, ...] = ("semantic", "schema", "conformance")
 
 
@@ -706,8 +711,6 @@ def _conformance_errors(twb_path: Path, document: dict) -> list[str]:
     Returns:
         One message per disagreement between the two; empty when they agree.
     """
-    import validate_conformance  # same scripts/ dir, stdlib-only
-
     try:
         root = ET.parse(twb_path).getroot()
     except ET.ParseError as error:
@@ -736,8 +739,6 @@ def run_gate(
     Returns:
         A :class:`GateReport`.
     """
-    import validate_conformance  # same scripts/ dir, stdlib-only
-
     xsd_errors, warnings = _xsd_errors(twb_path, target_tableau_version)
     return GateReport(
         results={
@@ -790,14 +791,20 @@ def gate(project_dir: Path | str) -> BuildResult:
     # left behind by an earlier passing build would be approved despite this gate failing.
     (version_dir / WORKBOOK_FILENAME).unlink(missing_ok=True)
 
+    # The same binding the build packaged from, re-resolved: a CSV renamed since then would
+    # otherwise be dropped from the archive and the workbook would open bound to nothing.
+    binding = bind_csvs(project_root, document)
+    if binding.errors:
+        return BuildResult(False, binding.errors, validation.version, twb_relative)
+
     report = run_gate(twb_path, document, target)
     if not report.ok:
         return BuildResult(
             False, report.errors, validation.version, twb_relative,
-            warnings=report.warnings,
+            warnings=report.warnings, gated=True,
         )
 
-    create_twbx(twb_path, _packaged_csvs(project_root, document))
+    create_twbx(twb_path, binding.paths)
     return BuildResult(
         ok=True,
         errors=[],
@@ -805,38 +812,66 @@ def gate(project_dir: Path | str) -> BuildResult:
         twb_path=twb_relative,
         twbx_path=f"{VERSION_DIR}/{validation.version}/{WORKBOOK_FILENAME}",
         warnings=report.warnings,
+        gated=True,
     )
 
 
-def _packaged_csvs(project_root: Path, document: dict) -> list[Path]:
-    """Return the CSVs the manifest binds to, in manifest order and de-duplicated.
+@dataclass(frozen=True)
+class CsvBinding:
+    """The CSVs a manifest binds to, resolved against what is on disk.
 
-    Only those: an unrelated file in ``data/`` has no business shipping inside the analyst's
-    deliverable.
+    Attributes:
+        paths: The files to package, in manifest order and de-duplicated. Only the ones the
+            manifest binds to: an unrelated file in ``data/`` has no business shipping inside
+            the analyst's deliverable.
+        headers: ``{filename: header row}`` for every CSV found, the physical schema the
+            assembler needs.
+        errors: One message per bound CSV that is not on disk. Both the build and the gate
+            refuse on these - a package missing a CSV opens in Tableau bound to nothing.
+    """
+
+    paths: list[Path]
+    headers: dict[str, list[str]]
+    errors: list[str]
+
+
+def bind_csvs(project_root: Path, document: dict) -> CsvBinding:
+    """Resolve the manifest's datasource CSVs against ``data/`` (or the scaffold).
 
     Args:
         project_root: The analyst's project directory.
         document: The build manifest.
 
     Returns:
-        Absolute paths of the CSVs to package.
+        A :class:`CsvBinding`.
     """
     on_disk = {
         (project_root / relative).name: project_root / relative
         for relative in _sample_csvs(project_root)
     }
-    wanted = [
+    headers = {name: read_csv_header(path) for name, path in on_disk.items()}
+    wanted = list(dict.fromkeys(
         str(source.get("csv", "")).strip() for source in document.get("datasources", [])
-    ]
-    return [on_disk[name] for name in dict.fromkeys(wanted) if name in on_disk]
+    ))
+    return CsvBinding(
+        paths=[on_disk[name] for name in wanted if name in on_disk],
+        headers=headers,
+        errors=[
+            f"datasource csv '{name}' is not on disk (found: "
+            f"{', '.join(sorted(headers)) or 'none'}) - the workbook would bind to "
+            f"nothing. Re-run 'tableau-data' or fix the manifest's 'csv'."
+            for name in sorted(set(wanted) - set(headers))
+        ],
+    )
 
 
 def build_workbook(project_dir: Path | str) -> BuildResult:
     """Assemble, validate, and package the workbook from the validated manifest.
 
     The manifest must validate first (:func:`validate`), so the assembler never sees an
-    entry it cannot build. The XML then goes through both migrated validators before it is
-    packaged: a workbook that fails either is left on disk unpackaged, for debugging.
+    entry it cannot build. The XML then goes through the validation gate (:func:`run_gate`)
+    before it is packaged: a workbook that fails any of the three validators is left on disk
+    unpackaged, for debugging.
 
     Args:
         project_dir: The analyst's project directory.
@@ -857,26 +892,9 @@ def build_workbook(project_dir: Path | str) -> BuildResult:
     # .twbx's existence, so a stale one left behind by a failed build would be approved.
     (version_dir / WORKBOOK_FILENAME).unlink(missing_ok=True)
 
-    on_disk = {
-        (project_root / relative).name: project_root / relative
-        for relative in _sample_csvs(project_root)
-    }
-    headers = {name: read_csv_header(path) for name, path in on_disk.items()}
-    wanted = [
-        str(source.get("csv", "")).strip() for source in document.get("datasources", [])
-    ]
-    missing = sorted({name for name in wanted if name not in headers})
-    if missing:
-        return BuildResult(
-            False,
-            [
-                f"datasource csv '{name}' is not on disk (found: "
-                f"{', '.join(sorted(headers)) or 'none'}) - the workbook would bind to "
-                f"nothing. Re-run 'tableau-data' or fix the manifest's 'csv'."
-                for name in missing
-            ],
-            version,
-        )
+    binding = bind_csvs(project_root, document)
+    if binding.errors:
+        return BuildResult(False, binding.errors, version)
 
     twb_path = version_dir / TWB_FILENAME
     tokens_path = project_root / DESIGN_TOKENS_FILENAME
@@ -884,7 +902,7 @@ def build_workbook(project_dir: Path | str) -> BuildResult:
         twb.render_workbook(
             document,
             (project_root / DATA_MODEL_FILENAME).read_text(encoding="utf-8-sig"),
-            headers,
+            binding.headers,
             # Optional read (CONTRACT.md §4.1): no branding step, no styling overrides.
             tokens_path.read_text(encoding="utf-8-sig") if tokens_path.exists() else "",
         ),
@@ -899,10 +917,11 @@ def build_workbook(project_dir: Path | str) -> BuildResult:
     if not report.ok:
         # Leave the .twb for inspection, but never package a workbook that failed the gate.
         return BuildResult(
-            False, report.errors, version, twb_relative, warnings=report.warnings
+            False, report.errors, version, twb_relative, warnings=report.warnings,
+            gated=True,
         )
 
-    create_twbx(twb_path, _packaged_csvs(project_root, document))
+    create_twbx(twb_path, binding.paths)
     logger.info(f"Built {twb_relative} and its .twbx from the validated manifest.")
     return BuildResult(
         ok=True,
@@ -911,6 +930,7 @@ def build_workbook(project_dir: Path | str) -> BuildResult:
         twb_path=twb_relative,
         twbx_path=f"{VERSION_DIR}/{version}/{WORKBOOK_FILENAME}",
         warnings=report.warnings,
+        gated=True,
     )
 
 
@@ -1027,15 +1047,16 @@ def format_validation(result: ValidationResult) -> str:
     return "\n".join(lines)
 
 
-def format_build(result: BuildResult, verb: str = "build") -> str:
+def format_build(result: BuildResult) -> str:
     """Render a :class:`BuildResult` as the assembly / gate report.
 
     Args:
         result: The outcome to render.
-        verb: What was attempted, for the failure line (``build`` or ``gate``).
 
     Returns:
-        A plain-ASCII block with the single pass/fail summary of all three validators.
+        A plain-ASCII block carrying the gate's single pass/fail summary. A failure that
+        never reached the gate says so, so the analyst does not go looking in the XML for a
+        problem that is in the manifest.
     """
     # Plain ASCII only (see format_precheck).
     lines: list[str]
@@ -1047,9 +1068,12 @@ def format_build(result: BuildResult, verb: str = "build") -> str:
             f"  workbook xml : {result.twb_path}",
         ]
     else:
-        lines = [f"[INVALID] the workbook did not {verb} - the validation gate failed:"]
+        lines = [
+            "[INVALID] the validation gate failed:" if result.gated
+            else "[INVALID] nothing was gated - the build could not get that far:"
+        ]
         lines += [f"  - {error}" for error in result.errors]
-        if result.twb_path:
+        if result.twb_path and result.gated:
             lines.append(f"  the XML is at {result.twb_path} for inspection; nothing packaged.")
     lines += [f"  [WARN] {warning}" for warning in result.warnings]
     return "\n".join(lines)
@@ -1119,7 +1143,7 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     if args.command == "gate":
         gate_result = gate(project_dir)
-        print(format_build(gate_result, verb="pass the gate"))
+        print(format_build(gate_result))
         return 0 if gate_result.ok else 2
 
     commit_result = commit(project_dir)

--- a/skills/tableau-build/scripts/validate_conformance.py
+++ b/skills/tableau-build/scripts/validate_conformance.py
@@ -1,0 +1,199 @@
+"""Spec-conformance validator: does the built workbook agree with the manifest?
+
+The third validator of the build gate, and the only one that reads both sides. The other
+two look at the workbook alone - :mod:`validate_twb` asks whether the XML is internally
+consistent, :mod:`validate_twb_xsd` whether it matches the schema - so a workbook that
+dropped a worksheet, or a zone the analyst approved in the mock, passes both of them
+happily: what is missing is missing consistently. The manifest is the machine-readable
+translation of the approved ``IMPLEMENTATION-SPEC.md``, so comparing the two is what proves
+the analyst is being handed the dashboard they signed off on.
+
+Four checks (issue #38):
+
+1. Every element id the manifest's layout places became a zone.
+2. Every zone that names a sheet names one that exists.
+3. Every worksheet the manifest declares exists **and** has a ``<window>``.
+4. Every sheet a dashboard embeds has a ``<viewpoint>`` in the dashboard's window.
+
+Plus the **unsupported-construct policy** (:func:`unsupported_notes`): a construct the
+builder has no template for reserves its box and is *named*, with the two ways forward the
+analyst is owed - a reference ``.twb`` saved from Tableau Desktop, or one hand-written block.
+A silently empty zone is the failure mode this exists to prevent.
+
+Pure and stdlib-only: it takes a parsed ``<workbook>`` element and the manifest document, so
+the contract test drives it directly.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from manifest import placed_layout_ids
+from zones import CONTAINER_PREFIXES, DEFERRED_KINDS
+
+#: A leaf zone carries its element id as its ``friendly-name`` verbatim; a container (and the
+#: wrapper of a titled/legended leaf) prefixes it with the orientation letter. Those are the
+#: only forms an id appears in, so they are the names an id is looked up under.
+_ID_PREFIXES: tuple[str, ...] = ("",) + tuple(
+    f"{prefix}-" for prefix in CONTAINER_PREFIXES.values()
+)
+
+
+def _zone_friendly_names(root: ET.Element) -> set[str]:
+    """Return every ``friendly-name`` in every dashboard's zone tree."""
+    return {
+        name
+        for zone in root.iterfind(".//dashboards/dashboard/zones//zone")
+        for name in [zone.get("friendly-name")]
+        if name
+    }
+
+
+def _referenced_sheet_names(root: ET.Element) -> set[str]:
+    """Return every sheet name the dashboards' zones reference.
+
+    A sheet zone, a filter card and a legend zone all name the sheet they belong to; nothing
+    else in a zone tree carries ``name``.
+    """
+    return {
+        name
+        for zone in root.iterfind(".//dashboards/dashboard/zones//zone")
+        for name in [zone.get("name")]
+        if name
+    }
+
+
+def _sheet_zone_names(root: ET.Element) -> set[str]:
+    """Return the sheet names actually *drawn* by a zone.
+
+    A sheet zone is the one identified by its ``name`` alone (:mod:`zones` gives it no
+    ``type-v2``); a filter card or a legend also names its sheet but does not render it, so
+    counting those as placement would pass a chart whose own zone went missing.
+    """
+    return {
+        name
+        for zone in root.iterfind(".//dashboards/dashboard/zones//zone")
+        for name in [zone.get("name")]
+        if name and zone.get("type-v2") is None
+    }
+
+
+def conformance_errors(root: ET.Element, document: dict) -> list[str]:
+    """Check a built workbook against the manifest it was built from.
+
+    Args:
+        root: The parsed ``<workbook>`` element.
+        document: The validated build manifest.
+
+    Returns:
+        One message per disagreement, each naming the offending sheet or element id; empty
+        when the workbook carries everything the manifest asked for.
+    """
+    errors: list[str] = []
+
+    sheet_names = {
+        name for sheet in root.iterfind("worksheets/worksheet")
+        for name in [sheet.get("name")] if name
+    }
+    window_names = {
+        name for window in root.iterfind("windows/window")
+        for name in [window.get("name")]
+        if name and window.get("class") == "worksheet"
+    }
+
+    # 1. Every zone the analyst approved is in the workbook.
+    friendly_names = _zone_friendly_names(root)
+    for element_id in sorted(placed_layout_ids(document.get("layout"))):
+        if not any(f"{prefix}{element_id}" in friendly_names for prefix in _ID_PREFIXES):
+            errors.append(
+                f"layout element '{element_id}' has no zone in the built dashboard - the "
+                f"analyst approved it in the mock, so the workbook must place it."
+            )
+
+    # 2. No zone points at a sheet that is not there (Tableau renders an error tile).
+    referenced = _referenced_sheet_names(root)
+    drawn = _sheet_zone_names(root)
+    for name in sorted(referenced - sheet_names):
+        errors.append(
+            f"dashboard zone references sheet '{name}', which is not a "
+            f"<worksheet> in the workbook."
+        )
+
+    # 3. Every declared worksheet exists, is placed, and has the window that gives it a tab.
+    # The placement check is what gives (1) teeth for a view element: a friendly-name survives
+    # on the wrapper of a titled or legended leaf even if the sheet zone inside it is gone.
+    for entry in document.get("worksheets") or []:
+        name = str((entry or {}).get("name", "")).strip()
+        if not name:
+            continue
+        if name not in sheet_names:
+            errors.append(
+                f"manifest worksheet '{name}' was not built - no "
+                f"<worksheet name='{name}'> in the workbook."
+            )
+            continue
+        if name not in window_names:
+            errors.append(
+                f"sheet '{name}' has no <window name='{name}'> - Tableau renders no tab "
+                f"for it, so it cannot be reviewed or repaired in Desktop."
+            )
+        element_id = str(entry.get("element_id", "")).strip()
+        if element_id and name not in drawn:
+            errors.append(
+                f"sheet '{name}' fills layout element '{element_id}' but no dashboard zone "
+                f"embeds it - the element's box would render blank."
+            )
+
+    # 4. An embedded sheet with no viewpoint opens at the wrong zoom in the dashboard.
+    for dashboard in root.iterfind("dashboards/dashboard"):
+        dashboard_name = dashboard.get("name", "")
+        window = root.find(f"windows/window[@name='{dashboard_name}']")
+        viewpoints = {
+            name for viewpoint in (
+                [] if window is None else window.iterfind("viewpoints/viewpoint")
+            )
+            for name in [viewpoint.get("name")] if name
+        }
+        for name in sorted(
+            {zone.get("name") for zone in dashboard.iterfind("zones//zone")
+             if zone.get("name")} & sheet_names - viewpoints
+        ):
+            errors.append(
+                f"dashboard '{dashboard_name}' embeds sheet '{name}' but its window has no "
+                f"<viewpoint name='{name}'> - the sheet opens at the wrong fit."
+            )
+
+    return errors
+
+
+def unsupported_notes(document: dict) -> list[str]:
+    """Name every construct the builder has no template for, and the two ways forward.
+
+    The builder refuses the *piece*, not the workbook: the zone keeps its box so the
+    approved geometry holds, and everything else is built. What must never happen is the
+    analyst discovering the gap by finding an empty rectangle - hence one note per gap, with
+    the offer the policy owes them (issue #38).
+
+    Args:
+        document: The build manifest.
+
+    Returns:
+        One plain-ASCII note per unsupported construct; empty when every construct in the
+        manifest has a template.
+    """
+    notes: list[str] = []
+    for entry in document.get("objects") or []:
+        if not isinstance(entry, dict):
+            continue
+        kind = str(entry.get("kind", "")).strip().lower()
+        if kind not in DEFERRED_KINDS:
+            continue
+        element_id = str(entry.get("element_id", "")).strip() or "<unnamed>"
+        notes.append(
+            f"no template for a '{kind}' object ('{element_id}'): its box is reserved as an "
+            f"empty zone so the approved geometry holds, and nothing is drawn in it. To "
+            f"close the gap, build one in Tableau Desktop and save it as a reference .twb "
+            f"for me to read - or say the word and I can hand-write this one block and "
+            f"validate it."
+        )
+    return notes

--- a/skills/tableau-build/scripts/validate_conformance.py
+++ b/skills/tableau-build/scripts/validate_conformance.py
@@ -12,8 +12,10 @@ Four checks (issue #38):
 
 1. Every element id the manifest's layout places became a zone.
 2. Every zone that names a sheet names one that exists.
-3. Every worksheet the manifest declares exists **and** has a ``<window>``.
-4. Every sheet a dashboard embeds has a ``<viewpoint>`` in the dashboard's window.
+3. Every worksheet the manifest declares exists, is drawn by a zone, **and** has a
+   ``<window>``.
+4. A dashboard's window and its embedded sheets agree both ways - no sheet without a
+   ``<viewpoint>``, no viewpoint without a sheet.
 
 Plus the **unsupported-construct policy** (:func:`unsupported_notes`): a construct the
 builder has no template for reserves its box and is *named*, with the two ways forward the
@@ -27,6 +29,7 @@ the contract test drives it directly.
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET
+from typing import Callable, Iterable, Optional
 
 from manifest import placed_layout_ids
 from zones import CONTAINER_PREFIXES, DEFERRED_KINDS
@@ -39,43 +42,31 @@ _ID_PREFIXES: tuple[str, ...] = ("",) + tuple(
 )
 
 
-def _zone_friendly_names(root: ET.Element) -> set[str]:
-    """Return every ``friendly-name`` in every dashboard's zone tree."""
-    return {
-        name
-        for zone in root.iterfind(".//dashboards/dashboard/zones//zone")
-        for name in [zone.get("friendly-name")]
-        if name
-    }
+def _attributes(
+    elements: Iterable[ET.Element],
+    attribute: str,
+    keep: Optional[Callable[[ET.Element], bool]] = None,
+) -> set[str]:
+    """Collect one attribute off a run of elements, dropping the ones that lack it.
 
+    Args:
+        elements: The elements to read.
+        attribute: The attribute name to collect.
+        keep: An optional extra predicate an element must satisfy.
 
-def _referenced_sheet_names(root: ET.Element) -> set[str]:
-    """Return every sheet name the dashboards' zones reference.
-
-    A sheet zone, a filter card and a legend zone all name the sheet they belong to; nothing
-    else in a zone tree carries ``name``.
+    Returns:
+        The non-empty attribute values.
     """
     return {
-        name
-        for zone in root.iterfind(".//dashboards/dashboard/zones//zone")
-        for name in [zone.get("name")]
-        if name
+        value for element in elements
+        for value in [element.get(attribute)]
+        if value and (keep is None or keep(element))
     }
 
 
-def _sheet_zone_names(root: ET.Element) -> set[str]:
-    """Return the sheet names actually *drawn* by a zone.
-
-    A sheet zone is the one identified by its ``name`` alone (:mod:`zones` gives it no
-    ``type-v2``); a filter card or a legend also names its sheet but does not render it, so
-    counting those as placement would pass a chart whose own zone went missing.
-    """
-    return {
-        name
-        for zone in root.iterfind(".//dashboards/dashboard/zones//zone")
-        for name in [zone.get("name")]
-        if name and zone.get("type-v2") is None
-    }
+def _zones(parent: ET.Element) -> Iterable[ET.Element]:
+    """Return every zone in a dashboard's (or the workbook's) zone tree, at any depth."""
+    return parent.iterfind(".//zones//zone")
 
 
 def conformance_errors(root: ET.Element, document: dict) -> list[str]:
@@ -91,18 +82,18 @@ def conformance_errors(root: ET.Element, document: dict) -> list[str]:
     """
     errors: list[str] = []
 
-    sheet_names = {
-        name for sheet in root.iterfind("worksheets/worksheet")
-        for name in [sheet.get("name")] if name
-    }
-    window_names = {
-        name for window in root.iterfind("windows/window")
-        for name in [window.get("name")]
-        if name and window.get("class") == "worksheet"
-    }
+    sheet_names = _attributes(root.iterfind("worksheets/worksheet"), "name")
+    window_names = _attributes(
+        root.iterfind("windows/window"), "name",
+        keep=lambda window: window.get("class") == "worksheet",
+    )
+    dashboard_zones = [
+        zone for dashboard in root.iterfind("dashboards/dashboard")
+        for zone in _zones(dashboard)
+    ]
 
     # 1. Every zone the analyst approved is in the workbook.
-    friendly_names = _zone_friendly_names(root)
+    friendly_names = _attributes(dashboard_zones, "friendly-name")
     for element_id in sorted(placed_layout_ids(document.get("layout"))):
         if not any(f"{prefix}{element_id}" in friendly_names for prefix in _ID_PREFIXES):
             errors.append(
@@ -110,9 +101,14 @@ def conformance_errors(root: ET.Element, document: dict) -> list[str]:
                 f"analyst approved it in the mock, so the workbook must place it."
             )
 
-    # 2. No zone points at a sheet that is not there (Tableau renders an error tile).
-    referenced = _referenced_sheet_names(root)
-    drawn = _sheet_zone_names(root)
+    # 2. No zone points at a sheet that is not there (Tableau renders an error tile). A sheet
+    # zone, a filter card and a legend zone all name their sheet; nothing else carries 'name'.
+    referenced = _attributes(dashboard_zones, "name")
+    # Only a sheet zone *draws* the sheet - :mod:`zones` gives it no 'type-v2'. Counting a
+    # filter card or a legend as placement would pass a chart whose own zone went missing.
+    drawn = _attributes(
+        dashboard_zones, "name", keep=lambda zone: zone.get("type-v2") is None
+    )
     for name in sorted(referenced - sheet_names):
         errors.append(
             f"dashboard zone references sheet '{name}', which is not a "
@@ -144,23 +140,29 @@ def conformance_errors(root: ET.Element, document: dict) -> list[str]:
                 f"embeds it - the element's box would render blank."
             )
 
-    # 4. An embedded sheet with no viewpoint opens at the wrong zoom in the dashboard.
+    # 4. The dashboard window's viewpoints and its sheets must match, both ways: a sheet with
+    # no viewpoint opens at the wrong fit, and a viewpoint naming no sheet is a stale entry a
+    # hand-written block leaves behind.
     for dashboard in root.iterfind("dashboards/dashboard"):
         dashboard_name = dashboard.get("name", "")
         window = root.find(f"windows/window[@name='{dashboard_name}']")
-        viewpoints = {
-            name for viewpoint in (
-                [] if window is None else window.iterfind("viewpoints/viewpoint")
+        if window is None:
+            errors.append(
+                f"dashboard '{dashboard_name}' has no <window name='{dashboard_name}'> - "
+                f"Tableau opens the workbook with no dashboard tab."
             )
-            for name in [viewpoint.get("name")] if name
-        }
-        for name in sorted(
-            {zone.get("name") for zone in dashboard.iterfind("zones//zone")
-             if zone.get("name")} & sheet_names - viewpoints
-        ):
+            continue
+        viewpoints = _attributes(window.iterfind("viewpoints/viewpoint"), "name")
+        embedded = _attributes(_zones(dashboard), "name") & sheet_names
+        for name in sorted(embedded - viewpoints):
             errors.append(
                 f"dashboard '{dashboard_name}' embeds sheet '{name}' but its window has no "
                 f"<viewpoint name='{name}'> - the sheet opens at the wrong fit."
+            )
+        for name in sorted(viewpoints - sheet_names):
+            errors.append(
+                f"dashboard '{dashboard_name}' has a <viewpoint name='{name}'> for a sheet "
+                f"that does not exist - a stale viewpoint Tableau rewrites on save."
             )
 
     return errors

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1275,6 +1275,103 @@ def test_only_the_referenced_csvs_are_packaged(tmp_path):
         assert "unrelated.csv" not in archive.namelist()
 
 
+# --- The validation gate (issue #38) ------------------------------------------
+
+def test_the_gate_runs_all_three_validators(tmp_path):
+    """One gate, one verdict, and the conformance validator is part of it."""
+    _built_project(tmp_path)
+    version_dir = tmp_path / build.VERSION_DIR / "v_1"
+    document = json.loads(
+        (version_dir / build.MANIFEST_FILENAME).read_text(encoding="utf-8")
+    )
+
+    report = build.run_gate(
+        version_dir / build.TWB_FILENAME, document, TARGET_VERSION
+    )
+
+    assert set(report.results) == set(build.GATE_VALIDATORS)
+    assert report.ok is True, report.errors
+
+
+def test_a_nonconforming_workbook_is_never_packaged(tmp_path, monkeypatch):
+    """AC #2: the gate catches it before the .twbx exists, and names the validator."""
+    import validate_conformance
+
+    monkeypatch.setattr(
+        validate_conformance, "conformance_errors",
+        lambda root, document: ["layout element 'kpi-revenue' has no zone"],
+    )
+
+    result = _built_project(tmp_path)
+
+    assert result.ok is False
+    assert any("conformance" in error for error in result.errors)
+    assert (tmp_path / build.VERSION_DIR / "v_1" / build.TWB_FILENAME).exists()
+    assert not (tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME).exists()
+
+
+def test_gate_revalidates_and_repackages_the_workbook_on_disk(tmp_path):
+    """The revalidate half of the fix loop, after a hand-written block is added."""
+    _built_project(tmp_path)
+    package = tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME
+    package.unlink()
+
+    result = build.gate(tmp_path)
+
+    assert result.ok is True, result.errors
+    assert package.exists()
+
+
+def test_gate_refuses_a_hand_edited_workbook_that_breaks_conformance(tmp_path):
+    """Hand-writing XML is offered, but only the gate decides whether it ships.
+
+    Renaming a sheet everywhere it appears leaves the XML *internally* consistent, so the
+    other two validators pass it - only the manifest knows the sheet is meant to be there.
+    """
+    _built_project(tmp_path)
+    twb_path = tmp_path / build.VERSION_DIR / "v_1" / build.TWB_FILENAME
+    twb_path.write_text(
+        twb_path.read_text(encoding="utf-8").replace(
+            '"Revenue Trend"', '"Ghost Sheet"'
+        ),
+        encoding="utf-8",
+    )
+
+    result = build.gate(tmp_path)
+
+    assert result.ok is False
+    assert any("conformance" in error for error in result.errors), result.errors
+    assert not (tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME).exists()
+
+
+def test_gate_refuses_when_no_workbook_has_been_built(tmp_path):
+    _ready_project(tmp_path)
+    _write_manifest(tmp_path, _manifest())
+
+    result = build.gate(tmp_path)
+
+    assert result.ok is False
+    assert any(build.TWB_FILENAME in error for error in result.errors)
+
+
+def test_an_unsupported_construct_is_named_and_the_rest_still_builds(tmp_path):
+    """AC #3: the build refuses the piece, not the workbook, and offers the way forward."""
+    _ready_project(tmp_path)
+    document = _manifest()
+    document["layout"]["root"]["children"].append({"id": "logo", "size": 10})
+    document["objects"] = [{"element_id": "logo", "kind": "image"}]
+    _write_spec(tmp_path, text=_spec_md(document["layout"]))
+    _write_manifest(tmp_path, document)
+
+    result = build.build_workbook(tmp_path)
+
+    assert result.ok is True, result.errors
+    gap = next(warning for warning in result.warnings if "logo" in warning)
+    assert "image" in gap and ".twb" in gap and "hand-write" in gap
+    # The rest of the deliverable is untouched by the refused piece.
+    assert (tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME).exists()
+
+
 # --- STATE.md transition (CONTRACT.md §4.3) ----------------------------------
 
 def test_commit_refuses_without_a_workbook(tmp_path):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1344,6 +1344,47 @@ def test_gate_refuses_a_hand_edited_workbook_that_breaks_conformance(tmp_path):
     assert not (tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME).exists()
 
 
+def test_gate_refuses_a_csv_that_is_no_longer_on_disk(tmp_path):
+    """The gate packages too, so it owes the same guard: a .twbx short a CSV opens bound to
+    nothing, and commit would approve it on the package's existence."""
+    _built_project(tmp_path)
+    (tmp_path / "data" / "sales_orders.csv").rename(tmp_path / "data" / "orders.csv")
+
+    result = build.gate(tmp_path)
+
+    assert result.ok is False
+    assert any("sales_orders.csv" in error for error in result.errors)
+    assert not (tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME).exists()
+    assert build.commit(tmp_path).ok is False
+
+
+def test_a_failure_before_the_gate_is_not_reported_as_a_failed_gate(tmp_path):
+    """Sending the analyst to the XML for a manifest problem costs them the real fix."""
+    _ready_project(tmp_path)
+    document = _manifest()
+    document["worksheets"][1]["chart_type"] = "donut"
+    _write_manifest(tmp_path, document)
+
+    result = build.build_workbook(tmp_path)
+
+    assert result.gated is False
+    assert "validation gate failed" not in build.format_build(result)
+
+
+def test_a_gate_failure_says_so(tmp_path):
+    _built_project(tmp_path)
+    twb_path = tmp_path / build.VERSION_DIR / "v_1" / build.TWB_FILENAME
+    twb_path.write_text(
+        twb_path.read_text(encoding="utf-8").replace('"Revenue KPI"', '"Ghost"'),
+        encoding="utf-8",
+    )
+
+    result = build.gate(tmp_path)
+
+    assert result.gated is True
+    assert "validation gate failed" in build.format_build(result)
+
+
 def test_gate_refuses_when_no_workbook_has_been_built(tmp_path):
     _ready_project(tmp_path)
     _write_manifest(tmp_path, _manifest())

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -180,6 +180,29 @@ def test_embedded_sheet_with_no_viewpoint_is_caught():
     ), errors
 
 
+def test_stale_viewpoint_naming_no_sheet_is_caught():
+    """The other direction: a hand-written block can leave a viewpoint behind."""
+    root = _built()
+    ET.SubElement(
+        root.find("windows/window[@class='dashboard']/viewpoints"),
+        "viewpoint", {"name": "Deleted Sheet"},
+    )
+
+    errors = _errors(root=root)
+    assert any(
+        "Deleted Sheet" in error and "viewpoint" in error for error in errors
+    ), errors
+
+
+def test_dashboard_with_no_window_is_caught():
+    root = _built()
+    windows = root.find("windows")
+    windows.remove(windows.find("window[@class='dashboard']"))
+
+    errors = _errors(root=root)
+    assert any("no dashboard tab" in error for error in errors), errors
+
+
 # --- The unsupported-construct policy ----------------------------------------
 
 @pytest.mark.parametrize("kind", ["image", "button", "legend"])

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,0 +1,215 @@
+"""Contract test for the build's third validator (issue #38).
+
+:mod:`validate_conformance` is the only check that compares the *manifest* to the built
+XML. The other two validators read the workbook alone: the semantic one asks whether the
+XML is internally consistent, the XSD one whether it matches the schema - so a workbook
+that silently dropped a whole worksheet, or a zone the analyst approved, passes both. That
+is the gap these checks close, plus the unsupported-construct policy: a construct the
+builder has no template for must be *named*, not silently reduced to an empty box.
+
+Every check is driven off a real built workbook (``twb.render_workbook``) rather than a
+hand-written fixture, so the checks stay coupled to what the assembler actually emits.
+"""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+import twb  # the pure assembler that produces the XML under test
+import validate_conformance as conformance
+
+TARGET_VERSION = "2024.2-2025.x"
+
+DATA_MODEL = """# Data Model
+
+## Data source: `sales_orders.csv`
+
+| Field | Type | Role | Sample values | Description |
+|-------|------|------|---------------|-------------|
+| order_date | date | dimension | 2024-01-05 | Order date |
+| region | string | dimension | West | Sales region |
+| revenue | real | measure | 1200.5 | Order revenue |
+"""
+
+CSV_HEADERS = {"sales_orders.csv": ["order_date", "region", "revenue"]}
+
+
+def _manifest() -> dict:
+    """A valid two-worksheet manifest for the data model above."""
+    return {
+        "target_tableau_version": TARGET_VERSION,
+        "datasources": [{
+            "name": "sales_orders",
+            "csv": "sales_orders.csv",
+            "fields": [
+                {"name": "order_date", "type": "date"},
+                {"name": "region", "type": "string"},
+                {"name": "revenue", "type": "real"},
+            ],
+        }],
+        "worksheets": [
+            {
+                "name": "Revenue KPI", "element_id": "kpi-revenue", "chart_type": "text",
+                "datasource": "sales_orders",
+                "shelves": {"rows": [], "columns": []},
+                "encodings": {"text": "revenue"},
+            },
+            {
+                "name": "Revenue Trend", "element_id": "chart-trend", "chart_type": "line",
+                "datasource": "sales_orders",
+                "shelves": {"columns": ["order_date"], "rows": ["revenue"]},
+                "encodings": {"color": "region"},
+            },
+        ],
+        "layout": {
+            "canvas": {"width": 1366, "height": 768},
+            "root": {"type": "vert", "children": [
+                {"id": "kpi-revenue", "size": 20},
+                {"id": "chart-trend", "size": 80},
+            ]},
+        },
+        "actions": [],
+        "parameters": [],
+    }
+
+
+def _built(document=None) -> ET.Element:
+    """Render a manifest into a parsed ``<workbook>`` element."""
+    return ET.fromstring(
+        twb.render_workbook(document or _manifest(), DATA_MODEL, CSV_HEADERS, "")
+    )
+
+
+def _errors(document=None, root=None) -> list[str]:
+    """Run the conformance checks over a built workbook."""
+    document = document or _manifest()
+    return conformance.conformance_errors(root if root is not None else _built(document),
+                                          document)
+
+
+# --- The happy path -----------------------------------------------------------
+
+def test_a_built_workbook_conforms_to_its_manifest():
+    assert _errors() == []
+
+
+def test_objects_and_titles_still_conform():
+    """Titled elements and object zones nest extra zones - the ids must still resolve."""
+    document = _manifest()
+    document["worksheets"][0]["title"] = "Revenue"
+    document["layout"]["root"]["children"].append({"id": "note", "size": 10})
+    document["objects"] = [{"element_id": "note", "kind": "text", "text": "Hello"}]
+    assert _errors(document) == []
+
+
+# --- Check 1: every element the manifest places became a zone -----------------
+
+def test_element_with_no_zone_is_caught():
+    """The manifest's own layout is the authority: a zone the assembler dropped is a bug."""
+    root = _built()
+    # 'kpi-revenue' is an unwrapped leaf, so its friendly-name is the only carrier of the id.
+    dropped = next(
+        zone for zone in root.iter("zone") if zone.get("friendly-name") == "kpi-revenue"
+    )
+    dropped.set("friendly-name", "something-else")
+
+    errors = _errors(root=root)
+    assert any("kpi-revenue" in error for error in errors), errors
+
+
+def test_unembedded_view_element_is_caught():
+    """A wrapped leaf keeps its friendly-name even if the sheet zone inside it is gone."""
+    root = _built()
+    wrapper = next(
+        zone for zone in root.iter("zone")
+        if zone.get("friendly-name") == "V-chart-trend"
+    )
+    wrapper.remove(wrapper.find("zone[@name='Revenue Trend']"))
+
+    errors = _errors(root=root)
+    assert any(
+        "Revenue Trend" in error and "chart-trend" in error for error in errors
+    ), errors
+
+
+# --- Check 2: every zone references a real sheet ------------------------------
+
+def test_zone_naming_a_nonexistent_sheet_is_caught():
+    root = _built()
+    zone = next(
+        zone for zone in root.iter("zone") if zone.get("name") == "Revenue Trend"
+    )
+    zone.set("name", "Ghost Sheet")
+
+    errors = _errors(root=root)
+    assert any("Ghost Sheet" in error for error in errors), errors
+
+
+# --- Check 3: every manifest worksheet is a sheet with a window ---------------
+
+def test_manifest_worksheet_missing_from_the_workbook_is_caught():
+    root = _built()
+    worksheets = root.find("worksheets")
+    worksheets.remove(worksheets.find("worksheet[@name='Revenue KPI']"))
+
+    errors = _errors(root=root)
+    assert any("Revenue KPI" in error for error in errors), errors
+
+
+def test_sheet_with_no_window_is_caught():
+    root = _built()
+    windows = root.find("windows")
+    windows.remove(windows.find("window[@name='Revenue KPI']"))
+
+    errors = _errors(root=root)
+    assert any(
+        "Revenue KPI" in error and "window" in error for error in errors
+    ), errors
+
+
+# --- Check 4: the dashboard window's viewpoints match its sheets --------------
+
+def test_embedded_sheet_with_no_viewpoint_is_caught():
+    root = _built()
+    viewpoints = root.find("windows/window[@class='dashboard']/viewpoints")
+    viewpoints.remove(viewpoints.find("viewpoint[@name='Revenue Trend']"))
+
+    errors = _errors(root=root)
+    assert any(
+        "Revenue Trend" in error and "viewpoint" in error for error in errors
+    ), errors
+
+
+# --- The unsupported-construct policy ----------------------------------------
+
+@pytest.mark.parametrize("kind", ["image", "button", "legend"])
+def test_a_deferred_object_kind_names_the_gap(kind):
+    """A construct with no template is refused *by name*, not silently emptied."""
+    document = _manifest()
+    document["layout"]["root"]["children"].append({"id": "logo", "size": 10})
+    document["objects"] = [{"element_id": "logo", "kind": kind}]
+
+    notes = conformance.unsupported_notes(document)
+    assert len(notes) == 1
+    note = notes[0]
+    assert kind in note and "logo" in note
+    # Both move-on options the policy owes the analyst (issue #38).
+    assert ".twb" in note and "hand-write" in note
+
+
+def test_a_supported_object_kind_is_not_reported():
+    document = _manifest()
+    document["layout"]["root"]["children"].append({"id": "note", "size": 10})
+    document["objects"] = [{"element_id": "note", "kind": "text", "text": "Hi"}]
+    assert conformance.unsupported_notes(document) == []
+
+
+def test_the_rest_of_the_workbook_still_builds_around_a_gap():
+    """Refusing one construct must not cost the analyst the other zones."""
+    document = _manifest()
+    document["layout"]["root"]["children"].append({"id": "logo", "size": 10})
+    document["objects"] = [{"element_id": "logo", "kind": "image"}]
+
+    root = _built(document)
+    assert root.find("worksheets/worksheet[@name='Revenue Trend']") is not None
+    assert conformance.conformance_errors(root, document) == []


### PR DESCRIPTION
Closes #38. Marks step 8 **experimental** and asks for bug reports.

## The third validator

`skills/tableau-build/scripts/validate_conformance.py` is the only check that reads **both** the manifest and the built XML. The other two read the workbook alone — the semantic validator asks whether the XML is internally consistent, the XSD validator whether it matches the schema — so anything the assembler dropped is missing *consistently* and both pass it happily.

Proven, not asserted: renaming a sheet everywhere it appears in the `.twb` leaves the XML perfectly self-consistent and sails past semantic + XSD. Only conformance catches it.

Four checks:

1. Every element id the manifest's layout places became a zone.
2. Every zone that names a sheet names one that exists.
3. Every worksheet the manifest declares is built, drawn by a zone, and has a `<window>`.
4. A dashboard's viewpoints and its embedded sheets agree **both ways** — no sheet without a viewpoint, no viewpoint without a sheet.

## The gate

`run_gate()` runs all three as one verdict, each error prefixed with the validator that raised it (`[semantic]` / `[schema]` / `[conformance]`). `build` gates through it and never packages a workbook that failed. A new `gate` subcommand re-runs the gate over the `.twb` already on disk — the revalidate half of the fix loop — repackaging on pass and deleting the stale `.twbx` on fail, so `commit` can never approve a failed workbook.

## Unsupported-construct policy

`image` / `button` / `legend` still reserve their box so the approved geometry holds, but the gap is now **named** as a `[WARN]` carrying both ways forward: a reference `.twb` built in Desktop (the permanent fix — a snippet plus a builder template) or one hand-written block proved by `build.py gate` (the move-on fix). `SKILL.md` tells the agent to relay it and ask which, and never to let the analyst discover a gap as a blank rectangle.

An unknown `chart_type` stays a fail-fast manifest refusal — a worksheet with no template cannot be reduced to an empty box — but `SKILL.md` now owes the analyst the same two options and forbids silently substituting a different chart type.

## Three bugs the review caught, all fixed

- **`gate` packaged a data-less deliverable.** It skipped the missing-CSV guard `build` performs, and its CSV selection silently dropped names not on disk — so a CSV renamed after a successful build produced a `.twbx` holding only `dashboard.twb`, reported `[BUILT]`, and `commit` approved it on the package's existence. Both paths now resolve through one `bind_csvs()`.
- **Every failure claimed "the validation gate failed"** — including invalid-manifest, missing-CSV and missing-`.twb` failures that never reach the gate. `BuildResult.gated` fixes the attribution, so nobody debugs the XML for a manifest problem.
- **Check 4 tested one direction only.** A viewpoint naming no sheet — exactly what a hand-written block leaves behind — passed all three validators.

## Step 8 is now experimental

The old README marker (*views in development*) and its status note were stale: they claimed the worksheet bodies and zone tree were outstanding and the views empty, untrue since #35/#36/#37/#44. The note now states what the build actually produces and why the label is still *experimental* — the validators are not Tableau, and a workbook can pass all three and still be rewritten or refused on open. It asks for the Desktop error text plus the `build-manifest.json` that produced it, and explains that each report becomes a permanent template fix.

## Tests

**566 passing** (was 561 on `main`).

- `tests/test_conformance.py` — 16 tests, each driven off a really built workbook rather than a hand-written fixture, so they stay coupled to what the assembler emits.
- `tests/test_build.py` — 11 gate-wiring tests: all three validators run, a nonconforming workbook is never packaged, `gate` revalidates and repackages, a consistently renamed sheet is caught *only* by conformance, `gate` refuses a CSV renamed since the build and leaves nothing for `commit`, a pre-gate failure is not reported as a gate failure, and a construct gap warns without costing the rest of the build.

Also verified by running the real CLI (`validate` / `build` / `gate` / `commit`) against a scaffolded project on a Windows console — plain-ASCII output, correct exit codes, and `commit` refused after a failed gate.

## Not in scope

README still carries no change for the remaining #39 work (`SKILL.md` repair section, the end-to-end demo run, contract-test coverage of the build transitions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)