### PR TITLE
fix(build): field captions keep the casing the author wrote (#69)

### DIFF
--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -151,7 +151,7 @@ class Column:
     @property
     def caption(self) -> str:
         """str: The UI caption Tableau shows (``order_date`` -> ``Order Date``)."""
-        return self.name.replace("_", " ").title()
+        return worksheet.caption_for(self.name)
 
 
 # --- Deterministic ids ---------------------------------------------------------

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -373,8 +373,14 @@ BIN_DECIMALS = "2"
 
 
 def caption_for(field_name: str) -> str:
-    """Return the UI caption for a field name (``order_date`` -> ``Order Date``)."""
-    return field_name.replace("_", " ").title()
+    """Return the UI caption for a field name (``order_date`` -> ``Order Date``).
+
+    Title-casing is for raw snake_case columns only. A name the author already cased -
+    ``ACV - Current``, ``YoY Direction``, ``In KPI Window`` - is passed through verbatim:
+    ``.title()`` would lower-case the rest of every acronym (issue #69).
+    """
+    spaced_name = field_name.replace("_", " ")
+    return spaced_name.title() if spaced_name == spaced_name.lower() else spaced_name
 
 
 class CalculatedField(NamedTuple):
@@ -444,10 +450,10 @@ class FieldRef:
     def caption(self) -> str:
         """str: The caption Tableau shows for the column.
 
-        A bin's name is already the caption (``Revenue (bin)``); title-casing it would
-        turn the ``(bin)`` marker into ``(Bin)`` and stop matching the column name.
+        A bin's name is already a caption (``Revenue (bin)``) and ``caption_for`` passes
+        cased names through, so the marker stays ``(bin)`` and keeps matching the column.
         """
-        return self.field_name if self.bin_size is not None else caption_for(self.field_name)
+        return caption_for(self.field_name)
 
 
 class FieldResolver:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -29,6 +29,7 @@ import init  # builds a realistic STATE.md the same way a real project would
 import manifest  # the pure manifest-schema core (on sys.path via conftest.py)
 import route  # the router parses/routes the STATE.md build writes
 import twb  # the pure .twb assembler
+import worksheet  # caption_for, the shared caption rule
 
 TARGET_VERSION = "2024.2-2025.x"
 
@@ -938,6 +939,35 @@ def test_column_types_come_from_the_data_model():
     assert by_name["[region]"].get("role") == "dimension"
     assert by_name["[order_date]"].get("datatype") == "date"
     assert by_name["[revenue]"].get("caption") == "Revenue"
+
+
+@pytest.mark.parametrize("field_name, caption", [
+    ("order_date", "Order Date"),                     # raw snake_case: title-cased as before
+    ("ACV - Current", "ACV - Current"),               # acronym survives
+    ("YoY Direction - ACV", "YoY Direction - ACV"),   # mixed case survives
+    ("In KPI Window", "In KPI Window"),               # acronym mid-name survives
+])
+def test_captions_only_title_case_uncased_names(field_name, caption):
+    """A name the author already cased is a display name (issue #69): ``.title()`` would
+    turn ``ACV`` into ``Acv`` in the Data pane, on pills and in Desktop error messages."""
+    assert worksheet.caption_for(field_name) == caption
+    assert twb.Column(name=field_name, ordinal=0, datatype="string").caption == caption
+
+
+def test_a_cased_calculated_field_keeps_its_authored_caption():
+    """The path the analyst hit (issue #69): Desktop reported "Acv - Current" - a name
+    nobody wrote - because the rendered column caption had been .title()-ed."""
+    document = _manifest()
+    document["calculated_fields"] = [
+        {"name": "ACV - Current", "formula": "SUM([revenue])", "datasource": "sales_orders"}
+    ]
+    document["worksheets"][1]["shelves"]["rows"] = [
+        {"field": "ACV - Current", "aggregation": "none"}
+    ]
+    root = _render(document)
+
+    column = root.find("datasources/datasource/column[@name='[ACV - Current]']")
+    assert column is not None and column.get("caption") == "ACV - Current"
 
 
 def test_every_documented_type_renders_a_complete_column():


### PR DESCRIPTION
Closes #69.

## The bug

Every field caption was run through `str.title()`, which lower-cases everything after the first letter of each word. Right for `order_date` -> `Order Date`, destructive for anything the author already cased:

| authored | Desktop showed |
|---|---|
| `ACV — Current` | **Acv — Current** |
| `YoY Direction — ACV` | **Yoy Direction — ACV** |
| `In KPI Window` | **In Kpi Window** |

These names appear in the Data pane, on pills, in tooltips and in Desktop's error text — the mrrSales analyst first met the bug as *"The calculation 'Acv — Current' can't…"*, a name nobody wrote.

## The fix

Title-case only names that are entirely uncased; pass everything else through verbatim. A calculated field's name **is** its display name — the manifest author chose that casing.

```python
spaced_name = field_name.replace("_", " ")
return spaced_name.title() if spaced_name == spaced_name.lower() else spaced_name
```

The bug had **two independent title-casing sites** (`worksheet.caption_for` and `twb.Column.caption`), so `Column.caption` now delegates to `caption_for` — one rule, one place, no drift.

`FieldRef.caption` also drops its bin special-case: it existed only to stop `.title()` turning `Revenue (bin)` into `Revenue (Bin)`, which the general pass-through rule now covers.

## Tests

604 pass. Four new assertions, all verified to fail against the old behavior:

- a parametrised unit test over both caption sites (`order_date` still title-cases; the three cased names survive);
- an end-to-end render asserting a cased calculated field reaches the workbook as `<column caption="ACV — Current">`.

No goldens moved — no existing fixture used a cased calc name.

## Verified against the real project

Rebuilt `mrrSales` v_3 with the fix; all 3 validators pass. All 20 calculated-field captions now read as authored (`ACV — Current`, `YoY Direction — ACV`, `In KPI Window`).

Five captions stay title-cased — `Booking Acv` (x4) and `In Mrr Scope`. Those are raw CSV columns (`booking_acv`, `in_mrr_scope`), entirely uncased, so the rule title-cases them and cannot know `acv` was an acronym. Fixing those would need a per-field caption override, which the manifest does not support today (`fields[]` validates `name` and `type` only, and `_columns_for` builds columns from the CSV header, never from the manifest). Deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)