### PR TITLE
fix: container proportions survive the open (#63)

### DIFF
--- a/skills/tableau-build/scripts/zones.py
+++ b/skills/tableau-build/scripts/zones.py
@@ -282,27 +282,36 @@ class _ZoneWriter:
         return max(1, round(units / ZONE_SPACE * self._height))
 
     @staticmethod
-    def _flex_child(children: list) -> int:
+    def _flex_child(children: list, sizes: list[float]) -> int:
         """Return the index of the child left unpinned, to absorb the container's slack.
 
-        Desktop pins every hand-proportioned child but one; the unpinned child takes the
-        rounding remainder and, when a sibling is hidden by a show/hide field, the space
-        that sibling gave up. A visibility-controlled child is therefore the worst
-        candidate - hiding the only flex child would leave the container's slack blank -
-        so the last *uncontrolled* child flexes, and the last child only if all of them
-        are controlled.
+        A hand-built container pins every child but one, and the one it leaves free is the
+        *largest* - never simply the last. In the reference workbook's main column the flex
+        child sits in the middle (the 51% trend section, between a pinned 150px KPI row and
+        a pinned 209px bottom section); in its trend section the trailing 22px legend is
+        pinned and the chart row flexes. The unpinned child is what absorbs the rounding
+        remainder, the room a hidden sibling gives up, and every pixel the dashboard gains
+        over its minimum size - which is right for the main content region and wrong for a
+        legend strip or a spacer, which would swallow the growth and leave the charts at
+        their authored size.
+
+        A visibility-controlled child is excluded outright: hiding the only flex child
+        would leave the container's slack blank.
 
         Args:
             children: The container's child nodes.
+            sizes: Each child's proportion, positionally.
 
         Returns:
             The index into ``children`` of the child to leave unpinned.
         """
-        for index in reversed(range(len(children))):
+        def is_controlled(index: int) -> bool:
             child = children[index]
-            if not (isinstance(child, dict) and str(child.get("visibility") or "").strip()):
-                return index
-        return len(children) - 1
+            return isinstance(child, dict) and bool(str(child.get("visibility") or "").strip())
+
+        indices = range(len(children))
+        free = [index for index in indices if not is_controlled(index)] or list(indices)
+        return max(free, key=lambda index: sizes[index])
 
     def _zone(self, parent: ET.Element, box: Box, friendly_name: str, **attributes) -> ET.Element:
         """Append one zone with its geometry, id and friendly name.
@@ -386,7 +395,7 @@ class _ZoneWriter:
             layout_strategy_id=DISTRIBUTE_EVENLY if is_evenly_split else None,
         )
         self._record_visibility(container, visibility)
-        flex = self._flex_child(children)
+        flex = self._flex_child(children, sizes)
         for index, (child, child_box) in enumerate(
             zip(children, self._divide(box, orientation, sizes)), start=1
         ):

--- a/skills/tableau-build/scripts/zones.py
+++ b/skills/tableau-build/scripts/zones.py
@@ -103,6 +103,14 @@ SHEET_LAYOUT_CACHES: dict[bool, dict[str, str]] = {
 #: The ``layout-strategy-id`` Desktop writes on a flow container it splits evenly (a KPI row).
 DISTRIBUTE_EVENLY = "distribute-evenly"
 
+#: How far apart two sibling proportions may be and still count as an even split.
+#:
+#: Issue #63: three near-equal siblings can only sum to 100 as ``33.34 / 33.33 / 33.33``,
+#: which an exact-equality test reads as *proportioned* - so the intentionally even row lost
+#: its strategy and got pinned instead. Anything looser than a rounding artefact (a 60/40
+#: split, say) stays proportioned.
+EVEN_SPLIT_TOLERANCE = 0.5
+
 #: The root zone's friendly name.
 ROOT_FRIENDLY_NAME = "Dashboard"
 
@@ -265,6 +273,37 @@ class _ZoneWriter:
         """Convert a vertical px measure into zone units at the canvas height."""
         return round(pixels / self._height * ZONE_SPACE)
 
+    def _pixels_x(self, units: int) -> int:
+        """Convert a horizontal zone-unit measure back into px at the canvas width."""
+        return max(1, round(units / ZONE_SPACE * self._width))
+
+    def _pixels_y(self, units: int) -> int:
+        """Convert a vertical zone-unit measure back into px at the canvas height."""
+        return max(1, round(units / ZONE_SPACE * self._height))
+
+    @staticmethod
+    def _flex_child(children: list) -> int:
+        """Return the index of the child left unpinned, to absorb the container's slack.
+
+        Desktop pins every hand-proportioned child but one; the unpinned child takes the
+        rounding remainder and, when a sibling is hidden by a show/hide field, the space
+        that sibling gave up. A visibility-controlled child is therefore the worst
+        candidate - hiding the only flex child would leave the container's slack blank -
+        so the last *uncontrolled* child flexes, and the last child only if all of them
+        are controlled.
+
+        Args:
+            children: The container's child nodes.
+
+        Returns:
+            The index into ``children`` of the child to leave unpinned.
+        """
+        for index in reversed(range(len(children))):
+            child = children[index]
+            if not (isinstance(child, dict) and str(child.get("visibility") or "").strip()):
+                return index
+        return len(children) - 1
+
     def _zone(self, parent: ET.Element, box: Box, friendly_name: str, **attributes) -> ET.Element:
         """Append one zone with its geometry, id and friendly name.
 
@@ -336,20 +375,30 @@ class _ZoneWriter:
             return
 
         orientation = "vert" if str(node.get("type", "")).strip().lower() == "vert" else "horz"
+        vertical = orientation == "vert"
         sizes = child_sizes(children)
         # An evenly split container is how Desktop records a KPI row: the strategy, not four
         # stored 25%s, is what keeps the cards equal as the dashboard stretches (issue #59).
-        is_evenly_split = len(sizes) > 1 and len(set(sizes)) == 1
+        is_evenly_split = len(sizes) > 1 and max(sizes) - min(sizes) <= EVEN_SPLIT_TOLERANCE
         container = self._zone(
             parent, box, f"{CONTAINER_PREFIXES[orientation]}-{element_id or path}",
             type_v2="layout-flow", param=orientation,
             layout_strategy_id=DISTRIBUTE_EVENLY if is_evenly_split else None,
         )
         self._record_visibility(container, visibility)
+        flex = self._flex_child(children)
         for index, (child, child_box) in enumerate(
             zip(children, self._divide(box, orientation, sizes)), start=1
         ):
+            first_new = len(container)
             self._node(container, child, child_box, f"{path}.{index}")
+            if is_evenly_split or index - 1 == flex or len(container) == first_new:
+                continue
+            # A proportioned split only survives the open if each child states its own size
+            # in px along the flow axis - the stored w/h alone is re-flowed away (issue #63).
+            pin = self._pixels_y(child_box.h) if vertical else self._pixels_x(child_box.w)
+            container[first_new].set("is-fixed", "true")
+            container[first_new].set("fixed-size", str(pin))
         render_zone_style(container, ZONE_MARGIN)
 
     def _record_visibility(self, zone: ET.Element, field: str) -> None:

--- a/skills/tableau-spec/SKILL.md
+++ b/skills/tableau-spec/SKILL.md
@@ -48,6 +48,11 @@ single **Element Mapping table** and a **Layout section** (see
   mapped **zone** id appears **exactly once**; interaction ids (`int-*`) are actions, not
   zones, and never appear. This is how the mock's geometry reaches `tableau-build` — a
   missing or inconsistent Layout blocks approval exactly like an unmapped element.
+- **Siblings meant to stay equal must be a container's only children.** Tableau holds a row
+  of equal cards equal by distributing the *container* evenly, so an equal group stranded
+  beside a smaller sibling (three chart cards above a 3% legend strip) cannot be held — the
+  build pins every child but the biggest, and the group drifts apart on any dashboard taller
+  than its minimum. Wrap the group in its own container; the validator flags this.
 
 ## The simplest-primitive guard
 

--- a/skills/tableau-spec/references/IMPLEMENTATION-SPEC-TEMPLATE.md
+++ b/skills/tableau-spec/references/IMPLEMENTATION-SPEC-TEMPLATE.md
@@ -44,6 +44,11 @@ of being guessed. Start with a short human-readable summary of the layout, then 
   siblings must sum to ~100. The root itself needs no size.
 - Every mapped **zone** id appears **exactly once**. Interaction ids (`int-*`) are
   dashboard actions, not zones — never place them in the tree.
+- Children meant to be **equal** must be their container's **only** children — wrap them
+  in a container of their own rather than listing them beside a smaller sibling. Equal cards
+  stay equal only when the whole container is distributed evenly, so
+  `[card 32, card 32, card 32, legend 4]` drifts apart, while
+  `[[card 33, card 33, card 34] 96, legend 4]` holds.
 
 <Example: a filter bar over a KPI row, a chart row, and a collapsible details panel.>
 

--- a/skills/tableau-spec/scripts/reconcile.py
+++ b/skills/tableau-spec/scripts/reconcile.py
@@ -217,6 +217,11 @@ INTERACTION_PREFIX = "int-"
 #: How far sibling sizes may drift from 100% before they "don't sum sanely" (rounding slack).
 SIBLING_SIZE_TOLERANCE = 2.0
 
+#: How close two sibling sizes must be to read as "the author meant these to be equal".
+#: Matches ``zones.EVEN_SPLIT_TOLERANCE`` in tableau-build, which is what decides whether a
+#: container is written as an evenly-distributed one.
+EQUAL_SIBLING_TOLERANCE = 0.5
+
 # Exactly '## Layout' (the level the contract/template mandate) so the section reliably
 # ends at the next '## ' heading.
 _LAYOUT_HEADING = re.compile(r"^##\s+Layout\b.*$", re.MULTILINE)
@@ -248,6 +253,40 @@ def extract_layout_block(spec_text: str) -> Optional[str]:
 def _is_number(value: object) -> bool:
     """Return True for a real (non-bool) JSON number."""
     return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _stranded_equal_group(path: str, sizes: list[float]) -> list[str]:
+    """Flag a container whose *largest* children are equal but which also holds a smaller one.
+
+    Tableau keeps a set of equal siblings equal by distributing the whole container evenly -
+    a property of the container, not of the children - so a group meant to stay equal has to
+    be the container's *only* children. Stranded among a smaller sibling (three chart cards
+    above a 3% legend strip), the group cannot be distributed: the build pins every child but
+    the biggest, so on any dashboard taller than its minimum one card of the group grows and
+    the rest stay put (issue #63).
+
+    Only the largest group matters. Equal siblings *below* the biggest child are all pinned,
+    at equal sizes, and stay equal - they simply do not grow.
+
+    Args:
+        path: The container's position in the tree, for the error message.
+        sizes: The children's sizes, positionally.
+
+    Returns:
+        One error message when the container strands an equal group, otherwise no messages.
+    """
+    if len(sizes) < 3:
+        return []
+    largest = max(sizes)
+    group = [index for index, size in enumerate(sizes) if largest - size <= EQUAL_SIBLING_TOLERANCE]
+    if len(group) < 2 or len(group) == len(sizes):
+        return []  # a unique biggest child, or a container that is evenly split as it stands
+    shares = " / ".join(f"{sizes[index]:g}" for index in group)
+    return [
+        f"{path}: children {group} are equal ({shares}) but share the container with a "
+        f"smaller sibling, so they cannot be distributed evenly and will drift apart as the "
+        f"dashboard grows - wrap the equal group in its own container"
+    ]
 
 
 def _walk_layout_node(
@@ -311,6 +350,7 @@ def _walk_layout_node(
                 f"{path}: sibling sizes sum to {total:g}, expected ~100 "
                 f"(each child's share of its parent)"
             )
+        errors.extend(_stranded_equal_group(path, sizes))
 
 
 def validate_layout(spec_text: str, mapped_ids: list[str]) -> list[str]:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -360,6 +360,37 @@ def test_reconcile_flags_insane_sibling_sizes():
     assert any("sum to 30" in error for error in validation.layout_errors)
 
 
+def test_reconcile_flags_an_equal_group_stranded_with_a_smaller_sibling():
+    """Two equal cards above a 3% legend strip cannot be distributed evenly: the build pins
+    every child but the biggest, so the cards drift apart as the dashboard grows. The author
+    is told to wrap the equal group in its own container (issue #63)."""
+    layout = (
+        '{"canvas": {"width": 1366, "height": 768}, "root": {"type": "vert", "children": '
+        '[{"id": "kpi-revenue", "size": 48.5}, {"id": "chart-trend", "size": 48.5}, '
+        '{"id": "flt-region", "size": 3}]}}'
+    )
+    validation = reconcile.reconcile(_mock_html(), _spec_md(layout=layout))
+
+    assert validation.ok is False
+    assert any(
+        "wrap the equal group in its own container" in error
+        for error in validation.layout_errors
+    )
+
+
+def test_reconcile_accepts_equal_siblings_under_a_bigger_one():
+    """Equal siblings *below* the biggest child are all pinned at equal sizes and stay
+    equal - they just do not grow. Only a stranded *largest* group is a problem."""
+    layout = (
+        '{"canvas": {"width": 1366, "height": 768}, "root": {"type": "vert", "children": '
+        '[{"id": "kpi-revenue", "size": 60}, {"id": "chart-trend", "size": 20}, '
+        '{"id": "flt-region", "size": 20}]}}'
+    )
+    validation = reconcile.reconcile(_mock_html(), _spec_md(layout=layout))
+
+    assert validation.layout_errors == []
+
+
 def test_reconcile_flags_missing_canvas():
     """The canvas dimensions are required (the mock's design size drives the build)."""
     layout = (

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -356,6 +356,59 @@ def test_an_evenly_split_flow_container_declares_the_strategy():
     assert uneven_row.get("layout-strategy-id") is None
 
 
+def test_a_near_equal_split_still_counts_as_evenly_split():
+    """Three siblings can only sum to 100 as ``33.34/33.33/33.33``. That row is even in
+    every sense that matters, so it gets the strategy and no per-child pinning (issue #63)."""
+    container, _, _ = _render({"type": "horz", "children": [
+        {"id": "a", "size": 33.34}, {"id": "b", "size": 33.33}, {"id": "c", "size": 33.33},
+    ]})
+    row = container.find("zone/zone")
+
+    assert row.get("layout-strategy-id") == "distribute-evenly"
+    assert [child.get("is-fixed") for child in row.findall("zone")] == [None, None, None]
+
+
+def test_a_proportioned_split_pins_every_child_but_the_flex_one():
+    """Desktop keeps a hand-proportioned split by writing each child's size in px along the
+    flow axis; without it the stored w/h is re-flowed away on open (issue #63)."""
+    container, _, _ = _render({"type": "horz", "children": [
+        {"id": "side", "size": 25}, {"id": "main", "size": 75},
+    ]})
+    row = container.find("zone/zone")
+    side, main = row.findall("zone")
+
+    assert row.get("layout-strategy-id") is None
+    # 25% of the root's width, inset by the root margin, in px at CANVAS.
+    assert side.get("is-fixed") == "true"
+    assert side.get("fixed-size") == str(round(int(side.get("w")) / zones.ZONE_SPACE * 1366))
+    # The last child flexes, absorbing the rounding remainder - as Desktop leaves it.
+    assert main.get("is-fixed") is None
+    assert main.get("fixed-size") is None
+
+
+def test_a_vertical_split_pins_children_by_height():
+    """The pin is the child's size along the *flow* axis, so a vertical container pins px
+    of height (issue #63)."""
+    container, _, _ = _render({"type": "vert", "children": [
+        {"id": "top", "size": 30}, {"id": "bottom", "size": 70},
+    ]})
+    top = container.find("zone/zone/zone")
+
+    assert top.get("fixed-size") == str(round(int(top.get("h")) / zones.ZONE_SPACE * 768))
+
+
+def test_a_show_hide_child_is_pinned_and_its_sibling_flexes():
+    """A show/hide panel is exactly what must not be the flex child: hiding it would leave
+    the container's slack blank. The uncontrolled sibling takes the reflow (issue #63)."""
+    container, _, _ = _render({"type": "horz", "children": [
+        {"id": "main", "size": 60}, {"id": "panel", "size": 40, "visibility": "Show Panel"},
+    ]})
+    main, panel = container.find("zone/zone").findall("zone")
+
+    assert panel.get("is-fixed") == "true"
+    assert main.get("is-fixed") is None
+
+
 # --- Content ------------------------------------------------------------------
 
 def test_a_worksheet_zone_names_its_sheet_and_reports_it_as_embedded():

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -397,6 +397,20 @@ def test_a_vertical_split_pins_children_by_height():
     assert top.get("fixed-size") == str(round(int(top.get("h")) / zones.ZONE_SPACE * 768))
 
 
+def test_the_biggest_child_flexes_even_when_it_is_not_last():
+    """A hand-built container pins every child but the biggest one - the reference workbook's
+    trend section pins its 40px title row *and* its trailing 22px legend, leaving the chart
+    row between them free. Flexing the trailing strip instead would hand it every pixel the
+    dashboard gains over its minimum size, and the charts would never grow (issue #63)."""
+    container, _, _ = _render({"type": "vert", "children": [
+        {"id": "title", "size": 8}, {"id": "charts", "size": 89}, {"id": "legend", "size": 3},
+    ]})
+    title, charts, legend = container.find("zone/zone").findall("zone")
+
+    assert charts.get("is-fixed") is None
+    assert [title.get("is-fixed"), legend.get("is-fixed")] == ["true", "true"]
+
+
 def test_a_show_hide_child_is_pinned_and_its_sibling_flexes():
     """A show/hide panel is exactly what must not be the flex child: hiding it would leave
     the container's slack blank. The uncontrolled sibling takes the reflow (issue #63)."""


### PR DESCRIPTION
Closes #63.

Desktop discarded the approved container proportions on open — a sidebar specced at 17.14% rendered at ~44%, the left chart cards collapsed to bare titles, and only the two 50/50 rows held their geometry. The zone rectangles were correct; nothing told Tableau to keep them.

## What was wrong

`distribute-evenly` was the only layout strategy the builder ever emitted, and only for children that were *exactly* equal. Every proportioned split (62/38, 17.14/82.86) got no strategy and no fixed sizing, so Desktop re-flowed the containers and threw the stored `w`/`h` away. 29 of the mrrSales v_3 workbook's 31 `layout-flow` containers carried nothing.

## What changed

**`tableau-build` — `skills/tableau-build/scripts/zones.py`**

- A proportioned container now pins each child with `is-fixed="true"` + `fixed-size="<px along the flow axis>"`, leaving one child free to flex.
- The flex child is the **largest** uncontrolled child, not the last. A column's last child is typically a legend strip or a spacer; flexing it handed it every pixel the dashboard gained over its minimum size while the charts stayed at their authored height.
- A visibility-controlled (DZV) child is never the flex child — hiding the only flex child would leave the container's slack blank.
- `EVEN_SPLIT_TOLERANCE = 0.5`: a KPI row authored `33.34 / 33.33 / 33.33` — the only way three near-equal siblings sum to 100 under the spec validator's ±2 rule — now counts as even, keeps `distribute-evenly`, and takes no pins.

**`tableau-spec` — `skills/tableau-spec/scripts/reconcile.py`**

- The layout check flags a container whose largest children are equal but which also holds a smaller sibling (three chart cards beside a 3% legend strip). Tableau holds equal cards equal by distributing the whole *container* evenly, so a stranded group can't be held — wrap it in its own container. `SKILL.md` and the spec template state the rule where the tree is authored.
- Equal siblings *below* the biggest child are not flagged: they're pinned at equal sizes and stay equal, they just don't grow.

## Where the rules come from

Both are read off a hand-built production workbook (untracked, `tests/temp-workbooks-for-tests/zones-and-containers.twb`): every container pins all children but the biggest, the free child is regularly in the middle — its main column pins a 150px KPI row and a 209px bottom section around a flexing 51% trend section, and its trend section pins both the 40px title row and the trailing 22px legend. Equal siblings stay bare under `distribute-evenly`.

## Tests

`tests/test_zones.py` — a near-equal split still counts as even; a proportioned split pins all but the flex child; a vertical split pins by height; the biggest child flexes even when it isn't last; a show/hide child is pinned and its sibling flexes.
`tests/test_spec.py` — a stranded equal group blocks approval; equal siblings under a bigger one don't.

611 passed, including the XSD and legacy-validator checks over the layout-rich zone tree.

## Verified

mrrSales v_3 rebuilt from the corrected spec: sidebar 237px (17.1%), left column 62% flexing, right column 436px (38%) with `distribute-evenly` over its two cards, the three left chart cards under their own `distribute-evenly` wrapper, and `legend-sales-type` pinned at 20px. Awaiting a visual confirmation in Desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)