### PR TITLE
fix(build): a legend is opt-out, and a squeezed view says so (#65)

### DIFF
--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -223,8 +223,12 @@ When one arrives:
   draws it inside the zone out of the sheet's own height, so a short zone (a KPI card) loses
   its number to it. Give every `worksheets[]` entry a `title` — it becomes a text zone above
   the sheet zone — or have the layout place a `text` object beside it; a view with neither
-  gets no header at all. A colour-encoded chart also gets a legend zone below it. Both
-  generated zones stack *inside* the element's own box, so they never disturb its siblings.
+  gets no header at all. A colour-encoded chart also gets a legend zone below it — set
+  `"legend": false` on the entry to suppress it. Both generated zones stack *inside* the
+  element's own box, so they never disturb its siblings — and they are *fixed* heights (30px +
+  22px), so a short box pays them in full: a ~70px KPI card is left ~17px of invisible number.
+  The build logs a `[WARN]` when that happens; a KPI card wants semantic colour and
+  `"legend": false`, and its header from a `text` object in the layout.
 - **Field labels are off on every sheet.** They repeat what the zone's header already says
   and cost the chart a whole band of the sheet.
 - **The dashboard is interactive** (CONTRACT.md §6). An `actions` entry of type `filter`

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -32,6 +32,14 @@ leave.
 a `worksheets[]` entry without a `title` (or a `text` object placed beside it in the tree)
 shows up with no header at all.
 
+**Watch what the generated zones cost a short element.** A `title` adds a fixed 30px header
+row inside the element's own box and a `color` encoding adds a fixed 22px legend below it —
+52px the view never gets back. On a ~70px KPI card that leaves ~17px and the number is
+invisible, so the build logs a `[WARN]` naming the element. The **KPI-card pattern** is
+semantic colour with no key: colour the card by an `up`/`down`/`flat` direction field and set
+`"legend": false`, then either drop `title` for a `text` object header in the layout or give
+the element a taller box.
+
 **Every leaf zone must be filled** by exactly one worksheet or one `objects` entry — an
 unfilled zone would build an empty container. A *mapped container* (a node with both an `id`
 and `children`, e.g. a DZV panel) is filled by its children and needs no entry of its own.
@@ -101,6 +109,7 @@ On `chart_type: "text"` the same encoding is the KPI card's big number instead.
 | `number_formats` | `[{"field": "revenue", "format": "$#,##0"}]` | The field's number format, emitted twice: as this sheet's cell format *and* as the datasource column's `default-format`, which is what Desktop reads for mark labels and axis ticks. One format per field per datasource — on a conflict the first worksheet wins and a `[WARN]` is logged. |
 | `reference_lines` | `[{"field": "revenue", "aggregation": "sum", "formula": "average", "scope": "per-table", "label": "<Computation>: <Value>"}]` | A line drawn at an aggregate of the measure. `formula` from `constant`/`total`/`sum`/`min`/`max`/`average`/`median`/`quantiles`/`percentile`/`stdev`/`confidence`/`medianconfidence` (default `average`); `scope` from `per-cell`/`per-pane`/`per-table` (default `per-table`). A `label` string is used verbatim; without one, `label_type` from `none`/`automatic`/`value`/`computation`/`custom` (default `computation`). |
 | `title` | `"Revenue by region"` | Puts a styled text zone above the sheet's zone in the dashboard and suppresses the sheet's own title. Omit to keep Tableau's sheet title. |
+| `legend` | `false` | Suppresses the generated dashboard legend zone. A colour-encoded chart gets a 22px legend strip below its sheet by default; `false` drops it and the sheet reclaims the height. The sheet's own right-edge legend card is unaffected. |
 | `fit` | `"entire-view"` | How the sheet fills its zone: `entire-view` (the default), `standard`, `fit-width`, `fit-height`. |
 | `format` | `{"shading": "#FFFFFF", "borders": "none", "gridlines": "#E5E8E8", "zero_lines": "none", "align": "center", "vertical_align": "top"}` | Format Shading / Borders / Lines / Alignment. Every colour is a `#rrggbb`; `borders`, `gridlines` and `zero_lines` also take `"none"` to turn the border or line off. `align` is `left`/`center`/`right`, `vertical_align` is `top`/`center`/`bottom`. |
 

--- a/skills/tableau-build/scripts/manifest.py
+++ b/skills/tableau-build/scripts/manifest.py
@@ -691,6 +691,15 @@ def _validate_modifiers(label: str, worksheet: dict, errors: list[str]) -> None:
                         f"'{value}' (expected one of: {', '.join(sorted(allowed))})"
                     )
 
+    # 'legend' opts out of the generated dashboard legend zone (issue #65). A truthy string
+    # like "false" would read as opt-in, so only a real boolean is accepted.
+    legend = worksheet.get("legend")
+    if legend is not None and not isinstance(legend, bool):
+        errors.append(
+            f"{label}: 'legend' must be true or false (it suppresses the generated "
+            f"dashboard legend zone); got {legend!r}"
+        )
+
     sort = worksheet.get("sort")
     if isinstance(sort, dict):
         order = sort.get("order")

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -653,12 +653,17 @@ def _dashboard_leaves(
             continue
         # Only the colour legend is placed in the dashboard; size/shape keys stay on the
         # worksheet's own right edge, where they do not compete for the element's box.
-        legend = next(
-            (zones.Legend(reference, pane_id)
-             for card_type, reference, pane_id in worksheet.legend_cards(plan)
-             if card_type == "color"),
-            None,
-        )
+        # 'legend: false' opts out entirely - a KPI card coloured by a semantic up/down field
+        # needs the colour but not the 22px key, which would eat its number (issue #65). The
+        # sheet's own right-edge legend card is unaffected either way.
+        legend = None
+        if entry.get("legend") is not False:  # absent means the default: keep the legend
+            legend = next(
+                (zones.Legend(reference, pane_id)
+                 for card_type, reference, pane_id in worksheet.legend_cards(plan)
+                 if card_type == "color"),
+                None,
+            )
         # First claimant wins: two views on one zone is a manifest bug, and picking the
         # later one would silently move the analyst's chart.
         leaves.setdefault(element_id, zones.Leaf(

--- a/skills/tableau-build/scripts/zones.py
+++ b/skills/tableau-build/scripts/zones.py
@@ -22,12 +22,15 @@ a button and a standalone legend still reserve their box as an empty zone - see
 
 from __future__ import annotations
 
+import logging
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from typing import NamedTuple, Optional
 
 # For DesignTokens only; :mod:`worksheet` does not import this module, so no cycle.
 from worksheet import DesignTokens
+
+logger = logging.getLogger(__name__)
 
 #: Dashboard zones live in a 100,000 x 100,000 virtual coordinate space, whatever the canvas.
 ZONE_SPACE = 100000
@@ -43,6 +46,13 @@ ZONE_MARGIN = "4"
 #: Height in px of a generated title text zone and of a colour legend zone.
 TITLE_HEIGHT_PX = 30
 LEGEND_HEIGHT_PX = 22
+
+#: The share of its own box a view must keep once the generated title and legend zones
+#: are stacked inside it. Below this the view is a stub - a 70px KPI card losing 52px to
+#: a header and a legend renders ~17px of number (issue #65) - so the build warns. The
+#: fixed zones only cross this line on a box under ~90px, which is exactly the KPI-card
+#: case; a 400px chart box spending the same 52px never trips it.
+VIEW_SQUEEZE_FLOOR = 0.4
 
 #: The share of the header row's width the title text takes. The rest is a blank spacer, so
 #: dropping a filter or a button into the row in Desktop needs no restructuring - which is
@@ -159,7 +169,8 @@ class Leaf:
             view zone has no header at all - the sheet's own title never renders on a
             dashboard (see :meth:`_ZoneWriter._content`).
         text: The text a ``text`` object zone displays.
-        legend: The colour legend to stack below the content, or ``None`` for no legend.
+        legend: The colour legend to stack below the content, or ``None`` for no legend -
+            which is what the manifest's ``legend: false`` resolves to (issue #65).
         param: What a ``filter`` / ``parameter`` zone controls - a qualified column-instance
             (``[federated.x].[none:region:nk]``) or a qualified parameter
             (``[Parameters].[Top N]``). Without it the kind falls back to an empty zone.
@@ -483,6 +494,7 @@ class _ZoneWriter:
         title_height = min(title_height, box.h)
         legend_height = min(legend_height, box.h - title_height)
         content_height = box.h - title_height - legend_height
+        self._warn_if_squeezed(label, box.h, title_height, legend_height, content_height)
         cursor = box.y
         if title_height:
             self._title(wrapper, leaf.title, Box(box.x, cursor, box.w, title_height), label)
@@ -494,6 +506,41 @@ class _ZoneWriter:
                 wrapper, leaf, Box(box.x, cursor, box.w, legend_height), label
             )
         render_zone_style(wrapper, ZONE_MARGIN)
+
+    def _warn_if_squeezed(
+        self, label: str, box_height: int, title_height: int, legend_height: int,
+        content_height: int,
+    ) -> None:
+        """Warn when the generated zones leave the view too little of the element's box.
+
+        The header and the legend are *fixed* heights, so a short zone pays them in full and
+        the view keeps the remainder - which on a KPI card can be a few px of invisible
+        number. The geometry is the analyst's call, so this is a note, not an error.
+
+        Args:
+            label: The element id (or tree path) naming the squeezed element.
+            box_height: The element's own box height, in zone units.
+            title_height: What the generated header takes, in zone units.
+            legend_height: What the generated legend takes, in zone units.
+            content_height: What is left for the view, in zone units.
+        """
+        if content_height >= box_height * VIEW_SQUEEZE_FLOOR:
+            return
+        consumers = [
+            name for name, height in (("header", title_height), ("legend", legend_height))
+            if height
+        ]
+        remedy = (
+            "'legend: false' on its worksheets[] entry, or a 'text' object header in the "
+            "layout" if legend_height else
+            "a 'text' object header in the layout instead of the element's 'title'"
+        )
+        logger.warning(
+            f"[WARN] {label}: a {self._pixels_y(box_height)}px zone loses "
+            f"{self._pixels_y(title_height + legend_height)}px to its generated "
+            f"{'+'.join(consumers)}, leaving {self._pixels_y(content_height)}px for the "
+            f"view; consider {remedy}"
+        )
 
     def _content(
         self, parent: ET.Element, leaf: Leaf, box: Box, label: str

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1650,3 +1650,21 @@ def test_router_reports_done_after_build_is_approved(tmp_path):
     assert build.commit(tmp_path).ok is True
 
     assert route.compute_next_step(tmp_path).is_done is True
+
+
+def test_a_non_boolean_legend_key_is_rejected():
+    """"legend": "false" is a truthy string - reading it as opt-in would silently keep the
+    zone the analyst asked to drop (issue #65)."""
+    document = _manifest()
+    document["worksheets"][0]["legend"] = "false"
+
+    assert any("'legend' must be true or false" in error for error in _errors(document))
+
+
+def test_a_boolean_legend_key_is_accepted():
+    """Both values are legal; false is the opt-out, true is the documented default."""
+    for value in (True, False):
+        document = _manifest()
+        document["worksheets"][0]["legend"] = value
+
+        assert _errors(document) == []

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -743,3 +743,71 @@ def test_the_layout_rich_workbook_passes_the_xsd(layout_rich_workbook, tmp_path)
     )
 
     assert not [f"line {error.line}: {error.message}" for error in errors]
+
+
+def test_a_short_box_losing_most_of_itself_to_generated_zones_warns(caplog):
+    """A 30px header + 22px legend inside a ~70px KPI box leaves ~17px of number (issue #65)."""
+    root = {"type": "vert", "children": [
+        {"id": "kpi-net-new-mrr", "size": 8}, {"id": "rest", "size": 92},
+    ]}
+
+    with caplog.at_level("WARNING"):
+        _render(
+            root,
+            {"kpi-net-new-mrr": zones.Leaf(
+                worksheet="Net New MRR", title="Net New MRR",
+                legend=zones.Legend("[c]", "0"), single_cell=True,
+            )},
+            canvas={"width": 1366, "height": 900},
+        )
+
+    assert "kpi-net-new-mrr" in caplog.text
+    assert "legend: false" in caplog.text
+
+
+def test_a_tall_box_with_the_same_generated_zones_is_silent(caplog):
+    """52px of header and legend out of a 400px chart box is normal, not a squeeze."""
+    root = {"type": "vert", "children": [
+        {"id": "chart-trend", "size": 50}, {"id": "rest", "size": 50},
+    ]}
+
+    with caplog.at_level("WARNING"):
+        _render(
+            root,
+            {"chart-trend": zones.Leaf(
+                worksheet="Trend", title="Trend", legend=zones.Legend("[c]", "0"),
+            )},
+            canvas={"width": 1366, "height": 900},
+        )
+
+    assert caplog.text == ""
+
+
+def test_legend_false_suppresses_the_generated_legend_zone():
+    """A KPI card coloured by a semantic up/down field needs the colour, not the key (#65)."""
+    import copy
+    import manifest
+    import twb as twb_module
+
+    document = copy.deepcopy(LAYOUT_RICH_MANIFEST)
+    document["worksheets"][0]["legend"] = False
+
+    assert manifest.validate_manifest(document, DATA_MODEL, TARGET_VERSION) == []
+
+    root = ET.fromstring(twb_module.render_workbook(document, DATA_MODEL, CSV_HEADERS))
+    wrapper = next(
+        zone for zone in root.find("dashboards/dashboard/zones").iter("zone")
+        if zone.get("friendly-name") == "V-chart-revenue"
+    )
+    parts = wrapper.findall("zone")
+
+    assert [zone.get("friendly-name") for zone in parts] == [
+        "H-chart-revenue header", "chart-revenue",  # no legend zone
+    ]
+    # The sheet reclaims the legend's height: header + view tile the wrapper exactly.
+    assert sum(int(zone.get("h")) for zone in parts) == int(wrapper.get("h"))
+    # The sheet's own right-edge legend card is untouched - only the dashboard zone is gone.
+    right_edge = root.find(
+        "windows/window[@name='Revenue by Region']/cards/edge[@name='right']"
+    )
+    assert right_edge is not None


### PR DESCRIPTION
Closes #65.

A KPI card in a short zone rendered as a ~17px stub — the number was invisible. In the mrrSales v_3 workbook the KPI element's box is ~70px; the builder stacked a fixed **30px** header zone and a fixed **22px** colour legend *inside* it, leaving the sheet ~17px of the 900px canvas.

PR #78 (issue #63) did not touch this: it fixed container **proportions** — pinning children with `is-fixed`/`fixed-size` so Desktop keeps the authored split. #65 is about what the generated zones cost an element *within its own box*, which that PR left alone.

## What was wrong

`skills/tableau-build/scripts/zones.py` gives a `worksheets[]` entry with a `title` a fixed-height header and a colour-encoded sheet a fixed-height legend, both stacked inside the element's box (by design, so siblings aren't disturbed). Neither generator checked what remained for the view, and the manifest had **no way to opt out of the legend** — any `color` encoding forced one. A KPI card coloured by a semantic direction field (`up`/`down`/`flat`) is exactly the case where the colour matters and the key is pure cost.

## What changed

**`tableau-build` — `scripts/twb.py`, `scripts/manifest.py`**

- `worksheets[].legend: false` suppresses the generated dashboard legend zone for that sheet, and the sheet zone reclaims the 22px. Absent means the documented default, so no existing manifest changes behaviour. This mirrors `title` (omit → no header) and adds no new vocabulary.
- The sheet's **own right-edge legend card** is unaffected either way — only the dashboard zone is dropped.
- `legend` must be a real boolean. The string `"false"` is truthy and would have read as opt-in, silently keeping the zone the analyst asked to drop.

**`tableau-build` — `scripts/zones.py`**

- `VIEW_SQUEEZE_FLOOR = 0.4`: when the fixed zones leave the view under 40% of its box, the build logs a `[WARN]` naming the element, what consumes it in px, and the remedy:

  ```
  [WARN] kpi-net-new-mrr: a 71px zone loses 52px to its generated header+legend,
  leaving 19px for the view; consider 'legend: false' on its worksheets[] entry,
  or a 'text' object header in the layout
  ```

  A note, not an error — the geometry is the analyst's call. Nothing reaches the `.twb`; it goes to stderr through the same `logger.warning` channel as the existing number-format `[WARN]`, so no plumbing through `RenderedZones` → `twb` → `build`.
- One threshold, not two: the generated zones are constant 30px + 22px, so the ratio only drops below 40% on a box under ~90px — exactly the KPI-card case. A 400px chart box spending the same 52px never trips it, which is why the issue's second `< ~2500 units` bound was redundant.

## Docs

- `BUILD-MANIFEST-TEMPLATE.md` — `legend` in the worksheet modifier table, and the KPI-card pattern (semantic colour, no key) beside the existing header rule.
- `tableau-build/SKILL.md` — the two generated zones are *fixed* heights, and what that costs a short box.

## Tests

`tests/test_zones.py` — `legend: false` emits no legend zone end to end (through `render_workbook`, asserting the wrapper's children tile it exactly and the sheet's right-edge card survives); the squeeze warning fires on a short titled+coloured box and is silent on a tall one.
`tests/test_build.py` — a non-boolean `legend` is rejected, both booleans accepted.

**616 passed**, including the XSD and legacy-validator checks over the layout-rich zone tree. Verified the existing fixtures emit no `[WARN]`, so the guard doesn't misfire on the demo spec.

## Not yet verified in Desktop

The XML shape is attested — a fixed 30px title above a free sheet under a `layout-flow` wrapper is the pattern PR #78 read off the hand-built workbook — so this is not a fidelity question. What no test can settle is the issue's acceptance: whether ~41px of card actually renders the number. That needs a mrrSales rebuild with `legend: false` on the KPI entries at a **2025.1** target (a `2026.1+` build writes document version 26.1 and won't open on Desktop 2025.1.10). If the number is still clipped, the remaining cost is the 30px `title` — dropping it for a `text` object header distinguishes "the legend was the problem" from "the box is simply too short".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
