### PR TITLE
fix(build): a manual sort is emitted as <manual-sort>, not <sort> (#70)

### DIFF
--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -1367,8 +1367,10 @@ def _render_sort(parent: ET.Element, plan: WorksheetPlan) -> None:
     column = plan.reference_of(plan.sort.reference)
 
     if plan.sort.order:
+        # 'manual-sort', not 'sort': the schema's sort group is computed-sort / manual-sort /
+        # natural-sort / alphabetic-sort, and a bare <sort> is rejected outright.
         manual = ET.SubElement(
-            parent, "sort", {"column": column, "direction": plan.sort.direction}
+            parent, "manual-sort", {"column": column, "direction": plan.sort.direction}
         )
         dictionary = ET.SubElement(manual, "dictionary")
         for member in plan.sort.order:

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -773,7 +773,11 @@ def test_a_manual_sort_writes_the_member_order():
         sort={"field": "region", "direction": "ASC", "order": ["West", "East"]},
     )])
     element = _worksheet_element("Manual", ET.fromstring(_render(document)))
-    buckets = element.findall("table/view/sort/dictionary/bucket")
+    assert element.find("table/view/sort") is None
+    manual = element.find("table/view/manual-sort")
+    assert manual.get("column").endswith("[none:region:nk]")
+    assert manual.get("direction") == "ASC"
+    buckets = manual.findall("dictionary/bucket")
     assert [bucket.text for bucket in buckets] == ['"West"', '"East"']
 
 


### PR DESCRIPTION
Closes #70.

## The bug

`worksheet.py::_render_sort` emitted an explicit member order as a bare
`<sort column= direction=><dictionary>…`. The workbook schema's sort group is
`computed-sort / manual-sort / natural-sort / alphabetic-sort`, so `<sort>` fails XSD
validation — one `[schema]` error per manually-sorted sheet — and Desktop rejects the
workbook.

## The fix

- `skills/tableau-build/scripts/worksheet.py` (`_render_sort`) — emit `<manual-sort>` with
  the same `column`/`direction` attributes and `<dictionary>` child (XSD: `Sort-ManualSort-G`,
  `Sort-CommonAttributes-AG`).
- `tests/test_charts.py::test_a_manual_sort_writes_the_member_order` — the test asserted the
  buggy path (`table/view/sort/dictionary/bucket`), so it encoded the bug. It now asserts
  `table/view/sort` is absent and checks `manual-sort`'s column, direction, and bucket order.
  Verified red before the fix, green after.

Full suite: **598 passed**. The XSD-gate + Desktop leg was verified in the mrrSales build
described in #70 (the 5 `[schema]` errors gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
