### PR TITLE
fix(build): the gate refuses to run partially when lxml is missing (#68)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ python-dotenv>=1.0,<2.0
 requests>=2.31,<3.0
 
 # Step E — XSD validation of generated .twb files
-lxml>=5.0,<6.0
+lxml>=5.0,<7.0

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -130,9 +130,12 @@ invented zone is caught rather than silently built.
    that raised it: `[semantic]` (is the XML internally consistent?), `[schema]` (does it match
    the XSD?) and `[conformance]` (does the workbook agree with the manifest — every layout
    element became a zone, every zone names a real sheet, every declared worksheet is built,
-   placed, and has a window). Only the third can see something *missing*: what is absent is
-   absent consistently, so the first two happily pass a workbook that dropped a chart. To
-   re-run the gate over a `.twb` already on disk — the revalidate half of a fix — use:
+   placed, and has a window). **The gate refuses to run partially** — if `lxml` is missing the
+   `[schema]` validator cannot execute, so the gate fails rather than reporting green on two
+   of three (`pip install -r requirements.txt`). Only the third can see something *missing*:
+   what is absent is absent consistently, so the first two happily pass a workbook that
+   dropped a chart. To re-run the gate over a `.twb` already on disk — the revalidate half of
+   a fix — use:
 
    ```bash
    python "${CLAUDE_SKILL_DIR}/scripts/build.py" gate "<project-dir>"

--- a/skills/tableau-build/scripts/build.py
+++ b/skills/tableau-build/scripts/build.py
@@ -596,7 +596,7 @@ class BuildResult:
         twb_path: Project-relative path of the workbook XML (written even on a validator
             failure, so the XML can be inspected).
         twbx_path: Project-relative path of the package; ``""`` when nothing was packaged.
-        warnings: Non-fatal notes (a skipped XSD check, the documented version shift).
+        warnings: Non-fatal notes (the documented version shift, reserved-but-empty boxes).
         gated: Whether the validation gate actually ran. A failure *before* it - an invalid
             manifest, a missing CSV, no ``.twb`` to gate - must not be reported as a failed
             gate, or the analyst debugs the wrong thing.
@@ -640,10 +640,15 @@ def _xsd_errors(twb_path: Path, target_tableau_version: str) -> tuple[list[str],
     Returns:
         ``(errors, warnings)``. For the 2026.1+ target every schema error is fatal; for
         2024.2-2025.x the single ``<explain-data>`` complaint is downgraded to a warning.
-        When ``lxml`` is absent the check is skipped with a warning.
+        When ``lxml`` is absent the check *cannot* run, so it fails: a gate that reports
+        green while one of its validators silently sat out is worse than a red one.
     """
     if importlib.util.find_spec("lxml") is None:
-        return [], ["XSD check skipped: lxml is not installed (pip install lxml)."]
+        return [
+            "the XSD check cannot run: lxml is not installed, and the gate refuses to run "
+            "partially. Install it with 'pip install lxml' (it is in requirements.txt) and "
+            "re-run."
+        ], []
 
     import validate_twb_xsd  # imports lxml at module level - guarded above
 
@@ -680,8 +685,8 @@ class GateReport:
 
     Attributes:
         results: ``{validator name: errors}`` for each of :data:`GATE_VALIDATORS`.
-        warnings: Non-fatal notes - a skipped XSD check, the documented version shift, and
-            each unsupported construct the build reserved a box for but did not draw.
+        warnings: Non-fatal notes - the documented version shift, and each unsupported
+            construct the build reserved a box for but did not draw.
     """
 
     results: dict[str, list[str]]

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1487,6 +1487,26 @@ def test_an_unsupported_construct_is_named_and_the_rest_still_builds(tmp_path):
     assert (tmp_path / build.VERSION_DIR / "v_1" / build.WORKBOOK_FILENAME).exists()
 
 
+def test_the_gate_refuses_to_run_without_lxml(tmp_path, monkeypatch):
+    """Issue #68: a validator that can silently not run is not a validator. Without lxml
+    the XSD check cannot execute, so the gate fails instead of reporting green degraded."""
+    real_find_spec = build.importlib.util.find_spec
+    monkeypatch.setattr(
+        build.importlib.util, "find_spec",
+        lambda name, *args: None if name == "lxml" else real_find_spec(name, *args),
+    )
+
+    result = _built_project(tmp_path)
+
+    assert result.ok is False
+    assert any("lxml" in error for error in result.errors)
+    assert any("pip install lxml" in error for error in result.errors)
+    # The absence is never a mere warning, and nothing is packaged for commit to approve.
+    assert not any("lxml" in warning for warning in result.warnings)
+    assert "[BUILT]" not in build.format_build(result)
+    assert build.commit(tmp_path).ok is False
+
+
 # --- STATE.md transition (CONTRACT.md §4.3) ----------------------------------
 
 def test_commit_refuses_without_a_workbook(tmp_path):


### PR DESCRIPTION
Closes #68.

## The bug

With `lxml` absent, `build.py build` printed `[BUILT] ... gate: all 3 validators passed` while
the `[schema]` validator never ran — it was downgraded to a `[WARN]` line under a green verdict.
That skip was hiding a real defect: installing `lxml` and re-running `gate` failed the same
workbook with 5 `[schema]` errors. A gate that reports green while silently degraded is the most
dangerous shape of this bug, since the skill text tells the agent the gate "is what the analyst's
trust rests on".

## The fix — option 1 (hard-fail)

- `skills/tableau-build/scripts/build.py`: `_xsd_errors` returns a `[schema]` **error** naming
  the install command instead of a warning. `build`/`gate` exit `[INVALID]`, nothing is
  packaged, and `commit` refuses on the absent `.twbx`.
- `requirements.txt`: pin widened to `lxml>=5.0,<7.0` (6.1.1 verified working; `<6.0` was stale).
- `skills/tableau-build/SKILL.md`: the "gate is what the analyst's trust rests on" paragraph now
  states that the gate refuses to run partially.
- Two docstrings that still advertised a skippable XSD check corrected.

Acceptance holds by construction: `[BUILT]` only prints when `GateReport.ok`, and the schema slot
can no longer be empty-because-skipped.

## Tests

`tests/test_build.py::test_the_gate_refuses_to_run_without_lxml` — written red-first; simulates
lxml's absence via `find_spec` and asserts the build fails with an lxml-naming error, carries no
lxml warning, prints no `[BUILT]` line, and that `commit` refuses.

Full suite: **598 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
