### PR TITLE
fix(build): bind each colour encoding to its own series table (#67)

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -61,7 +61,7 @@ silently un-styles every workbook while both skills still pass their own checks:
 | heading | what `build` does with it |
 |---|---|
 | `## Typography` | The `- **Font family**:` and `- **Chart title**:` bullets become the worksheet font and title run. |
-| `### Chart series colors` | The ordered hex list becomes **every worksheet's colour palette**, emitted as an inline `<color-palette>` on the mark's colour encoding, plus the default mark colour for charts with nothing on Colour. |
+| `### Chart series colors` | The ordered hex list becomes a worksheet's colour palette, emitted as an inline `<color-palette>` on the mark's colour encoding, plus the default mark colour for charts with nothing on Colour. One table per coloured field (each introduced by its field name in backticks) binds each colour encoding to **its own** table, in row order; a field no table names takes the whole list. |
 
 The palette needs **no data member values** — that was the open question that kept it unbuilt.
 A member-bound palette (`<map to='#…'><bucket>"West"</bucket>`) is impossible from a manifest,

--- a/skills/tableau-brand/references/DESIGN-TOKENS-TEMPLATE.md
+++ b/skills/tableau-brand/references/DESIGN-TOKENS-TEMPLATE.md
@@ -38,6 +38,18 @@
 ### Chart series colors
 [Ordered list of hex colors for chart data series.]
 
+[When the dashboard colors by more than one dimension, write one table per colored field
+instead, each introduced by its field name in backticks — `tableau-build` binds each color
+encoding to the table named for its field, and a field no table names falls back to the flat
+list above. Row order is the domain walk order: Tableau pairs the first color with the first
+domain member, so order the rows the way the members will appear (the chart's sort order).]
+
+**`[field_name]`**
+
+| Member | Token | Hex |
+|--------|-------|-----|
+| [member] | [Indigo 700] | `[hex]` |
+
 ### Text
 - Dark (titles): [hex]
 - Medium (labels): [hex]

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -48,7 +48,10 @@ any chart mark labels. Reach for a modifier before reaching for a new chart type
 Styling comes from `DESIGN-TOKENS.md` when the analyst ran `tableau-brand`: its font family,
 chart-title size/colour and ordered `### Chart series colors` are applied to every worksheet
 automatically — the series colours ride along as an inline palette, so no data member values
-are needed. When it is absent, Tableau's own defaults apply and nothing is invented. The
+are needed. When that section carries **one table per coloured field** (each introduced by its
+field name in backticks), each `color` encoding is bound to its own table; a field no table
+names takes the whole list, and the optional worksheet key `"palette": "<field name>"` names a
+table explicitly when the encoding field's name differs. When it is absent, Tableau's own defaults apply and nothing is invented. The
 manifest carries no fonts or brand colours; its per-sheet `format` block covers only sheet
 furniture (borders, lines, shading, alignment).
 

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -143,7 +143,8 @@ colour encoding carries an inline `<color-palette>` listing the brand's colours 
 and Tableau walks the field's domain against them exactly as it does with its own default 10.
 So:
 
-- a **dimension** on `color` (a stacked bar, a pie, a treemap) takes the whole ordered palette;
+- a **dimension** on `color` (a stacked bar, a pie, a treemap) takes an ordered palette — **its
+  own**, when the tokens file carries a series table named for that field (see below);
 - a **measure** on `color` (a filled map, a heatmap) is a continuous ramp, and gets the first
   and last brand colours as its low and high ends;
 - a `dual-axis` / `combo` chart is coloured by the built-in Measure Names and takes the
@@ -156,6 +157,23 @@ So:
 Tokens with no `### Chart series colors` section leave Tableau's default 10 in place. That
 heading is required by `tableau-brand`'s validator precisely because `build` binds to its name
 (CONTRACT.md §1).
+
+### One table per coloured field
+
+A dashboard that colours by more than one dimension gets one series table per field under that
+heading, each introduced by its field name in backticks (`` `country_bucket` ``). Each field on
+`color` is bound to **its own** table; a field no table names falls back to the whole ordered
+list, which is what keeps a single-table tokens file rendering exactly as before.
+
+**A table's row order is the domain walk order.** Tableau pairs the first colour with the first
+domain member, so a table has to be written in the order the members will appear — the same
+order the sheet's `sort.order` pins, or the ACV/rank order the brand step sorted by. Reordering
+the rows recolours the chart.
+
+Optional worksheet key **`"palette": "<field name>"`** names the table explicitly, for when the
+field on `color` does not carry the table's name — a calculated `Package Bucket` coloured from
+the `package_group_name` table, say. A name no table in `DESIGN-TOKENS.md` carries is a
+validation error (silently falling back to the whole list is the bug the key exists to prevent).
 
 ## Interactions
 

--- a/skills/tableau-build/scripts/build.py
+++ b/skills/tableau-build/scripts/build.py
@@ -527,10 +527,14 @@ def validate(project_dir: Path | str) -> ValidationResult:
     if document is None:
         return ValidationResult(False, [load_error or ""], version, manifest_rel)
 
+    tokens_path = project_root / DESIGN_TOKENS_FILENAME
     errors = validate_manifest(
         document,
         (project_root / DATA_MODEL_FILENAME).read_text(encoding="utf-8-sig"),
         read_target_tableau_version(text),
+        # Optional read (CONTRACT.md §4.1): with no branding step there are no series tables,
+        # so a worksheet naming one is an error worth catching here rather than at render.
+        tokens_path.read_text(encoding="utf-8-sig") if tokens_path.exists() else "",
     )
     errors += spec_layout_errors(
         (project_root / VERSION_DIR / version / SPEC_FILENAME).read_text(

--- a/skills/tableau-build/scripts/manifest.py
+++ b/skills/tableau-build/scripts/manifest.py
@@ -48,6 +48,7 @@ from worksheet import (
     VERTICAL_ALIGNMENTS,
     CalculatedField,
     aggregate_calculated_fields,
+    parse_design_tokens,
 )
 from zones import FILTER_MODES
 
@@ -772,6 +773,7 @@ def _validate_worksheets(
     container_ids: set[str],
     errors: list[str],
     aggregate_calcs: Optional[dict[str, frozenset[str]]] = None,
+    palette_names: Optional[set[str]] = None,
 ) -> set[str]:
     """Validate the worksheets against the datasources and the layout tree.
 
@@ -785,6 +787,8 @@ def _validate_worksheets(
         errors: Accumulator for validation errors.
         aggregate_calcs: ``{datasource: {calculated field that already aggregates}}``, from
             :func:`_aggregate_calculated_fields`.
+        palette_names: The lower-cased field names DESIGN-TOKENS.md carries a series table
+            for - what a worksheet's ``palette`` key may name (issue #67).
 
     Returns:
         The element ids the worksheets fill.
@@ -810,6 +814,16 @@ def _validate_worksheets(
         elif name in seen_names:
             errors.append(f"{label}: duplicate worksheet name '{name}'")
         seen_names.add(name)
+
+        # A 'palette' that names no series table would silently fall back to the whole
+        # ordered list - the exact wrong-colours symptom the key exists to fix (issue #67).
+        palette = str(worksheet.get("palette", "")).strip()
+        if palette and palette.lower() not in (palette_names or set()):
+            known = ", ".join(sorted(palette_names or set())) or "none"
+            errors.append(
+                f"{label}: palette '{palette}' names no series table in DESIGN-TOKENS.md "
+                f"under '### Chart series colors' (tables found: {known})"
+            )
 
         chart_type = str(worksheet.get("chart_type", "")).strip().lower()
         if chart_type not in CHART_TYPES:
@@ -1267,7 +1281,10 @@ def _validate_visibility(
 
 
 def validate_manifest(
-    manifest_document: dict, data_model_text: str, target_tableau_version: str
+    manifest_document: dict,
+    data_model_text: str,
+    target_tableau_version: str,
+    design_tokens_text: str = "",
 ) -> list[str]:
     """Validate a build manifest against the data model and the project's target version.
 
@@ -1278,6 +1295,8 @@ def validate_manifest(
         manifest_document: The parsed ``build-manifest.json``.
         data_model_text: The contents of ``DATA-MODEL.md`` (the field authority).
         target_tableau_version: STATE.md's ``target_tableau_version`` (CONTRACT.md §2).
+        design_tokens_text: The contents of ``DESIGN-TOKENS.md`` (``""`` when there was no
+            branding step) - the authority for a worksheet's ``palette`` name.
 
     Returns:
         A list of error messages; empty when the manifest is buildable.
@@ -1319,6 +1338,7 @@ def validate_manifest(
     filled = _validate_worksheets(
         manifest_document.get("worksheets"), declared_fields, calculated, zone_ids,
         container_ids, errors, _aggregate_calculated_fields(manifest_document),
+        set(parse_design_tokens(design_tokens_text).field_palettes),
     )
 
     views = _view_zones(manifest_document.get("worksheets"))

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -107,6 +107,11 @@ BRAND_PALETTE_NAME = "Brand"
 
 _SERIES_HEADING = re.compile(r"^#+\s*.*series colors", re.IGNORECASE)
 
+#: A field name naming the sub-palette that follows it, in the tokens convention's backticks
+#: (``**`country_bucket`**``, or a `` `field` `` in the prose introducing a table). A hex is
+#: backticked too, hence the leading letter/underscore.
+_TOKEN_FIELD_NAME = re.compile(r"`([A-Za-z_][A-Za-z0-9_ .-]*)`")
+
 
 @dataclass(frozen=True)
 class DesignTokens:
@@ -128,7 +133,12 @@ class DesignTokens:
         title_size: Chart-title point size.
         title_color: Chart-title colour, lower-cased hex.
         kpi_size: Point size for a KPI card's big number.
-        series_colors: The brand's ordered chart-series colours, lower-cased hex.
+        series_colors: Every chart-series colour in file order, lower-cased hex - the
+            fallback for an encoding no sub-palette names.
+        field_palettes: ``{lower-cased field name: that field's ordered colours}``, one entry
+            per named series table. A tokens file that colours more than one dimension writes
+            a table per field; walking a domain against the *concatenation* colours every
+            encoding but the first with another field's ramp (issue #67).
         present: Whether a DESIGN-TOKENS.md was actually supplied.
     """
 
@@ -137,7 +147,21 @@ class DesignTokens:
     title_color: str = DEFAULT_TITLE_COLOR
     kpi_size: int = DEFAULT_KPI_SIZE
     series_colors: tuple[str, ...] = ()
+    field_palettes: dict[str, tuple[str, ...]] = field(default_factory=dict)
     present: bool = False
+
+    def palette_for(self, field_name: str) -> tuple[str, ...]:
+        """Return the sub-palette a field names, or the whole ordered list.
+
+        Args:
+            field_name: The name of the field on Colour, or the manifest's ``palette``
+                override.
+
+        Returns:
+            The field's own colours when a series table names it, else
+            :attr:`series_colors`.
+        """
+        return self.field_palettes.get(field_name.strip().lower(), self.series_colors)
 
 
 def _font_family(value: str) -> str:
@@ -181,8 +205,11 @@ def parse_design_tokens(tokens_text: str) -> DesignTokens:
     The parse is tolerant by design (the file is prose an agent authored from a template):
     it looks for the ``- **Font family**:`` and ``- **Chart title**:`` bullets and takes the
     first font name / px size / hex colour on each, and reads every hex under the
-    ``### Chart series colors`` heading as the ordered palette. Anything it cannot find keeps
-    its Tableau default.
+    ``### Chart series colors`` heading as the ordered palette. When that section names
+    fields - a `` `field_name` `` in the prose or bold-code heading introducing a table - the
+    colours under each name are also kept as that field's own sub-palette, so a sheet
+    coloured by it walks its ramp instead of the concatenation (issue #67). Anything it
+    cannot find keeps its Tableau default.
 
     Args:
         tokens_text: The contents of a ``DESIGN-TOKENS.md`` (``""`` when absent).
@@ -195,6 +222,8 @@ def parse_design_tokens(tokens_text: str) -> DesignTokens:
 
     font, title_size, title_color = DEFAULT_FONT, DEFAULT_TITLE_SIZE, DEFAULT_TITLE_COLOR
     series_colors: list[str] = []
+    field_palettes: dict[str, list[str]] = {}
+    named_field = ""
     in_series = False
     for raw_line in tokens_text.splitlines():
         line = raw_line.strip()
@@ -203,9 +232,21 @@ def parse_design_tokens(tokens_text: str) -> DesignTokens:
             # and every author formats that differently (one comma-separated run, a bullet
             # each), so every hex until the next heading is a series colour.
             in_series = _SERIES_HEADING.match(line) is not None
+            named_field = ""
             continue
         if in_series:
-            series_colors += [match.group(0).lower() for match in _HEX.finditer(line)]
+            colors = [match.group(0).lower() for match in _HEX.finditer(line)]
+            if not colors:
+                # A line with no colour is prose or a table header, and prose is where a
+                # sub-palette gets its name: `country_bucket` introduces the table under it.
+                name = _TOKEN_FIELD_NAME.search(line)
+                if name:
+                    named_field = name.group(1).strip().lower()
+                    field_palettes.setdefault(named_field, [])
+                continue
+            series_colors += colors
+            if named_field:
+                field_palettes[named_field] += colors
             continue
         if not line.startswith("-"):
             continue
@@ -231,6 +272,9 @@ def parse_design_tokens(tokens_text: str) -> DesignTokens:
         title_color=title_color,
         kpi_size=max(title_size + 8, DEFAULT_KPI_SIZE),
         series_colors=tuple(series_colors),
+        field_palettes={
+            name: tuple(colors) for name, colors in field_palettes.items() if colors
+        },
         present=True,
     )
 
@@ -922,6 +966,9 @@ class WorksheetPlan:
         fit: How the sheet fills its zone - a :data:`FIT_ZOOMS` key.
         sheet_format: The resolved Format Borders / Lines / Shading / Alignment block.
         geo_role: A map's geographic semantic role, or ``""``.
+        palette: The DESIGN-TOKENS.md series table to colour the marks from, when the field
+            on Colour does not carry that table's name (a calculated ``Package Bucket``
+            coloured from ``package_group_name``). ``""`` means "the field's own name".
         reference_lines: Resolved reference lines, in manifest order.
         parameters: Parameters the worksheet's calculations read - the view must declare them
             or Tableau cannot resolve the calculation. Filled in by :mod:`twb`, which owns
@@ -954,6 +1001,7 @@ class WorksheetPlan:
     fit: str = DEFAULT_FIT
     sheet_format: SheetFormat = field(default_factory=SheetFormat)
     geo_role: str = ""
+    palette: str = ""
 
     def qualify(self, name: str) -> str:
         """Return a bracketed name qualified with this worksheet's datasource."""
@@ -1030,6 +1078,7 @@ def plan_worksheet(entry: dict, resolver: FieldResolver) -> WorksheetPlan:
         fit=_plan_fit(entry.get("fit"), chart_type),
         sheet_format=_plan_sheet_format(entry.get("format")),
         geo_role=str(entry.get("geo_role", "")).strip() if spec.geographic else "",
+        palette=str(entry.get("palette", "")).strip(),
     )
 
 
@@ -1540,10 +1589,16 @@ def _add_palette(add: AddRule, plan: WorksheetPlan, tokens: DesignTokens) -> Non
     """Add the brand palette to whatever the worksheet colours its marks by.
 
     The colours ride along inline (see :class:`DesignTokens`), so no data member has to be
-    known. Three shapes, decided by what is on Colour: a *dimension* takes the whole ordered
-    palette and Tableau walks the domain against it; a *measure* is a continuous ramp, and a
-    ramp has two ends - the first and last brand colours, low to high; *nothing* on Colour has
-    no domain at all, so it gets the brand's first colour as the flat mark colour.
+    known. Three shapes, decided by what is on Colour: a *dimension* takes an ordered palette
+    and Tableau walks the domain against it; a *measure* is a continuous ramp, and a ramp has
+    two ends - the first and last brand colours, low to high; *nothing* on Colour has no
+    domain at all, so it gets the brand's first colour as the flat mark colour.
+
+    *Which* ordered palette a dimension takes is the fix for issue #67: a tokens file that
+    colours several fields writes a table per field, and walking a domain against all of them
+    concatenated gives every encoding but the first another field's ramp. The field on Colour
+    names its own table (or the manifest's ``palette`` key does); only a field no table names
+    falls back to the whole list.
 
     Args:
         add: ``_render_style``'s rule accumulator.
@@ -1552,6 +1607,9 @@ def _add_palette(add: AddRule, plan: WorksheetPlan, tokens: DesignTokens) -> Non
     """
     if not tokens.series_colors:
         return
+    # The manifest's 'palette' always wins: it exists for the field whose name the tokens
+    # file does not carry.
+    palette_name = plan.palette
     if plan.spec.dual:
         # A dual chart colours its two measures apart by Measure Names - a dimension, whatever
         # the measures are.
@@ -1560,14 +1618,17 @@ def _add_palette(add: AddRule, plan: WorksheetPlan, tokens: DesignTokens) -> Non
         reference = plan.encodings["color"]
         field_reference = plan.reference_of(reference)
         quantitative = reference.instance_type == "quantitative"
+        palette_name = palette_name or reference.field_name
     else:
         # Nothing on Colour, so there is no domain to walk - but the marks still have *a*
         # colour, and Tableau's is its default blue. The brand's first series colour is what
         # keeps a plain bar or line from reading as "generated" too.
-        add("mark", "format", {"attr": "mark-color", "value": tokens.series_colors[0]})
+        add("mark", "format", {
+            "attr": "mark-color", "value": tokens.palette_for(palette_name)[0],
+        })
         return
 
-    colors = tokens.series_colors
+    colors = tokens.palette_for(palette_name)
     if quantitative:
         colors = (colors[0], colors[-1])
     # ponytail: XSD-legal, but only Desktop can confirm it keeps the palette on save rather

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1088,6 +1088,118 @@ def test_no_series_colours_means_tableau_default_10():
     ) is None
 
 
+# --- Per-field sub-palettes (issue #67) ----------------------------------------
+
+#: A tokens file whose ``### Chart series colors`` section carries one table per coloured
+#: field - the shape tableau-brand writes for a dashboard that colours by more than one
+#: dimension. Order-walking the *concatenation* of these tables hands every encoding the
+#: first table's colours, which is issue #67.
+PER_FIELD_TOKENS = """# Design Tokens
+
+## Typography
+
+- **Font family**: Open Sans
+
+## Colors
+
+### Chart series colors
+
+**`region`** - the primary split, ordered by revenue rank.
+
+| Member | Token | Hex |
+|--------|-------|-----|
+| West | Purple 700 | `#6941C6` |
+| East | Purple 500 | `#9E77ED` |
+
+**`product_category`**
+
+| Member | Token | Hex |
+|--------|-------|-----|
+| Technology | Indigo 700 | `#3538CD` |
+| Furniture | Indigo 500 | `#6172F3` |
+"""
+
+#: One sheet per colour field, plus one coloured by a field no table names.
+PER_FIELD_SHEETS = [
+    _sheet("By Region", "bar", shelves={"columns": ["region"], "rows": ["revenue"]},
+           encodings={"color": "region"}),
+    _sheet("By Category", "bar", shelves={"columns": ["region"], "rows": ["revenue"]},
+           encodings={"color": "product_category"}),
+    _sheet("By Country", "bar", shelves={"columns": ["region"], "rows": ["revenue"]},
+           encodings={"color": "country"}),
+]
+
+
+def _palette_of(sheet_name: str, root: ET.Element) -> list[str]:
+    """Return the colours of a sheet's mark colour encoding, in order."""
+    encoding = _worksheet_element(sheet_name, root).find(
+        "table/style/style-rule[@element='mark']/encoding"
+    )
+    return [color.text for color in encoding.find("color-palette")]
+
+
+def test_a_named_series_table_binds_to_its_own_field():
+    """Issue #67: with a table per field, each colour encoding walks *its* table. Handing
+    both sheets the concatenation coloured 'By Category' with the region purples."""
+    root = ET.fromstring(_render(_manifest(PER_FIELD_SHEETS), tokens=PER_FIELD_TOKENS))
+
+    assert _palette_of("By Region", root) == ["#6941c6", "#9e77ed"]
+    assert _palette_of("By Category", root) == ["#3538cd", "#6172f3"]
+
+
+def test_an_unnamed_colour_field_falls_back_to_the_whole_list():
+    """No table names 'country', so the brand's full ordered list is still the best guess -
+    which is also what keeps a single-table tokens file rendering exactly as before."""
+    root = ET.fromstring(_render(_manifest(PER_FIELD_SHEETS), tokens=PER_FIELD_TOKENS))
+
+    assert _palette_of("By Country", root) == [
+        "#6941c6", "#9e77ed", "#3538cd", "#6172f3",
+    ]
+
+
+def test_the_palette_key_binds_a_table_the_encoding_field_does_not_name():
+    """The escape hatch: a calculated encoding field ('Package Bucket') rarely carries the
+    name of the tokens table that colours it, so the manifest says which one."""
+    sheets = [_sheet(
+        "By Country", "bar", shelves={"columns": ["region"], "rows": ["revenue"]},
+        encodings={"color": "country"}, palette="product_category",
+    )]
+    root = ET.fromstring(_render(_manifest(sheets), tokens=PER_FIELD_TOKENS))
+
+    assert _palette_of("By Country", root) == ["#3538cd", "#6172f3"]
+
+
+def test_a_palette_name_no_tokens_table_carries_is_rejected():
+    """A typo'd name would silently fall back to the flat list - the symptom #67 is about."""
+    document = _manifest([_sheet(
+        "By Country", "bar", shelves={"columns": ["region"], "rows": ["revenue"]},
+        encodings={"color": "country"}, palette="no_such_table",
+    )])
+    errors = manifest.validate_manifest(
+        document, DATA_MODEL, TARGET_VERSION, PER_FIELD_TOKENS
+    )
+    assert any("palette 'no_such_table'" in error for error in errors)
+
+
+def test_the_palette_key_validates_against_the_tokens_file():
+    """The same manifest with a name the tokens file does carry is buildable."""
+    document = _manifest([_sheet(
+        "By Country", "bar", shelves={"columns": ["region"], "rows": ["revenue"]},
+        encodings={"color": "country"}, palette="product_category",
+    )])
+    assert manifest.validate_manifest(
+        document, DATA_MODEL, TARGET_VERSION, PER_FIELD_TOKENS
+    ) == []
+
+
+def test_a_single_table_tokens_file_names_no_sub_palette():
+    """The demo's prose-and-commas section has no per-field tables, so nothing changes."""
+    tokens = worksheet.parse_design_tokens(DESIGN_TOKENS)
+
+    assert tokens.field_palettes == {}
+    assert tokens.series_colors == ("#1b4f72", "#2e86c1", "#48c9b0", "#f39c12")
+
+
 def test_a_measure_on_text_labels_the_marks_of_any_chart_type():
     """A bar with SUM on Text is labelled bars - and the labels are what make its
     number_format visible, which is why a styled bar used to look identical to a plain one."""


### PR DESCRIPTION
Closes #67.

## What was wrong

Every colour encoding in a built workbook was handed the **same** flat list — every hex under `DESIGN-TOKENS.md → ### Chart series colors`, concatenated across all the per-field tables. In mrrSales v_3 that meant `chart-country` (`country_bucket`: USA/India/ROW) walked onto the `sales_type` purples, and the Indigo / Fuchsia ramps sat at positions 10–18 where no 3-member domain ever reaches. Order-walking a concatenation is only correct for the first table's field.

## What changed

- **Per-field sub-palettes.** `parse_design_tokens` keeps each table under that heading as its own ordered palette, keyed by the backticked field name introducing it (`**\`country_bucket\`**`, or a `` `field` `` in the paragraph above the table). Every hex still lands in `series_colors`, so a single-table tokens file parses exactly as before.
- **Bind by encoding field.** `_add_palette` binds a sheet's colour encoding to the table named for *its* field; a field no table names falls back to the whole ordered list (current behaviour — goldens unchanged).
- **Manifest escape hatch.** Optional worksheet key `"palette": "<field name in tokens>"` for when the encoding field's name differs from the table's (a calculated `Package Bucket` coloured from `package_group_name`). `validate_manifest` takes the `DESIGN-TOKENS.md` text and rejects a name no table carries, listing the tables it found; `build.validate` passes the file as an optional read (CONTRACT.md §4.1).
- **Docs.** CONTRACT.md, tableau-build `SKILL.md` + `BUILD-MANIFEST-TEMPLATE.md` and tableau-brand's `DESIGN-TOKENS-TEMPLATE.md` document the one-table-per-field convention and the ordering contract: a table's row order **is** the domain walk order, so it must match the order the members appear in (the same order `sort.order` pins).

## Tests

`tests/test_charts.py`: two named tables bind per field; an unnamed colour field keeps the flat-list fallback; the `palette` key binds a table the encoding field does not name; an unknown name is a validation error; the demo's single-table section names no sub-palette.

`python -m pytest -q` → **631 passed**, chart goldens unchanged.

## Not closed by this PR

- Rebuilding mrrSales v_3 and eyeballing the legends needs that project directory.
- The KPI cards' `YoY Direction` still takes the flat list: its tokens file carries no table for that field, so `tableau-brand` has to write a semantic green/red table before the manifest can pin it with `"palette"`.

No Desktop verification needed — the emitted XML is the same inline `<color-palette>` on the same style rule that already round-trips; only which hexes go inside changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
