### PR TITLE
fix(build): every single-pane chart type states its mark class (#64)

### DIFF
--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -41,7 +41,7 @@ Interaction ids (`int-*`) are actions, not zones, and never appear in the tree.
 
 | `chart_type` | what it emits |
 |--------------|---------------|
-| `bar` | Discrete dimension × aggregated measure. Add a `color` encoding for a **stacked** bar. |
+| `bar` | A dimension × aggregated measure - discrete, or a continuous date with a `date_part` (the mark is an explicit `Bar` either way). Add a `color` encoding for a **stacked** bar. |
 | `line` | Same shape, but the dimension is a **continuous date** — give it a `date_part`. |
 | `area` | Line with an explicit `Area` mark. |
 | `pie` | Rows/Cols stay empty; everything is encodings (`color`, `wedge-size`, `size`, `text`). |

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -643,17 +643,24 @@ class ChartSpec:
 #: that are really modifiers - sorted, filtered, styled, custom tooltip - are the optional
 #: ``sort`` / ``filters`` / design tokens / ``tooltip`` manifest keys, applicable to any row
 #: here; a stacked bar is ``bar`` with a ``color`` encoding.
+#:
+#: Issue #64: every single-pane type names its mark explicitly. ``Automatic`` picks by
+#: shelf shape - a *discrete* dimension x measure draws bars, but a *continuous* date x
+#: measure draws points - so a ``bar`` over the ``date_part`` month spine that
+#: BUILD-MANIFEST-TEMPLATE.md steers date axes to rendered as scattered dots.
+#: ``chart_type`` is the analyst's stated intent; nothing is left to Tableau's inference.
 CHART_SPECS: dict[str, ChartSpec] = {
-    "bar": ChartSpec(),
-    "line": ChartSpec(),
+    "bar": ChartSpec(mark_class="Bar"),
+    "line": ChartSpec(mark_class="Line"),
     "area": ChartSpec(mark_class="Area"),
     "pie": ChartSpec(mark_class="Pie", label_marks=True, empty_shelves=True),
-    "scatter": ChartSpec(),
+    "scatter": ChartSpec(mark_class="Circle"),
     "map": ChartSpec(geographic=True),
-    "text": ChartSpec(label_marks=True, kpi_card=True, empty_shelves=True),
-    "table": ChartSpec(label_marks=True),
+    "text": ChartSpec(mark_class="Text", label_marks=True, kpi_card=True,
+                      empty_shelves=True),
+    "table": ChartSpec(mark_class="Text", label_marks=True),
     "heatmap": ChartSpec(mark_class="Square"),
-    "histogram": ChartSpec(),
+    "histogram": ChartSpec(mark_class="Bar"),
     "treemap": ChartSpec(mark_class="Square", label_marks=True),
     "bullet": ChartSpec(mark_class="Bar"),
     "gantt": ChartSpec(mark_class="Gantt"),

--- a/tests/fixtures/charts/bar-filtered.xml
+++ b/tests/fixtures/charts/bar-filtered.xml
@@ -52,7 +52,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Bar" />
           </pane>
         </panes>
         <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>

--- a/tests/fixtures/charts/bar-formatted.xml
+++ b/tests/fixtures/charts/bar-formatted.xml
@@ -49,7 +49,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Bar" />
           </pane>
         </panes>
         <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>

--- a/tests/fixtures/charts/bar-labelled.xml
+++ b/tests/fixtures/charts/bar-labelled.xml
@@ -37,7 +37,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Bar" />
             <encodings>
               <text column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
             </encodings>

--- a/tests/fixtures/charts/bar-sorted.xml
+++ b/tests/fixtures/charts/bar-sorted.xml
@@ -35,7 +35,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Bar" />
           </pane>
         </panes>
         <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>

--- a/tests/fixtures/charts/bar-stacked.xml
+++ b/tests/fixtures/charts/bar-stacked.xml
@@ -43,7 +43,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Bar" />
             <encodings>
               <color column="[federated.b2993893834e8f0306a282d0a717d7a9].[none:region:nk]" />
             </encodings>

--- a/tests/fixtures/charts/bar-styled.xml
+++ b/tests/fixtures/charts/bar-styled.xml
@@ -40,7 +40,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Bar" />
             <encodings>
               <text column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
             </encodings>

--- a/tests/fixtures/charts/bar.xml
+++ b/tests/fixtures/charts/bar.xml
@@ -34,7 +34,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Bar" />
           </pane>
         </panes>
         <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>

--- a/tests/fixtures/charts/calculated-field.xml
+++ b/tests/fixtures/charts/calculated-field.xml
@@ -36,7 +36,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Bar" />
           </pane>
         </panes>
         <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[usr:Margin Pct:qk]</rows>

--- a/tests/fixtures/charts/custom-tooltip.xml
+++ b/tests/fixtures/charts/custom-tooltip.xml
@@ -35,7 +35,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Bar" />
             <encodings>
               <tooltip column="[federated.b2993893834e8f0306a282d0a717d7a9].[attr:product_category:nk]" />
               <tooltip column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />

--- a/tests/fixtures/charts/histogram.xml
+++ b/tests/fixtures/charts/histogram.xml
@@ -36,7 +36,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Bar" />
           </pane>
         </panes>
         <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[cnt:revenue:qk]</rows>

--- a/tests/fixtures/charts/kpi-card.xml
+++ b/tests/fixtures/charts/kpi-card.xml
@@ -36,7 +36,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Text" />
             <encodings>
               <text column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
             </encodings>

--- a/tests/fixtures/charts/line.xml
+++ b/tests/fixtures/charts/line.xml
@@ -34,7 +34,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Line" />
           </pane>
         </panes>
         <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]</rows>

--- a/tests/fixtures/charts/scatter.xml
+++ b/tests/fixtures/charts/scatter.xml
@@ -36,7 +36,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Circle" />
             <encodings>
               <lod column="[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]" />
             </encodings>

--- a/tests/fixtures/charts/text-table.xml
+++ b/tests/fixtures/charts/text-table.xml
@@ -36,7 +36,7 @@
             <view>
               <breakdown value="auto" />
             </view>
-            <mark class="Automatic" />
+            <mark class="Text" />
             <encodings>
               <text column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
             </encodings>

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -365,21 +365,31 @@ def test_the_same_manifest_rebuilds_byte_identical():
 # --- Mark classes and shelves --------------------------------------------------
 
 @pytest.mark.parametrize("sheet_name,mark_class", [
-    ("Bar", "Automatic"),
-    ("Line", "Automatic"),
+    ("Bar", "Bar"),
+    ("Line", "Line"),
     ("Area", "Area"),
     ("Pie", "Pie"),
-    ("Scatter", "Automatic"),
-    ("Text Table", "Automatic"),
-    ("Kpi Card", "Automatic"),
-    ("Histogram", "Automatic"),
+    ("Scatter", "Circle"),
+    ("Text Table", "Text"),
+    ("Kpi Card", "Text"),
+    ("Histogram", "Bar"),
     ("Map", "Automatic"),
 ])
 def test_mark_class_per_chart_type(sheet_name, mark_class):
-    """The mark class is what makes Tableau draw the right shape; Area and Pie must be
-    explicit or Tableau falls back to a line."""
+    """The mark class is what makes Tableau draw the right shape; every single-pane type
+    states it rather than letting Tableau's Automatic infer one from the shelves."""
     pane = _worksheet_element(sheet_name).find("table/panes/pane")
     assert pane.find("mark").get("class") == mark_class
+
+
+def test_a_bar_over_a_continuous_date_is_still_a_bar():
+    """Issue #64: the reproducing shape. Automatic reads a continuous date x measure as
+    points, so a month-spine bar chart drew scattered dots instead of bars."""
+    document = _manifest(worksheets=[_sheet("Monthly Bar", "bar", shelves={
+        "columns": [{"field": "order_date", "date_part": "month"}], "rows": ["revenue"],
+    })])
+    element = _worksheet_element("Monthly Bar", ET.fromstring(_render(document)))
+    assert element.find("table/panes/pane/mark").get("class") == "Bar"
 
 
 def test_pie_and_kpi_put_everything_on_encodings():


### PR DESCRIPTION
Closes #64.

## Problem

`ChartSpec.mark_class` defaults to `"Automatic"` and `bar`, `line`, `scatter`, `histogram`, `text` and `table` all sat on that default. Tableau's Automatic mark picks by shelf shape: a **discrete** dimension x measure draws bars (why the goldens looked right), but a **continuous** date x measure draws **points**. Since `BUILD-MANIFEST-TEMPLATE.md` steers date axes to continuous, the default betrayed the documented usage - all 8 sheets of the mrrSales v_3 workbook emitted `<mark class="Automatic" />` and every month-spine chart rendered as scattered dots.

## Change

`CHART_SPECS` names the mark each `chart_type` means: `bar`/`histogram` -> `Bar`, `line` -> `Line`, `scatter` -> `Circle`, `text`/`table` -> `Text`. `dual-axis` deliberately keeps its `Automatic` panes (documented behaviour) and `combo`'s per-pane `("Bar", "Line")` is untouched. All four new values are in the `PrimitiveType-ST` enumeration of `xsd/twb_2026.1.0.xsd`.

## Tests

- `test_mark_class_per_chart_type` asserts the explicit class per chart type.
- `test_a_bar_over_a_continuous_date_is_still_a_bar` pins the reproducing shape (a `bar` with `date_part: "month"` on columns).
- 14 goldens regenerated; the diff is exactly one `<mark class>` line per file, nothing else moved. 599 tests pass.

## Verified against Desktop

mrrSales v_3 rebuilt (`build.py gate`: all 3 validators pass) and opened in Tableau Desktop 2025.1.10. Was 8x `Automatic`, now 4 `Bar` / 1 `Line` / 3 `Text` - all five charts sit on the continuous `tmn:sale_date:qk` pill and draw stacked bars / a marked line; the KPI cards read `Text`. Analyst-approved.

## Not in scope

`gantt` emits `mark_class="Gantt"`, which is **not** in the XSD enum (it lists `GanttBar`) - pre-existing, worth its own issue.