### PR TITLE
fix(build): an aggregate calc is a measure whatever it returns (#71)

### DIFF
--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -638,6 +638,15 @@ class FieldResolver:
         )
         datatype = declared_type or self.field_types.get(field_name, "string")
         role, column_type = self.type_facts.get(datatype, ("dimension", "nominal"))
+        if self.is_aggregate(field_name):
+            # Issue #71: a calculation that aggregates is a measure whatever it returns.
+            # Attested against Desktop output in
+            # skill/tableau-dashboard-creator/examples/top-level-workbook-example.twb: every
+            # string 'Color * Delta' calc over a plain SUM is role='measure' type='nominal',
+            # while the two over {FIXED} LODs - row-level, so not aggregates by
+            # is_aggregate_formula either - stay role='dimension'. Only the role flips; the
+            # 'type' still follows the datatype, so a string measure is nominal.
+            role = "measure"
 
         if bin_size is not None:
             # A bin is a *new* dimension column computed from the measure, not a derivation

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -604,14 +604,14 @@ def test_a_literal_brace_does_not_hide_an_aggregate_reference():
     assert worksheet.aggregate_calculated_fields(declared) == frozenset({"Ratio", "Badge"})
 
 
-@pytest.mark.parametrize("field,instance", [
-    ("Ratio", "[usr:Ratio:qk]"),
-    ("Ratio Label", "[usr:Ratio Label:nk]"),
-    ("Ratio Dir", "[usr:Ratio Dir:nk]"),
-    ("Ratio Scaled", "[usr:Ratio Scaled:qk]"),
-    ("Ratio Badge", "[usr:Ratio Badge:nk]"),
+@pytest.mark.parametrize("field,instance,column_type", [
+    ("Ratio", "[usr:Ratio:qk]", "quantitative"),
+    ("Ratio Label", "[usr:Ratio Label:nk]", "nominal"),
+    ("Ratio Dir", "[usr:Ratio Dir:nk]", "nominal"),
+    ("Ratio Scaled", "[usr:Ratio Scaled:qk]", "quantitative"),
+    ("Ratio Badge", "[usr:Ratio Badge:nk]", "nominal"),
 ])
-def test_an_aggregate_calc_reaches_the_shelf_as_a_user_derivation(field, instance):
+def test_an_aggregate_calc_reaches_the_shelf_as_a_user_derivation(field, instance, column_type):
     """Issue #62: a calc that aggregates - directly or by referencing one that does - has no
     row-level value, so any instance but ``usr:`` is a pill Desktop refuses with "can't be
     applied to a user-defined aggregate".
@@ -630,6 +630,19 @@ def test_an_aggregate_calc_reaches_the_shelf_as_a_user_derivation(field, instanc
     assert column_instance is not None, f"no column-instance emitted for [{field}]"
     assert column_instance.get("derivation") == "User"
     assert column_instance.get("name") == instance
+
+    # Issue #71: the *column* the 'usr:' instance derives from has to agree with it. A
+    # role='dimension' column under a derivation='User' instance says "group by this" over a
+    # field with no row-level value - the shape behind "cannot mix aggregate and
+    # non-aggregate arguments". Desktop writes role='measure' for a string aggregate calc
+    # (see the 'Color * Delta' calcs in the tracked reference workbook) and leaves 'type'
+    # following the datatype, so the string ones stay nominal.
+    column = element.find(
+        f"table/view/datasource-dependencies/column[@name='[{field}]']"
+    )
+    assert column is not None, f"no column emitted for [{field}]"
+    assert column.get("role") == "measure"
+    assert column.get("type") == column_type
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #71.

## The question the issue asked

A calculated field that aggregates but returns a string — `Ratio Dir = IF [Ratio] >= 0 THEN 'up' ELSE 'down' END` — was emitted as `role="dimension"` on a column whose instance is `derivation="User"`: "group by this", over a field with no row-level value to group by. The issue asked for a Desktop attestation before picking a side, since the three validators pass it either way (`twb-fidelity-oracle-is-desktop`).

## The attestation

Answered from the tracked Desktop output in `skill/tableau-dashboard-creator/examples/top-level-workbook-example.twb` — real Desktop 2025.1 output that already contains eight instances of this exact construct. **8/8 consistent:**

| string calc | numeric input | column | instance |
|---|---|---|---|
| Color New Business YoY Delta | plain `SUM`s | `role='measure' type='nominal'` | `usr:` / `User` |
| Color Expirations YoY Delta | plain `SUM`s | `role='measure' type='nominal'` | `usr:` |
| Color Cancellations YoY Delta | plain `SUM`s | `role='measure' type='nominal'` | `usr:` |
| Color Expirations Delta | plain `SUM`s | `role='measure' type='nominal'` | `usr:` |
| Color Cancellations Delta | plain `SUM`s | `role='measure' type='nominal'` | `usr:` |
| Color New Business Delta | plain `SUM`s | `role='measure' type='nominal'` | `usr:` |
| Color Active YoY Delta | `{FIXED : SUM(…)}` | `role='dimension'` | `none:` / `None` |
| ColorTotal Contracts | `{FIXED : SUM(…)}` | `role='dimension'` | `none:` / `None` |

Desktop writes `role="measure"`, and the discriminator is exactly `is_aggregate_formula`'s documented LOD-stripping semantics — a `{FIXED}` input is row-level, so those two stay dimensions. No new Desktop session was needed.

## The fix

`FieldResolver.reference` (`skills/tableau-build/scripts/worksheet.py`) overrides `role` to `measure` for `self.is_aggregate(field_name)`.

- **Only `role` flips.** `type` still follows the datatype, so a string measure stays `nominal` — which is what Desktop writes.
- Placed above the derivation branch chain, so nothing downstream shifts. The tooltip guard at `worksheet.py:1233` was already excluded by `derivation == "None"`.
- Both emission sites move together — the worksheet's `datasource-dependencies` column and the datasource-level column share the same `FieldRef` via `worksheet.render_column`.

## Tests

`tests/test_charts.py::test_an_aggregate_calc_reaches_the_shelf_as_a_user_derivation` now asserts the **column's** `role` and `type` alongside the instance, parametrised per field. Confirmed to fail on all three string calcs with the override removed; full suite 631 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)