### PR TITLE
feat(build): SKILL.md repair flow, end-to-end demo run, and the first two Desktop-reported fixes

### DIFF
--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -2,7 +2,7 @@
 name: tableau-build
 description: Builds the Tableau workbook for the tableau-dashboard-plugin workflow from the approved IMPLEMENTATION-SPEC.md and DATA-MODEL.md, producing a Replace-Data-Source-ready dashboard.twbx beside the mock it was specced from. Derives a machine-readable build manifest (datasources, worksheets with chart type and shelves/encodings, the spec's layout container tree, actions, parameters, and the project's target Tableau version) and schema-validates it fail-fast, so an unknown chart type, an element id missing from the layout, or a field that is not in the data model is caught with the offending entry named before any XML is generated. Reads the approved IMPLEMENTATION-SPEC.md at the current version, DATA-MODEL.md, and the CSVs under data/. Use when the user wants to build the workbook, generate the twbx, or when tableau-route reports build is next. Step 8 of 8 in the workflow.
 disable-model-invocation: true
-allowed-tools: Read, Write, Edit, AskUserQuestion, Bash(python *), Bash(python3 *)
+allowed-tools: Read, Write, Edit, Grep, AskUserQuestion, Bash(python *), Bash(python3 *)
 ---
 
 # tableau-build
@@ -150,7 +150,47 @@ invented zone is caught rather than silently built.
    Commit re-validates the manifest, refuses unless `dashboard.twbx` is on disk (run step 5
    first), and records `build` = `approved`. If it prints `[REFUSED]`, fix what it names and
    re-run. On success, tell the analyst the pipeline is complete and where the deliverable
-   lives.
+   lives — and ask them to open it (see below).
+
+## When Desktop rejects it — the report-back repair
+
+**The validators are not Tableau.** A workbook can pass all three and still be refused, or
+silently rewritten, on open. So the last thing you say after `commit` is that Desktop is the
+authority: *open the `.twbx`, and if Tableau reports an error or a view renders differently
+from the mock it was specced from, paste the error text back here.* That report is not a
+support ticket — it is the input to a permanent template fix, so the next workbook the builder
+generates is right too.
+
+When one arrives:
+
+1. **Locate the construct.** Desktop names a sheet, a field or an element; find its entry in
+   `build-manifest.json` at the precheck's manifest path. That entry is what was asked for —
+   the bug is either the XML that came out of it, or a validation that should have refused it.
+2. **Diagnose which template wrote the bad XML.** Each part of the workbook has one author:
+
+   | what Desktop complains about | the template |
+   |---|---|
+   | a view's marks, shelves, encodings, sort / filter / tooltip / reference line, formatting | `worksheet.py` |
+   | a zone's position or size, a generated header / legend wrapper, an object kind | `zones.py` |
+   | an action, a parameter, dynamic zone visibility | `features.py` |
+   | the workbook shell, a datasource, a column, the version attribute | `twb.py` |
+   | the manifest was accepted when it should have been refused | `manifest.py` (a missing check) |
+
+3. **Fix it in the repo, never in the generated XML.** Add the smallest manifest that
+   reproduces the bad XML as a test in `tests/` (`test_build.py`, `test_charts.py`,
+   `test_features.py`, `test_zones.py`), watch it fail, then fix the template until it passes
+   and the suite is green. A patch to the `.twb` fixes one workbook; a patch to the template
+   fixes every workbook built afterwards. When the correct XML is not obvious, get it from
+   Desktop: build that one construct by hand there, save, and diff its `.twb` against the
+   generated one — Desktop's own output is the only authority on fidelity.
+4. **Rebuild and re-attest.** Re-run step 5, then have the analyst open the new `.twbx` and
+   confirm the error is gone. The second Desktop open is what closes the loop; the gate going
+   green is not.
+5. **When this repo is not to hand** — an analyst in their own project, without the plugin
+   source — hand-patch that one `.twb`, prove it with `build.py gate`, and ask them to file the
+   error text plus the `build-manifest.json` that produced it at
+   <https://github.com/laviDrori0702/tableau-dashboard-creator-skill/issues/new>, so the fix
+   still lands in the templates.
 
 ## Notes
 

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -166,7 +166,8 @@ When one arrives:
 1. **Locate the construct.** Desktop names a sheet, a field or an element; find its entry in
    `build-manifest.json` at the precheck's manifest path. That entry is what was asked for —
    the bug is either the XML that came out of it, or a validation that should have refused it.
-2. **Diagnose which template wrote the bad XML.** Each part of the workbook has one author:
+2. **Diagnose which template wrote the bad XML.** Each part of the workbook has one author —
+   the file that *emits* it, which is where the fix goes:
 
    | what Desktop complains about | the template |
    |---|---|
@@ -176,6 +177,11 @@ When one arrives:
    | the workbook shell, a datasource, a column, the version attribute | `twb.py` |
    | the manifest was accepted when it should have been refused | `manifest.py` (a missing check) |
 
+   For an action, a filter card or dynamic zone visibility, check `twb.py` too: it *plans*
+   them (`_plan_actions`, `_plan_quick_filter`, `_plan_interactions`) and `features.py` only
+   renders what it was handed, so a wrong target or a missing declaration is often decided
+   there.
+
 3. **Fix it in the repo, never in the generated XML.** Add the smallest manifest that
    reproduces the bad XML as a test in `tests/` (`test_build.py`, `test_charts.py`,
    `test_features.py`, `test_zones.py`), watch it fail, then fix the template until it passes
@@ -183,7 +189,9 @@ When one arrives:
    fixes every workbook built afterwards. When the correct XML is not obvious, get it from
    Desktop: build that one construct by hand there, save, and diff its `.twb` against the
    generated one — Desktop's own output is the only authority on fidelity.
-4. **Rebuild and re-attest.** Re-run step 5, then have the analyst open the new `.twbx` and
+4. **Rebuild and re-attest.** Re-run steps 5 **and** 6 — a rebuild alone leaves `build` sitting
+   at the `approved` it earned from the pre-fix workbook, and only `commit` re-checks that a
+   packaged deliverable is actually on disk. Then have the analyst open the new `.twbx` and
    confirm the error is gone. The second Desktop open is what closes the loop; the gate going
    green is not.
 5. **When this repo is not to hand** — an analyst in their own project, without the plugin

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -974,7 +974,14 @@ def _plan_sort(entry: object, resolver: FieldResolver) -> Optional[SortPlan]:
 
 
 def _plan_tooltip(entries: object, resolver: FieldResolver) -> list[tuple[str, FieldRef]]:
-    """Resolve the ``tooltip`` list into ``(label, field)`` pairs."""
+    """Resolve the ``tooltip`` list into ``(label, field)`` pairs.
+
+    A bare dimension is wrapped in ``ATTR()`` on the way in: the Tooltip shelf does not add
+    to the view's level of detail, so Tableau needs one value per mark and refuses the
+    un-aggregated pill ("The field Region can't be displayed in Tooltips because it can't be
+    converted to a measure using ATTR()"). Desktop makes the same substitution when a
+    dimension is dropped there, so the manifest never has to spell it out.
+    """
     if not isinstance(entries, list):
         return []
     pairs: list[tuple[str, FieldRef]] = []
@@ -982,9 +989,32 @@ def _plan_tooltip(entries: object, resolver: FieldResolver) -> list[tuple[str, F
         if not isinstance(entry, dict):
             continue
         reference = resolver.reference(entry)
+        if reference is not None and _needs_attr_on_tooltip(entry, reference):
+            reference = resolver.reference({**entry, "aggregation": "attr"})
         if reference is not None:
             pairs.append((str(entry.get("label", reference.caption)).strip(), reference))
     return pairs
+
+
+def _needs_attr_on_tooltip(entry: dict, reference: FieldRef) -> bool:
+    """Whether a resolved tooltip entry has to be re-resolved as ``ATTR()``.
+
+    Args:
+        entry: The manifest tooltip entry.
+        reference: What :meth:`FieldResolver.reference` made of it.
+
+    Returns:
+        True for an un-aggregated dimension the manifest asked for plainly. An explicit
+        ``aggregation`` (including ``none``) is the author's choice and is left alone; a
+        measure already defaults to ``SUM``, a date part and a bin carry their own
+        derivations, and an aggregating calculation resolves to the ``User`` derivation.
+    """
+    return (
+        reference.role == "dimension"
+        and reference.derivation == "None"
+        and reference.bin_size is None
+        and not _lower(entry.get("aggregation"))
+    )
 
 
 def _plan_number_formats(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1486,8 +1486,10 @@ def test_commit_touches_no_other_step(tmp_path):
 
     after = route.parse_state(tmp_path / "STATE.md").statuses
     assert after["build"] == "approved"
-    assert {step: status for step, status in after.items() if step != "build"} == \
-           {step: status for step, status in before.items() if step != "build"}
+    assert (
+        {step: status for step, status in after.items() if step != "build"}
+        == {step: status for step, status in before.items() if step != "build"}
+    )
 
 
 def test_recommit_overwrites_in_place(tmp_path):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1452,6 +1452,18 @@ def test_commit_refuses_an_invalid_manifest(tmp_path):
     assert route.parse_state(tmp_path / "STATE.md").statuses["build"] == "pending"
 
 
+def test_commit_refuses_when_the_entry_gate_is_closed(tmp_path):
+    """Commit is gated like every other entrypoint: an unresolved producer refuses it."""
+    _built_project(tmp_path)
+    _state_with(tmp_path, spec="pending", data="approved")
+
+    result = build.commit(tmp_path)
+
+    assert result.ok is False
+    assert "spec" in result.message
+    assert route.parse_state(tmp_path / "STATE.md").statuses["build"] == "pending"
+
+
 def test_commit_approves_and_leaves_current_version_alone(tmp_path):
     """A valid manifest approves build in place - current_version is never bumped (§4.3)."""
     _built_project(tmp_path)
@@ -1462,6 +1474,20 @@ def test_commit_approves_and_leaves_current_version_alone(tmp_path):
     state = route.parse_state(tmp_path / "STATE.md")
     assert state.statuses["build"] == "approved"
     assert state.current_version == "v_1"
+
+
+def test_commit_touches_no_other_step(tmp_path):
+    """Build is last, so nothing goes stale: every other status survives the commit (§4.2)."""
+    _built_project(tmp_path, intake="approved", brand="skipped", plan="approved",
+                   mock="approved")
+    before = route.parse_state(tmp_path / "STATE.md").statuses
+
+    assert build.commit(tmp_path).ok is True
+
+    after = route.parse_state(tmp_path / "STATE.md").statuses
+    assert after["build"] == "approved"
+    assert {step: status for step, status in after.items() if step != "build"} == \
+           {step: status for step, status in before.items() if step != "build"}
 
 
 def test_recommit_overwrites_in_place(tmp_path):

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -718,6 +718,49 @@ def test_a_custom_tooltip_registers_every_field_it_names():
     assert "<![CDATA[<[federated" in _worksheet_xml("Custom Tooltip")
 
 
+def test_a_bare_dimension_on_tooltip_is_wrapped_in_attr():
+    """Desktop-reported (#39): a dimension on Tooltip must reach the pane as ATTR().
+
+    The Tooltip shelf does not add to the view's level of detail, so a field on it has to
+    resolve to one value per mark. Tableau wraps a dimension in ``ATTR()`` and refuses the
+    un-aggregated pill outright: *"The field Region can't be displayed in Tooltips because
+    it can't be converted to a measure using ATTR()."* The manifest must not have to know
+    that - ``{"label": "Region", "field": "region"}`` is a legal entry.
+    """
+    document = _manifest([_sheet(
+        "Bare Tooltip", "bar",
+        shelves={"columns": ["region"], "rows": ["revenue"]},
+        tooltip=[{"label": "Region", "field": "region"}],
+    )])
+    pane = _worksheet_element(
+        "Bare Tooltip", ET.fromstring(_render(document))
+    ).find("table/panes/pane")
+
+    registered = {
+        tooltip.get("column").rsplit(".", 1)[-1]
+        for tooltip in pane.findall("encodings/tooltip")
+    }
+    assert registered == {"[attr:region:nk]"}
+    assert "[attr:region:nk]" in pane.find("customized-tooltip/formatted-text/run[2]").text
+
+
+def test_an_explicit_tooltip_aggregation_is_left_alone():
+    """The ATTR wrap is a default, not an override: an asked-for aggregation still wins."""
+    document = _manifest([_sheet(
+        "Counted Tooltip", "bar",
+        shelves={"columns": ["region"], "rows": ["revenue"]},
+        tooltip=[{"label": "Orders", "field": "region", "aggregation": "countd"}],
+    )])
+    pane = _worksheet_element(
+        "Counted Tooltip", ET.fromstring(_render(document))
+    ).find("table/panes/pane")
+
+    assert {
+        tooltip.get("column").rsplit(".", 1)[-1]
+        for tooltip in pane.findall("encodings/tooltip")
+    } == {"[ctd:region:qk]"}
+
+
 def test_a_tooltip_field_reaches_the_dependencies():
     """A tooltip-only field still has to be declared, or the tooltip renders empty."""
     declared = {


### PR DESCRIPTION
Closes #39 — the last slice of `feat/tableau-build`. The build step was already
feature-complete on `main` (#37, #38, #44); this closes it out: the skill's prose, the
repair flow that turns a Desktop error into a permanent template fix, an end-to-end run on
the demo inputs, and the Desktop attestation that run earned.

## Acceptance criteria

| Checkbox | What satisfies it |
|---|---|
| `SKILL.md` frontmatter + repair section | bf73288, 3b44424 — trigger-rich frontmatter ending "Step 8 of 8", `disable-model-invocation: true`, `allowed-tools` (`Grep` added for the diagnose step), and a new **"When Desktop rejects it — the report-back repair"** section: locate the construct in `build-manifest.json` → diagnose the owning template from a what-Desktop-complains-about → file table → fix in the repo behind a failing test, never in the generated XML → rebuild and re-attest → a no-repo fallback that still files the error text so the fix lands in the templates. Every table row and test file it names was verified against the actual modules. |
| End-to-end `.twbx` on the demo, three validators, opens in Desktop | All 8 skills driven in a scratch project seeded from `demo/input/`: 3 datasources, 9 worksheets, 56 zones at the mock's geometry, 3 actions, 2 filter cards, brand font + palette. `validate` → `[OK]`, `build` → `[BUILT]` (semantic + XSD + conformance green; the only `[WARN]` is the expected `explain-data` version shift), `commit` → `approved`, router → `[DONE]`. **Opens in Tableau Desktop 2025.1.10, verified 2026-08-03** — attested with the full detail on #39. |
| Contract tests cover build gating/transitions, suite green | 7a64a39 brings `tests/test_build.py` to parity with `test_spec.py`: `commit` refuses when the entry gate is closed, and approving `build` touches no other step's status (CONTRACT.md §4.2). **570 passed.** |
| README / marketplace / CONTRACT.md / router agree | Audited, no change needed. CONTRACT.md §1 row 8, `route.py`'s `STEPS` step 8 and the skill all state the same required reads (`IMPLEMENTATION-SPEC.md` at `current_version`; `DATA-MODEL.md` + `data/*.csv` with the scaffold fallback), optional `DESIGN-TOKENS.md`, non-skippable, never bumps `current_version` (§4.3). README's step-8 *experimental* + bug-report wording (cc13520) is deliberate and matches the shipped repair flow; `.claude-plugin/*.json` carry no dev flag.

## The repair flow proved itself during the attestation

Desktop rejected the first workbook: *"The field Region can't be displayed in Tooltips because
it can't be converted to a measure using ATTR()."* Tableau's Tooltip shelf does not add to the
view's level of detail, so a field on it must resolve to one value per mark — the builder was
emitting the un-aggregated pill.

75c97c0 fixes it in `worksheet.py` (`_plan_tooltip` re-resolves a bare dimension as `ATTR()`),
red-then-green behind two new tests in `test_charts.py`. It had been invisible because the
existing `custom-tooltip` golden spelled out `"aggregation": "attr"` by hand, so nothing
exercised a tooltip written the natural way. The wrap is a default, not an override: an explicit
aggregation, a date part, a bin and an aggregating calculation all keep their own derivation.

## Also from review

3b44424 applied a two-axis review's findings: the repair loop now says re-run steps 5 **and** 6
(a rebuild alone leaves `build` approved off the pre-fix workbook, and only `commit` re-checks
that a packaged deliverable is on disk), and a note that `twb.py` *plans* the actions, filter
cards and zone visibility that `features.py` only renders.

`demo/` is deliberately untouched — regenerating it is #30, and the scratch run's artifacts can
seed that later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
