### PR TITLE
fix(brand,build): a font family token is a machine value (#66)

### DIFF
--- a/skills/tableau-brand/SKILL.md
+++ b/skills/tableau-brand/SKILL.md
@@ -110,7 +110,7 @@ two points below; do not hand-edit `STATE.md` yourself.
 | section | required? | what goes there |
 |---------|-----------|-----------------|
 | `## Colors` | **required** | Backgrounds, accent bars, a cohesive ≤5-color series palette, text colors. |
-| `## Typography` | **required** | Font family + sizes/weights for title, chart title, labels, tooltips. `Font family` is a **machine value** - `tableau-build` copies it into every text run's `fontname=`, so write the family name alone (`Tableau`, not `Tableau (Medium / Light - native)`) and keep weights/availability notes in prose. |
+| `## Typography` | **required** | Font family + sizes/weights for title, chart title, labels, tooltips. `Font family` is a **machine value** - `tableau-build` copies it into every text run's `fontname=`, so it must be one installed family, weight included: `Tableau Bold` \| `Tableau Book` \| `Tableau Light` \| `Tableau Medium` \| `Tableau Regular` \| `Tableau Semibold`. There is no font called plain `Tableau`; keep availability notes in prose, not in the value. |
 | `## Spacing` | **required** | Card padding, section spacing, container margins, accent-bar height. |
 | `## Fallback Decisions` | **required** | Every value pulled from a Tableau default, flagged as guessed (or "None"). |
 | `## Source` | optional | Which branding source produced these tokens. |

--- a/skills/tableau-brand/SKILL.md
+++ b/skills/tableau-brand/SKILL.md
@@ -110,7 +110,7 @@ two points below; do not hand-edit `STATE.md` yourself.
 | section | required? | what goes there |
 |---------|-----------|-----------------|
 | `## Colors` | **required** | Backgrounds, accent bars, a cohesive ≤5-color series palette, text colors. |
-| `## Typography` | **required** | Font family + sizes/weights for title, chart title, labels, tooltips. |
+| `## Typography` | **required** | Font family + sizes/weights for title, chart title, labels, tooltips. `Font family` is a **machine value** - `tableau-build` copies it into every text run's `fontname=`, so write the family name alone (`Tableau`, not `Tableau (Medium / Light - native)`) and keep weights/availability notes in prose. |
 | `## Spacing` | **required** | Card padding, section spacing, container margins, accent-bar height. |
 | `## Fallback Decisions` | **required** | Every value pulled from a Tableau default, flagged as guessed (or "None"). |
 | `## Source` | optional | Which branding source produced these tokens. |

--- a/skills/tableau-brand/references/DESIGN-TOKENS-TEMPLATE.md
+++ b/skills/tableau-brand/references/DESIGN-TOKENS-TEMPLATE.md
@@ -14,7 +14,7 @@
 
 ## Typography
 
-- **Font family**: [font]
+- **Font family**: [one installed family, weight included - e.g. Tableau Book]
 - **Dashboard title**: [size]px, [weight], [hex]
 - **Chart title**: [size]px, [weight], [hex]   *(a Text object, not the worksheet's built-in header — see Constraints)*
 - **Filter / section labels**: [size]px, [weight], [hex]

--- a/skills/tableau-brand/references/tableau-design-tokens.md
+++ b/skills/tableau-brand/references/tableau-design-tokens.md
@@ -15,7 +15,7 @@ read by the skill at authoring time only; it is never a handoff artifact.
 Use the native **Tableau** font family (it ships with Tableau Desktop, so the
 workbook renders identically without installing anything):
 
-- **Font family**: Tableau (Tableau Bold / Tableau Medium / Tableau Light)
+- **Font family**: Tableau
 - **Dashboard title**: 28px, Tableau Bold, `#1c2833`
 - **Chart title**: 15px, Tableau Medium, `#1c2833`
 - **Filter / section labels**: 12px, Tableau Medium, `#5d6d7e`

--- a/skills/tableau-brand/references/tableau-design-tokens.md
+++ b/skills/tableau-brand/references/tableau-design-tokens.md
@@ -12,10 +12,19 @@ read by the skill at authoring time only; it is never a handoff artifact.
 
 ## Typography
 
-Use the native **Tableau** font family (it ships with Tableau Desktop, so the
-workbook renders identically without installing anything):
+Use the native **Tableau** fonts (they ship with Tableau Desktop, so the workbook
+renders identically without installing anything). The weight is part of the family
+name - there is no font called plain "Tableau" - and the six installed families are:
 
-- **Font family**: Tableau
+`Tableau Bold` | `Tableau Book` | `Tableau Light` | `Tableau Medium` |
+`Tableau Regular` | `Tableau Semibold`
+
+Every font value below (and in the token file) must be one of those names verbatim:
+`tableau-build` copies `Font family` into every text run's `fontname=` and into the
+worksheet's `font-family` format, so a name Desktop cannot resolve loses the whole
+brand typography silently.
+
+- **Font family**: Tableau Book
 - **Dashboard title**: 28px, Tableau Bold, `#1c2833`
 - **Chart title**: 15px, Tableau Medium, `#1c2833`
 - **Filter / section labels**: 12px, Tableau Medium, `#5d6d7e`

--- a/skills/tableau-brand/scripts/brand.py
+++ b/skills/tableau-brand/scripts/brand.py
@@ -113,6 +113,16 @@ _FONT_FAMILY_BULLET = re.compile(r"^-\s*\**\s*font family\s*\**\s*:\s*(.+)$", re
 #: real family names use. A parenthetical, an em-dash or a slash means the value is prose.
 _FONT_FAMILY = re.compile(r"[A-Za-z0-9][A-Za-z0-9 .'&+-]*")
 
+#: The Tableau families that actually ship with Desktop (mirror of
+#: ``tableau-build``'s ``worksheet.TABLEAU_FONTS``; the two skills are self-contained,
+#: CONTRACT.md §7). There is no font called plain "Tableau" - the weight is part of the
+#: family name - so a value like "Tableau" or "Tableau Sans" resolves to nothing and
+#: Desktop falls back silently on every run.
+TABLEAU_FONTS: tuple[str, ...] = (
+    "Tableau Bold", "Tableau Book", "Tableau Light",
+    "Tableau Medium", "Tableau Regular", "Tableau Semibold",
+)
+
 
 def parse_statuses(text: str) -> dict[str, str]:
     """Parse the per-step statuses out of a STATE.md manifest.
@@ -201,12 +211,15 @@ def validate_design_tokens(text: str) -> tuple[bool, list[str], list[str]]:
 def font_family_problem(text: str) -> Optional[str]:
     """Report a ``Font family`` token value that is prose rather than a font name.
 
-    ``tableau-build`` puts this value straight into every text run's ``fontname=``, so an
-    annotated value like ``Tableau (Medium / Light - native, no webfont)`` names no font
-    Windows can resolve and Desktop silently falls back on every title, label and tooltip
-    (issue #66). Build sanitizes what it can; this catches it where it is authored, while
-    the analyst can still say which family they meant. An unfilled ``[font]`` placeholder
-    and a file with no such bullet are both fine - other checks own those.
+    ``tableau-build`` puts this value straight into every text run's ``fontname=`` and into
+    the worksheet's ``font-family`` format, so an annotated value like ``Tableau (Medium /
+    Light - native, no webfont)`` names no font Windows can resolve and Desktop silently
+    falls back on every title, label and tooltip (issue #66). A bare ``Tableau`` fails the
+    same way: the weight is part of the family name, so only the six
+    :data:`TABLEAU_FONTS` exist. Build sanitizes what it can; this catches it where it is
+    authored, while the analyst can still say which family they meant. An unfilled
+    ``[font]`` placeholder and a file with no such bullet are both fine - other checks own
+    those.
 
     Args:
         text: The contents of a ``DESIGN-TOKENS.md`` file.
@@ -221,12 +234,13 @@ def font_family_problem(text: str) -> Optional[str]:
         value = match.group(1).strip().strip("`*")
         if not value or value.startswith("["):  # an unfilled template placeholder
             continue
-        if not _FONT_FAMILY.fullmatch(value):
+        tableau_font = value.lower().startswith("tableau")
+        if not _FONT_FAMILY.fullmatch(value) or (tableau_font and value not in TABLEAU_FONTS):
             return (
-                f"'Font family' is {value!r}, which is not a font family Tableau can "
-                f"resolve - it becomes every text run's fontname= verbatim. Write the "
-                f"family name only (e.g. 'Tableau'); put weights and availability notes "
-                f"in prose."
+                f"'Font family' is {value!r}, which is not a font family Desktop can "
+                f"resolve - it becomes every text run's fontname= verbatim. Name one "
+                f"family, weight included ({' | '.join(TABLEAU_FONTS)}), and put "
+                f"availability notes in prose."
             )
     return None
 

--- a/skills/tableau-brand/scripts/brand.py
+++ b/skills/tableau-brand/scripts/brand.py
@@ -106,6 +106,13 @@ SOURCE_NONE = "none"               # nothing -> run the brand interview (<=10 Qs
 # any trailing "#"s): "## Colors" -> "Colors".
 _HEADING_LINE = re.compile(r"^#{1,6}\s+(.*?)\s*#*\s*$")
 
+#: The ``- **Font family**:`` bullet ``tableau-build`` reads to style every text run.
+_FONT_FAMILY_BULLET = re.compile(r"^-\s*\**\s*font family\s*\**\s*:\s*(.+)$", re.IGNORECASE)
+
+#: What a font family Windows can resolve looks like - letters, digits, and the punctuation
+#: real family names use. A parenthetical, an em-dash or a slash means the value is prose.
+_FONT_FAMILY = re.compile(r"[A-Za-z0-9][A-Za-z0-9 .'&+-]*")
+
 
 def parse_statuses(text: str) -> dict[str, str]:
     """Parse the per-step statuses out of a STATE.md manifest.
@@ -189,6 +196,39 @@ def validate_design_tokens(text: str) -> tuple[bool, list[str], list[str]]:
         if section.lower() not in headings_blob
     ]
     return (not missing_required, missing_required, missing_recommended)
+
+
+def font_family_problem(text: str) -> Optional[str]:
+    """Report a ``Font family`` token value that is prose rather than a font name.
+
+    ``tableau-build`` puts this value straight into every text run's ``fontname=``, so an
+    annotated value like ``Tableau (Medium / Light - native, no webfont)`` names no font
+    Windows can resolve and Desktop silently falls back on every title, label and tooltip
+    (issue #66). Build sanitizes what it can; this catches it where it is authored, while
+    the analyst can still say which family they meant. An unfilled ``[font]`` placeholder
+    and a file with no such bullet are both fine - other checks own those.
+
+    Args:
+        text: The contents of a ``DESIGN-TOKENS.md`` file.
+
+    Returns:
+        A fix-it message, or None when every ``Font family`` bullet names a font.
+    """
+    for raw_line in text.splitlines():
+        match = _FONT_FAMILY_BULLET.match(raw_line.strip())
+        if not match:
+            continue
+        value = match.group(1).strip().strip("`*")
+        if not value or value.startswith("["):  # an unfilled template placeholder
+            continue
+        if not _FONT_FAMILY.fullmatch(value):
+            return (
+                f"'Font family' is {value!r}, which is not a font family Tableau can "
+                f"resolve - it becomes every text run's fontname= verbatim. Write the "
+                f"family name only (e.g. 'Tableau'); put weights and availability notes "
+                f"in prose."
+            )
+    return None
 
 
 def render_design_tokens_template() -> str:
@@ -572,15 +612,21 @@ def commit(project_dir: Path | str, status: str) -> CommitResult:
                 f"Author it first, or commit '--status skipped' to skip this step "
                 f"(only possible once 'branding/branding.md' exists).",
             )
-        ok, missing_required, missing_recommended = validate_design_tokens(
-            tokens_path.read_text(encoding="utf-8-sig")
-        )
+        tokens_text = tokens_path.read_text(encoding="utf-8-sig")
+        ok, missing_required, missing_recommended = validate_design_tokens(tokens_text)
         if not ok:
             return CommitResult(
                 False,
                 f"'{DESIGN_TOKENS_FILENAME}' is missing required section(s): "
                 f"{', '.join(missing_required)}. Add them and re-run commit.",
                 missing_required=missing_required,
+                missing_recommended=missing_recommended,
+            )
+        font_problem = font_family_problem(tokens_text)
+        if font_problem is not None:
+            return CommitResult(
+                False,
+                f"Cannot approve brand: {font_problem} Fix it and re-run commit.",
                 missing_recommended=missing_recommended,
             )
     elif status == "skipped" and not (project_root / BRANDING_SPEC).exists():

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -19,6 +19,7 @@ Everything is pure and stdlib-only: text in, XML elements out, no filesystem.
 
 from __future__ import annotations
 
+import logging
 import re
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field, fields
@@ -27,6 +28,8 @@ from typing import Callable, NamedTuple, Optional
 # A worksheet that reads a parameter has to declare it; :mod:`features` owns what a parameter
 # column looks like and imports nothing back, so no cycle.
 from features import PARAMETERS_DATASOURCE, Parameter, render_parameter_column
+
+logger = logging.getLogger(__name__)
 
 # --- CDATA -------------------------------------------------------------------
 # ponytail: ElementTree cannot emit CDATA, and Tableau *requires* it around field
@@ -76,6 +79,14 @@ DEFAULT_TITLE_SIZE = 12
 DEFAULT_TITLE_COLOR = "#000000"
 DEFAULT_KPI_SIZE = 22
 
+#: A trailing prose annotation on a token value: "Tableau (Medium / Light - native)".
+_FONT_ANNOTATION = re.compile(r"\s*\(.*\)\s*$", re.DOTALL)
+
+#: What a font family Windows can resolve looks like - letters, digits, and the punctuation
+#: real family names use. An em-dash, a slash or a comma-separated stack is prose, and a
+#: prose value reaches Desktop as an unresolvable ``fontname=`` (issue #66).
+_FONT_FAMILY = re.compile(r"[A-Za-z0-9][A-Za-z0-9 .'&+-]*")
+
 _HEX = re.compile(r"#[0-9a-fA-F]{3,8}\b")
 _SIZE = re.compile(r"(\d+)\s*px", re.IGNORECASE)
 
@@ -116,6 +127,37 @@ class DesignTokens:
     kpi_size: int = DEFAULT_KPI_SIZE
     series_colors: tuple[str, ...] = ()
     present: bool = False
+
+
+def _font_family(value: str) -> str:
+    """Reduce a ``- **Font family**:`` token value to a name Desktop can actually resolve.
+
+    The value is authored prose, so it arrives annotated: ``Tableau (Medium / Light - native,
+    no webfont)``. Taken verbatim it becomes every run's ``fontname=``, which Windows cannot
+    resolve, so Desktop silently falls back on every title, label and tooltip and the brand
+    typography is lost with no warning (issue #66). A trailing parenthetical is dropped; if
+    what is left is not a plausible family name, Tableau's own default is used instead.
+    Either change is logged, because the analyst chose that font on purpose.
+
+    Args:
+        value: The bullet's value, already stripped of markdown emphasis.
+
+    Returns:
+        The font family to emit as every ``fontname=``.
+    """
+    family = _FONT_ANNOTATION.sub("", value).strip()
+    if not _FONT_FAMILY.fullmatch(family):
+        logger.warning(
+            f"[WARN] design token 'Font family' is {value!r}, which is not a font family "
+            f"Tableau can resolve; using {DEFAULT_FONT!r}. Write the family name only."
+        )
+        return DEFAULT_FONT
+    if family != value:
+        logger.warning(
+            f"[WARN] design token 'Font family' {value!r} carries a prose annotation; "
+            f"emitting fontname={family!r}."
+        )
+    return family
 
 
 def parse_design_tokens(tokens_text: str) -> DesignTokens:
@@ -159,7 +201,7 @@ def parse_design_tokens(tokens_text: str) -> DesignTokens:
             continue
 
         if label == "font family":
-            font = value.strip("`*")
+            font = _font_family(value.strip("`*"))
         elif label == "chart title":
             size = _SIZE.search(value)
             if size:

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -75,6 +75,16 @@ def cdata(text: str) -> str:
 #: Tableau's own defaults, used for any token DESIGN-TOKENS.md does not carry (and for every
 #: token when the file is absent) - "neutral" means Tableau's look, not an invented one.
 DEFAULT_FONT = "Tableau Book"
+
+#: The Tableau families that actually ship with Desktop. There is no font called plain
+#: "Tableau": the weight is part of the family name, so "Tableau" alone resolves to nothing
+#: and Desktop falls back silently. Real Desktop output writes one of these verbatim - see
+#: ``tests/temp-workbooks-for-tests/zones-and-containers.twb``, whose every run carries
+#: ``fontname='Tableau Medium'``.
+TABLEAU_FONTS: tuple[str, ...] = (
+    "Tableau Bold", "Tableau Book", "Tableau Light",
+    "Tableau Medium", "Tableau Regular", "Tableau Semibold",
+)
 DEFAULT_TITLE_SIZE = 12
 DEFAULT_TITLE_COLOR = "#000000"
 DEFAULT_KPI_SIZE = 22
@@ -135,9 +145,11 @@ def _font_family(value: str) -> str:
     The value is authored prose, so it arrives annotated: ``Tableau (Medium / Light - native,
     no webfont)``. Taken verbatim it becomes every run's ``fontname=``, which Windows cannot
     resolve, so Desktop silently falls back on every title, label and tooltip and the brand
-    typography is lost with no warning (issue #66). A trailing parenthetical is dropped; if
-    what is left is not a plausible family name, Tableau's own default is used instead.
-    Either change is logged, because the analyst chose that font on purpose.
+    typography is lost with no warning (issue #66). A trailing parenthetical is dropped; what
+    is left has to be a font family - and for Tableau's own type that means one of
+    :data:`TABLEAU_FONTS`, weight included, because no font is named plain "Tableau". Anything
+    else falls back to :data:`DEFAULT_FONT`. Either change is logged, because the analyst
+    chose that font on purpose.
 
     Args:
         value: The bullet's value, already stripped of markdown emphasis.
@@ -146,10 +158,12 @@ def _font_family(value: str) -> str:
         The font family to emit as every ``fontname=``.
     """
     family = _FONT_ANNOTATION.sub("", value).strip()
-    if not _FONT_FAMILY.fullmatch(family):
+    tableau_font = family.lower().startswith("tableau")
+    if not _FONT_FAMILY.fullmatch(family) or (tableau_font and family not in TABLEAU_FONTS):
         logger.warning(
             f"[WARN] design token 'Font family' is {value!r}, which is not a font family "
-            f"Tableau can resolve; using {DEFAULT_FONT!r}. Write the family name only."
+            f"Desktop can resolve; using {DEFAULT_FONT!r}. Name one family, weight "
+            f"included: {' | '.join(TABLEAU_FONTS)}."
         )
         return DEFAULT_FONT
     if family != value:

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -79,8 +79,9 @@ DEFAULT_FONT = "Tableau Book"
 #: The Tableau families that actually ship with Desktop. There is no font called plain
 #: "Tableau": the weight is part of the family name, so "Tableau" alone resolves to nothing
 #: and Desktop falls back silently. Real Desktop output writes one of these verbatim - see
-#: ``tests/temp-workbooks-for-tests/zones-and-containers.twb``, whose every run carries
-#: ``fontname='Tableau Medium'``.
+#: ``skill/tableau-dashboard-creator/examples/top-level-workbook-example.twb``, whose runs
+#: carry ``fontname='Tableau Medium'`` and ``fontname='Tableau Light'`` and never a bare
+#: ``Tableau``.
 TABLEAU_FONTS: tuple[str, ...] = (
     "Tableau Bold", "Tableau Book", "Tableau Light",
     "Tableau Medium", "Tableau Regular", "Tableau Semibold",

--- a/tests/test_brand.py
+++ b/tests/test_brand.py
@@ -233,9 +233,20 @@ def test_font_family_prose_value_is_named():
     assert "Font family" in problem
 
 
+def test_a_bare_tableau_is_named():
+    """Tableau ships no font called plain 'Tableau' - the weight is part of the family name
+    (Bold / Book / Light / Medium / Regular / Semibold), so a bare 'Tableau' resolves to
+    nothing in Desktop and the message has to say which names are real."""
+    problem = brand.font_family_problem("- **Font family**: Tableau\n")
+
+    assert problem is not None
+    assert "Tableau Medium" in problem
+
+
 def test_a_plain_font_family_has_no_problem():
-    """The normal case, the unfilled template placeholder, and a file with no typography
-    bullet at all must all pass."""
+    """A real Tableau family, a non-Tableau family, the unfilled template placeholder, and a
+    file with no typography bullet at all must all pass."""
+    assert brand.font_family_problem("- **Font family**: Tableau Medium\n") is None
     assert brand.font_family_problem("- **Font family**: Segoe UI\n") is None
     assert brand.font_family_problem("- **Font family**: [font]\n") is None
     assert brand.font_family_problem("no typography section here") is None

--- a/tests/test_brand.py
+++ b/tests/test_brand.py
@@ -222,6 +222,31 @@ def test_validate_tokens_allows_custom_sections_when_refining():
     assert ok is True and missing_required == []
 
 
+def test_font_family_prose_value_is_named():
+    """Issue #66: an annotated font value reaches ``tableau-build`` as a machine identifier
+    and Desktop cannot resolve it. Catch it where it is written, with a fix-it."""
+    problem = brand.font_family_problem(
+        "## Typography\n\n- **Font family**: Tableau (Medium / Light — native)\n"
+    )
+
+    assert problem is not None
+    assert "Font family" in problem
+
+
+def test_a_plain_font_family_has_no_problem():
+    """The normal case, the unfilled template placeholder, and a file with no typography
+    bullet at all must all pass."""
+    assert brand.font_family_problem("- **Font family**: Segoe UI\n") is None
+    assert brand.font_family_problem("- **Font family**: [font]\n") is None
+    assert brand.font_family_problem("no typography section here") is None
+
+
+def test_shipped_reference_font_family_is_machine_usable():
+    """The bundled fallback reference is what the model copies from - issue #66's bad value
+    came straight out of it."""
+    assert brand.font_family_problem(brand.render_fallback_reference()) is None
+
+
 def test_shipped_template_is_schema_complete():
     """The bundled DESIGN-TOKENS-TEMPLATE.md contains the required core."""
     ok, missing_required, _ = brand.validate_design_tokens(brand.render_design_tokens_template())

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -971,9 +971,9 @@ def test_a_prose_annotated_font_family_is_sanitized(caplog):
 def test_a_bare_tableau_is_not_a_family(caplog):
     """Tableau ships six *families* - Bold, Book, Light, Medium, Regular, Semibold - and no
     font called plain 'Tableau'. The weight is part of the name, so a bare 'Tableau' resolves
-    to nothing (verified against Desktop output in
-    tests/temp-workbooks-for-tests/zones-and-containers.twb, which carries
-    fontname='Tableau Medium')."""
+    to nothing (verified against Desktop's own output in
+    skill/tableau-dashboard-creator/examples/top-level-workbook-example.twb, which carries
+    fontname='Tableau Medium' and fontname='Tableau Light')."""
     with caplog.at_level("WARNING"):
         tokens = worksheet.parse_design_tokens("## Typography\n\n- **Font family**: Tableau\n")
 

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -953,6 +953,44 @@ def test_an_unfilled_token_template_is_ignored():
     assert tokens.font_family == worksheet.DEFAULT_FONT
 
 
+def test_a_prose_annotated_font_family_is_sanitized(caplog):
+    """Issue #66: tableau-brand wrote 'Tableau (Medium / Light - native, no webfont)' into the
+    token value. Taken verbatim it is not a font Windows can resolve, so Desktop silently
+    falls back on every run - the trailing parenthetical is an annotation, not a family
+    name."""
+    with caplog.at_level("WARNING"):
+        tokens = worksheet.parse_design_tokens(
+            "## Typography\n\n"
+            "- **Font family**: Tableau (Medium / Light — native, no webfont)\n"
+        )
+
+    assert tokens.font_family == "Tableau"
+    assert "[WARN]" in caplog.text
+
+
+def test_an_unresolvable_font_family_falls_back(caplog):
+    """Nothing a font can be named survives the strip, so emitting it would hand Desktop a
+    fontname it cannot resolve - Tableau's own default is the honest answer, loudly."""
+    with caplog.at_level("WARNING"):
+        tokens = worksheet.parse_design_tokens(
+            "## Typography\n\n- **Font family**: Helvetica / Arial — whichever\n"
+        )
+
+    assert tokens.font_family == worksheet.DEFAULT_FONT
+    assert "[WARN]" in caplog.text
+
+
+def test_a_clean_font_family_is_left_alone(caplog):
+    """The sanitizer must be silent on the normal case, or the [WARN] means nothing."""
+    with caplog.at_level("WARNING"):
+        tokens = worksheet.parse_design_tokens(
+            "## Typography\n\n- **Font family**: Segoe UI\n"
+        )
+
+    assert tokens.font_family == "Segoe UI"
+    assert caplog.text == ""
+
+
 def test_style_rules_are_alphabetical_by_element():
     """Tableau Desktop rewrites them alphabetically on save; emitting any other order
     produces a diff the analyst did not make."""

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -956,16 +956,41 @@ def test_an_unfilled_token_template_is_ignored():
 def test_a_prose_annotated_font_family_is_sanitized(caplog):
     """Issue #66: tableau-brand wrote 'Tableau (Medium / Light - native, no webfont)' into the
     token value. Taken verbatim it is not a font Windows can resolve, so Desktop silently
-    falls back on every run - the trailing parenthetical is an annotation, not a family
-    name."""
+    falls back on every run. Stripping the annotation leaves a bare 'Tableau', which is not a
+    family either, so the named default weight is what gets emitted."""
     with caplog.at_level("WARNING"):
         tokens = worksheet.parse_design_tokens(
             "## Typography\n\n"
             "- **Font family**: Tableau (Medium / Light — native, no webfont)\n"
         )
 
-    assert tokens.font_family == "Tableau"
+    assert tokens.font_family == worksheet.DEFAULT_FONT
     assert "[WARN]" in caplog.text
+
+
+def test_a_bare_tableau_is_not_a_family(caplog):
+    """Tableau ships six *families* - Bold, Book, Light, Medium, Regular, Semibold - and no
+    font called plain 'Tableau'. The weight is part of the name, so a bare 'Tableau' resolves
+    to nothing (verified against Desktop output in
+    tests/temp-workbooks-for-tests/zones-and-containers.twb, which carries
+    fontname='Tableau Medium')."""
+    with caplog.at_level("WARNING"):
+        tokens = worksheet.parse_design_tokens("## Typography\n\n- **Font family**: Tableau\n")
+
+    assert tokens.font_family == worksheet.DEFAULT_FONT
+    assert "[WARN]" in caplog.text
+
+
+def test_a_real_tableau_family_passes(caplog):
+    """The weight-bearing families are exactly what Desktop writes - never rewrite one."""
+    for family in worksheet.TABLEAU_FONTS:
+        with caplog.at_level("WARNING"):
+            tokens = worksheet.parse_design_tokens(
+                f"## Typography\n\n- **Font family**: {family}\n"
+            )
+
+        assert tokens.font_family == family
+        assert caplog.text == ""
 
 
 def test_an_unresolvable_font_family_falls_back(caplog):


### PR DESCRIPTION
Closes #66.

Every text run in the mrrSales v_3 workbook carried
`fontname="Tableau (Medium / Light — native, no webfont)"`. Windows can resolve no
such font, so Desktop fell back silently on every title, tooltip, label and axis —
the whole brand typography lost, with no warning at build time. Two halves owned it:
`tableau-brand` wrote a prose annotation into a machine value and its validator
accepted it; `tableau-build` copied the bullet verbatim into every `fontname=`.

## The fix

**Build (robust half — works on existing token files).** `worksheet._font_family()`
strips a trailing parenthetical, then requires what remains to be a font family.
For Tableau's own type that means one of the six *installed* families — the weight
is part of the name, so there is no font called plain `Tableau`:

```
Tableau Bold | Tableau Book | Tableau Light | Tableau Medium | Tableau Regular | Tableau Semibold
```

Anything else falls back to `DEFAULT_FONT` (`Tableau Book`) and logs `[WARN]`, so the
analyst sees what will actually be emitted. Non-Tableau families (`Segoe UI`) are
unpoliced, as before.

**Brand (prevention half).** `brand.font_family_problem()` catches the same thing where
it is authored; `commit --status approved` refuses with a fix-it naming the six valid
families. Unfilled `[font]` placeholders and files without the bullet still pass.

**The origin.** The shipped fallback reference was itself the source of the bad value —
`- **Font family**: Tableau (Tableau Bold / Tableau Medium / Tableau Light)`. It now names
the six installed families, states that the weight is part of the name, and defaults to
`Tableau Book`. The template placeholder and the SKILL.md schema row say the same.

## Why these six names

`skill/tableau-dashboard-creator/examples/top-level-workbook-example.twb` is real Desktop
output, and it writes the weight into the family name at both sites this plugin generates:

```xml
<run bold='true' fontcolor='#181d27' fontname='Tableau Medium' fontsize='22'>
<format attr='font-family' value='Tableau Medium' />
```

84 runs `Tableau Medium`, 8 `Tableau Light`, never a bare `Tableau`.

## Verification

Rebuilt mrrSales v_3 (its token set to `Tableau Medium`, matching the org's own Desktop
workbooks): **64/64 `fontname="Tableau Medium"`**, **8/8
`attr="font-family" value="Tableau Medium"`**, all three validators pass, and the `.twb` is
byte-identical to the pre-fix build apart from those 72 values. Confirmed rendering in
Desktop 2025.1.10.

## Tests

- `tests/test_charts.py` — prose value → `DEFAULT_FONT` + `[WARN]`; bare `Tableau` →
  `DEFAULT_FONT` + `[WARN]`; each of the six families unchanged and silent; `Segoe UI`
  unchanged and silent; an unresolvable value → `DEFAULT_FONT` + `[WARN]`.
- `tests/test_brand.py` — prose value and bare `Tableau` named by the validator with the six
  real names; `Tableau Medium`, `Segoe UI`, the `[font]` placeholder and a bullet-less file
  all pass; the shipped reference is machine-usable.

625 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
