### PR TITLE
chore(plugin): bump version to 0.1.1 so installs pick up tableau-build

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tableau-dashboard-plugin",
   "displayName": "Tableau Dashboard Plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Turn a free-text dashboard request into an interactive HTML demo and a Replace-Data-Source-ready Tableau .twbx, via 8 single-job skills that hand off through files on disk. See CONTRACT.md for the inter-skill API.",
   "author": {
     "name": "Lavi Drori",


### PR DESCRIPTION
## Why
The plugin install cache (~/.claude/plugins/cache) is keyed by version. 0.1.0 was snapshotted before `skills/tableau-build` was merged (#57), so installed copies never see the new skill — `/plugins` lists only 8 skills.

## Change
One line: `plugin.json` version 0.1.0 → 0.1.1. After merging, 'Update now' in /plugins installs a fresh 0.1.1 cache that includes tableau-build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)