### PR TITLE
fix(build): lift the parameter-action target to every attested type (#49)

### DIFF
--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -241,18 +241,23 @@ When one arrives:
   `filter` object is a quick-filter card over one worksheet's field, and a `parameter` object is
   that parameter's control. Endpoints are validated: an action source and its filter/highlight
   targets must be **view** zones, a parameter action's target a declared parameter.
-- **A `visibility` key on a layout node is Dynamic Zone Visibility**, and its boolean
-  calculated field must resolve to **one value, independent of the view** — so the calc compares
-  a parameter. Either shape is normal: a two-value parameter with a control (`= true` / `=
-  "on"`, the collapse-this-panel toggle) or a parameter a parameter action writes into,
-  compared against its opening value (`<> "All"`, the nothing-to-show-until-you-pick reveal,
-  which needs no control because clearing the selection resets it). **Never write a *visibility*
+- **A `visibility` key on a layout node is Dynamic Zone Visibility**, and it names either a
+  **boolean parameter** or a boolean calculated field. **Name the parameter directly whenever
+  it is already boolean** — Desktop binds the zone straight to `[Parameters].[…]` and a
+  comparison calc would be dead weight. A calc is needed only when the parameter is not boolean,
+  and it must resolve to **one value, independent of the view** — so it compares a parameter.
+  Either shape is normal: a two-value parameter with a control (`= true` / `= "on"`, the
+  collapse-this-panel toggle) or a parameter a parameter action writes into, compared against
+  its opening value (`<> "All"`, the nothing-to-show-until-you-pick reveal, which needs no
+  control because clearing the selection resets it). **Never write a *visibility*
   calc as an LOD expression** — `{FIXED : …}` is view-independent too and Tableau accepts it,
   but it is hard to reason about and hard to repair by hand. That is the only place LODs are
   ruled out; elsewhere they are ordinary `calculated_fields`. A row-level boolean is not a
   visibility field at all: it splits the marks and the zone stops toggling. The Detail-shelf
-  placement the field needs, the parameter declarations and the format flags are the builder's
-  job.
+  placement a visibility *calc* needs (a parameter needs none), the parameter declarations and
+  the format flags are the builder's job — as is putting a **parameter action's source field on
+  its source sheet's Detail shelf**, without which Desktop opens the workbook and the action
+  never fires.
 - **An unsupported construct is refused by name, never silently.** An image / button / legend
   object needs a reference the manifest does not carry (a filename, an action, a sheet + colour
   field) and Tableau does not treat those as optional, so the layout **reserves its box as an

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -228,7 +228,10 @@ calculations read it declares it automatically.
 ### Dynamic Zone Visibility
 
 **Show/hide a zone** with `visibility` on a **layout** node: `{"id": "chart-category",
-"visibility": "Show Breakdown"}`. The value must be the name of a declared **boolean**
+"visibility": "Show Breakdown"}`. When a parameter action drives the zone and the parameter
+is already `boolean`, name **the parameter itself** — Desktop binds the zone straight to it
+and the comparison calc is dead weight. A `string` parameter still needs the calc
+(`<> "All"`). Otherwise the value must be the name of a declared **boolean**
 calculated field, and the zone is shown when it is true. For a zone with a generated header or
 legend, the whole wrapper is what shows and hides.
 

--- a/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
+++ b/skills/tableau-build/references/BUILD-MANIFEST-TEMPLATE.md
@@ -193,10 +193,19 @@ name and needs a `field` — the field read off the clicked mark and written int
 Clearing the selection **resets** a parameter action's parameter to its `current_value`, so
 whatever the parameter drives returns to its opening state. That is what makes a parameter
 action safe to use without a control: the viewer cannot get stuck in a state only a control
-could undo. The reset is why **a parameter action's target must be a `string` parameter** —
-that is the only type whose reset value has an attested serialization, and a target that
-could not be reset is rejected rather than built without it. Give it a `values` domain
-(`["All", "West", "East"]`) and open it on the neutral member.
+could undo. The reset is why **a parameter action's target must be a `string`, `integer` or
+`boolean` parameter** — those are the types whose reset value has an attested serialization,
+and a target that could not be reset is rejected rather than built without it. A `real`,
+`date` or `datetime` target is refused.
+
+The **`field` must be the same type as the target parameter** (whole and decimal numbers
+count as one type): the action writes the clicked mark's value straight in with no
+conversion, so a `string` field into an `integer` parameter is a pairing Desktop refuses.
+
+Give the parameter a `values` domain (`["All", "West", "East"]`, or `[true, false]` for a
+Dynamic-Zone-Visibility toggle) and open it on the neutral member. A `range` domain works but
+clamps whatever the click writes to its bounds, which usually reads as a broken dashboard
+rather than an error — prefer `values`.
 
 `set` and `url` actions are **rejected**: the builder emits nothing for them, and a dashboard
 that validated with one would open with the interaction silently missing. A `drill`

--- a/skills/tableau-build/references/snippets/dashboard/CLEAR-OPTION-ATTESTATION.md
+++ b/skills/tableau-build/references/snippets/dashboard/CLEAR-OPTION-ATTESTATION.md
@@ -1,0 +1,128 @@
+# `<clear-option>` value serialization, per parameter data type
+
+What a Desktop-saved workbook writes in an `<edit-parameter-action>`'s
+`<clear-option value>` when the action's **"Clearing the selection will: Set value to"**
+is set. Backs `features.CLEAR_VALUE_TAGS` / `features.serialize_clear_value` and
+`manifest.PARAMETER_ACTION_TARGET_TYPES` (issue #49).
+
+| parameter `datatype` | tag | example `value` | attested from |
+| --- | --- | --- | --- |
+| `string` | `s:LROOT:` | `s:LROOT:All` | `dashboard_dzv_clear_unselected.twbx`, `parameter-action.twb` (this dir) |
+| `integer` | `i:` | `i:1` | `Logistics Dashboard_v2025.1.twbx`, `Clear All Button_v2023.3.twbx` (`i:0`), `Art of HR - Compensation Overview Makeover_v2024.2.twbx` (`i:1`/`i:2`/`i:3`) |
+| `boolean` | `b:` | `b:false` | `SalesMRR.twbx`, `Churns Analysis.twbx`, `US Penetration Overview.twbx`, `Rapaport Subscriptions Waterfall.twbx` |
+| `real` | **unattested** | — | — |
+| `date` / `datetime` | **unattested** | — | — |
+
+Three things the samples settle:
+
+1. The leading letter **is** a data-type tag, and only a string carries the extra `LROOT:`
+   segment. `i:` and `b:` have no second segment.
+2. The value after the tag is **undelimited** — `All`, not `"All"`; `false`, not `"false"`.
+   It is the bare literal, matching `features.parameter_literal` for a number and a boolean
+   and the *unquoted* text for a string.
+3. Every boolean sample resets to `b:false`; `b:true` is inferred, not read. The
+   inference is safe because the parameter's own `value=` and `<member value=>` use the
+   same bare lowercase `true`/`false` literal that `b:false` does.
+4. A `do-nothing` clear-option's `value` is not read. Desktop usually leaves `s:LROOT:`
+   there whatever the target's type (`features.CLEAR_VALUE_UNUSED`), but not always —
+   `Logistics Dashboard_v2025.1.twbx` carries `value='r:::1'` on a `do-nothing` targeting an
+   **integer** parameter, so that slot holds stale junk and is no evidence of a `real` tag.
+
+The source workbooks are not vendored here: the boolean samples are customer dashboards
+(one has a live Salesforce account URL as a parameter's current value). The fragments below
+are the whole of what was read.
+
+## `string` — `dashboard_dzv_clear_unselected.twbx` (document version 18.1)
+
+```xml
+<column caption='Selected Region' datatype='string' name='[Selected Region]'
+        param-domain-type='list' role='measure' type='nominal' value='&quot;All&quot;'>
+  <calculation class='tableau' formula='&quot;All&quot;' />
+  <members>
+    <member value='&quot;All&quot;' />
+    <member value='&quot;East&quot;' />
+    <member value='&quot;North&quot;' />
+    <member value='&quot;West&quot;' />
+  </members>
+</column>
+...
+<edit-parameter-action caption='Pick region' name='[Action4_94ABA201C771E732BB68894FD33BD1E9]'>
+  <activation type='on-select' />
+  <source dashboard='Dashboard 1' type='sheet' worksheet='Detail Table' />
+  <agg-type type='attr' />
+  <clear-option type='assign-fixed-value' value='s:LROOT:All' />
+  <params>
+    <param name='source-field' value='[federated.b2993893834e8f0306a282d0a717d7a9].[none:region:nk]' />
+    <param name='target-parameter' value='[Parameters].[Selected Region]' />
+  </params>
+</edit-parameter-action>
+```
+
+## `integer` — `Logistics Dashboard_v2025.1.twbx` (document version 18.1)
+
+```xml
+<column caption='Driver ID Parameter' datatype='integer' datatype-customized='true'
+        name='[Parameter 4]' param-domain-type='list' role='measure'
+        type='quantitative' value='3'>
+  <calculation class='tableau' formula='3' />
+  <members>
+    <member value='1' />
+    <member value='2' />
+    <!-- ... through 11 -->
+  </members>
+</column>
+...
+<edit-parameter-action caption='Drivers Name' name='[Action7_CB637FA5404F43848AB1A401D31911D0]'>
+  <activation type='on-select' />
+  <source dashboard='Drivers' type='sheet'>
+    <exclude-sheet name='Rank ' />
+  </source>
+  <agg-type type='attr' />
+  <clear-option type='assign-fixed-value' value='i:1' />
+  <params>
+    <param name='source-field' value='[federated.1mwylet0mo9yzg15b8cu21pchupa].[none:DriverID (Drivers.csv):ok]' />
+    <param name='target-parameter' value='[Parameters].[Parameter 4]' />
+  </params>
+</edit-parameter-action>
+```
+
+Note the reset value (`1`) is what was typed into "Set value to", not the parameter's
+current value (`3`) — the two are independent. This builder resets to the parameter's
+opening value, which is the case that keeps a Dynamic-Zone-Visibility panel closable.
+
+## `boolean` — `SalesMRR.twbx` (document version 18.1)
+
+```xml
+<column caption='DZV: Sales MRR' datatype='boolean' name='[Parameter 1]'
+        param-domain-type='list' role='measure' type='nominal' value='true'>
+  <calculation class='tableau' formula='true' />
+  <members>
+    <member value='true' />
+    <member value='false' />
+  </members>
+</column>
+...
+<edit-parameter-action caption='DZV action' name='[Action1_55A3760AE05A4DB7B2F5D5576E0928D2]'>
+  <activation type='on-select' />
+  <source dashboard='Sales Dashboard' type='sheet' worksheet='Sales MRR by Month' />
+  <agg-type type='attr' />
+  <clear-option type='assign-fixed-value' value='b:false' />
+  <params>
+    <param name='source-field' value='[sqlproxy...].[none:Calculation_1446781410472054788:nk]' />
+    <param name='target-parameter' value='[Parameters].[Parameter 1]' />
+  </params>
+</edit-parameter-action>
+```
+
+## Reproducing / extending this
+
+To attest `real`, `date` or `datetime`, save a Desktop workbook with a parameter of that
+type and a Change Parameter action whose **"Clearing the selection will:"** is **Set value
+to**, then read the `<clear-option>` out of the `.twb`:
+
+```bash
+python -c "import re,sys; print(re.findall(r'<clear-option[^>]*>', open(sys.argv[1],encoding='utf-8').read()))" workbook.twb
+```
+
+If Desktop greys out "Set value to" for a type, that type genuinely has no reset and
+belongs out of `PARAMETER_ACTION_TARGET_TYPES` permanently.

--- a/skills/tableau-build/references/snippets/dashboard/CLEAR-OPTION-ATTESTATION.md
+++ b/skills/tableau-build/references/snippets/dashboard/CLEAR-OPTION-ATTESTATION.md
@@ -126,3 +126,28 @@ python -c "import re,sys; print(re.findall(r'<clear-option[^>]*>', open(sys.argv
 
 If Desktop greys out "Set value to" for a type, that type genuinely has no reset and
 belongs out of `PARAMETER_ACTION_TARGET_TYPES` permanently.
+
+
+## Two rules Desktop enforced that the XML alone does not show
+
+Both found by opening a generated workbook in Desktop 2025.1.10 (the validators passed it
+either way — see the fidelity note in `CLAUDE.md`: Desktop is the oracle, not the XSD).
+
+1. **A parameter action's source field must be on the source sheet's Detail shelf.**
+   Declaring it in the sheet's `<datasource-dependencies>` is not enough: the workbook opens
+   and the action simply never fires, with no error. `twb._plan_interactions` puts it on
+   `plan.detail` (an `<lod>` in the pane's `<encodings>`), the same shelf a DZV field uses.
+
+2. **A boolean parameter drives Dynamic Zone Visibility directly.** Desktop's "Control
+   visibility using value" accepts the parameter itself, and writes
+
+   ```xml
+   <single-value-field-node fieldname='[Parameters].[Parameter 1]' ... />
+   ```
+
+   with an edge straight into the `dashboard-zone-visibility-node` — no comparison
+   calculation in between, and no sheet carrying the field (a parameter is view-independent).
+   Attested in `SalesMRR.twbx`, `US Penetration Overview.twbx`,
+   `Rapaport Subscriptions Waterfall.twbx` and `Logistics Dashboard_v2025.1.twbx`. A
+   *string* parameter still needs the comparison calc (`[Parameters].[Region] <> "All"`),
+   which is the only shape that existed while a parameter action could target strings alone.

--- a/skills/tableau-build/scripts/features.py
+++ b/skills/tableau-build/scripts/features.py
@@ -47,14 +47,21 @@ PARAMETER_ROLE = "measure"
 #: Bare-value datatypes; everything else needs delimiters (see :func:`parameter_literal`).
 _BARE_VALUE_TYPES = frozenset({"integer", "real"})
 
-#: What a parameter action's ``<clear-option>`` value is prefixed with - Tableau's own token,
-#: read off a Desktop 2025.1-saved workbook (``s:LROOT:All`` resets a parameter to ``All``).
-#: The value that follows is *undelimited*: the plain text, not a :func:`parameter_literal`.
-#: The ``s`` is a string's type tag and is all that is attested, so a parameter action may
-#: only target a string parameter - ``manifest.PARAMETER_ACTION_TARGET_TYPE`` enforces that,
-#: which is what makes the reset below unconditional for anything that validates (issue #49
-#: lifts the restriction once the other types' tags are read off a Desktop-saved workbook).
-CLEAR_VALUE_PREFIX = "s:LROOT:"
+#: The type tag a parameter action's ``<clear-option value>`` carries, per parameter data
+#: type. The leading letter is the data type and only a string adds the ``LROOT:`` segment;
+#: the value that follows is *undelimited* (``All``, not ``"All"``). Read off Desktop-saved
+#: workbooks - see ``references/snippets/dashboard/CLEAR-OPTION-ATTESTATION.md`` for the
+#: exact elements and where each came from. ``real``, ``date`` and ``datetime`` are absent
+#: because no Desktop workbook writing one has been seen; ``manifest`` rejects a parameter
+#: action targeting them rather than building one that cannot reset (issue #49).
+CLEAR_VALUE_TAGS: dict[str, str] = {
+    "string": "s:LROOT:",
+    "integer": "i:",
+    "boolean": "b:",
+}
+
+#: What Desktop writes in a ``do-nothing`` clear-option, where the value is never read.
+CLEAR_VALUE_UNUSED = "s:LROOT:"
 
 
 def parameter_literal(value: object, data_type: str) -> str:
@@ -78,6 +85,25 @@ def parameter_literal(value: object, data_type: str) -> str:
     return text if text.startswith('"') else f'"{text}"'
 
 
+def serialize_clear_value(current: object, data_type: str) -> str:
+    """Serialize a parameter action's reset value the way Desktop writes it.
+
+    Args:
+        current: The value the parameter goes back to when the selection is cleared.
+        data_type: The parameter's manifest data type.
+
+    Returns:
+        The ``<clear-option value>`` text (``s:LROOT:All``, ``i:10``, ``b:false``), or ``""``
+        for a data type with no attested tag - which leaves the action a ``do-nothing``.
+    """
+    tag = CLEAR_VALUE_TAGS.get(data_type)
+    if tag is None:
+        return ""
+    # A string's value goes in bare; a number's and a boolean's are already bare literals.
+    body = current if data_type == "string" else parameter_literal(current, data_type)
+    return f"{tag}{body}"
+
+
 @dataclass(frozen=True)
 class Parameter:
     """One resolved parameter: its literal current value and its domain.
@@ -88,8 +114,8 @@ class Parameter:
         data_type: The manifest data type (a key of :data:`PARAMETER_TYPES`).
         value: The current value, already rendered as a Tableau literal.
         clear_value: The serialized value a parameter action resets to when the selection is
-            cleared (see :data:`CLEAR_VALUE_PREFIX`); ``""`` for a parameter whose type has no
-            attested serialization, which keeps the value the last click put there.
+            cleared (see :func:`serialize_clear_value`); ``""`` for a parameter whose type has
+            no attested serialization, which keeps the value the last click put there.
         members: A list domain's allowed values, as literals; empty for the other domains.
         bounds: A range domain's ``(min, max, granularity)`` literals, or ``None``.
         number_format: A ``default-format`` pattern for the control, or ``""``.
@@ -167,9 +193,7 @@ def plan_parameters(entries: object) -> list[Parameter]:
             name=name,
             data_type=data_type,
             value=parameter_literal(current, data_type),
-            clear_value=(
-                f"{CLEAR_VALUE_PREFIX}{current}" if data_type == "string" else ""
-            ),
+            clear_value=serialize_clear_value(current, data_type),
             members=members,
             bounds=bounds,
             number_format=str(entry.get("format", "")).strip(),
@@ -286,7 +310,7 @@ class ParameterAction:
         source_field: The qualified column-instance the value is read from.
         target_parameter: The qualified parameter the value is written to.
         clear_value: The serialized value the parameter is reset to when the selection is
-            cleared (:data:`CLEAR_VALUE_PREFIX`); ``""`` keeps the last clicked value.
+            cleared (:func:`serialize_clear_value`); ``""`` keeps the last clicked value.
         activation: ``on-select`` or ``on-hover``.
     """
 
@@ -369,7 +393,7 @@ def render_actions(
         ET.SubElement(element, "agg-type", {"type": "attr"})
         ET.SubElement(element, "clear-option", (
             {"type": "assign-fixed-value", "value": action.clear_value}
-            if action.clear_value else {"type": "do-nothing", "value": CLEAR_VALUE_PREFIX}
+            if action.clear_value else {"type": "do-nothing", "value": CLEAR_VALUE_UNUSED}
         ))
         params = ET.SubElement(element, "params")
         for name, value in (

--- a/skills/tableau-build/scripts/manifest.py
+++ b/skills/tableau-build/scripts/manifest.py
@@ -1285,10 +1285,12 @@ def _validate_visibility(
 ) -> None:
     """Validate every layout node's ``visibility`` field (Dynamic Zone Visibility).
 
-    Tableau shows or hides a zone on a single boolean value, and the builder qualifies that
-    field against the datasource that declares it - so the field has to be a declared
-    *calculated* field of type ``boolean``. A CSV column would need one value per view, which
-    is not something the manifest can promise.
+    Tableau shows or hides a zone on a single boolean value, so the name has to be either a
+    declared *calculated* field of type ``boolean`` or a declared ``boolean`` **parameter** -
+    Desktop binds the datagraph straight to ``[Parameters].[Name]`` for the latter, which is
+    the simpler wiring when a parameter action is what drives the zone (no comparison calc in
+    between). A CSV column would need one value per view, which is not something the manifest
+    can promise.
 
     Args:
         bindings: ``(path, field name)`` pairs from the layout walk.
@@ -1303,12 +1305,18 @@ def _validate_visibility(
         if isinstance(entry, dict)
         and str(entry.get("type", "")).strip().lower() == VISIBILITY_TYPE
     }
+    boolean_parameters = {
+        str(entry.get("name", "")).strip()
+        for entry in manifest_document.get("parameters") or []
+        if isinstance(entry, dict)
+        and str(entry.get("data_type", "")).strip().lower() == VISIBILITY_TYPE
+    }
     for path, field_name in bindings:
-        if field_name not in booleans:
+        if field_name not in booleans | boolean_parameters:
             errors.append(
-                f"{path}: visibility '{field_name}' is not a declared calculated field of "
-                f"type '{VISIBILITY_TYPE}' (declared boolean: "
-                f"{', '.join(sorted(booleans)) or 'none'})"
+                f"{path}: visibility '{field_name}' is not a declared '{VISIBILITY_TYPE}' "
+                f"calculated field or parameter (declared boolean: "
+                f"{', '.join(sorted(booleans | boolean_parameters)) or 'none'})"
             )
 
 

--- a/skills/tableau-build/scripts/manifest.py
+++ b/skills/tableau-build/scripts/manifest.py
@@ -31,7 +31,7 @@ import re
 from pathlib import Path
 from typing import NamedTuple, Optional
 
-from features import ACTIVATIONS, PARAMETER_TYPES
+from features import ACTIVATIONS, CLEAR_VALUE_TAGS, PARAMETER_TYPES
 # Names, not the module: half the functions below take a parameter called ``worksheet``.
 from worksheet import (
     CHART_SPECS,
@@ -125,14 +125,25 @@ CARD_FILTER_TYPES = frozenset({"string", "boolean"})
 #: The type a Dynamic Zone Visibility field must have - a zone is shown or hidden, nothing else.
 VISIBILITY_TYPE = "boolean"
 
-#: The parameter data type a parameter action may target. Deselecting has to reset the
-#: parameter (:data:`features.CLEAR_VALUE_PREFIX`), or a panel the parameter reveals has
-#: nothing to hide it again and the viewer is stuck - and the reset value's serialization is
-#: only attested for a string. So a non-string target is rejected rather than built without
-#: its reset.
-#: ponytail: lift this the moment a numeric parameter action is saved in Desktop and the
-#: clear-option's type tag read off it - issue #49 carries the exact steps.
-PARAMETER_ACTION_TARGET_TYPE = "string"
+#: The parameter data types a parameter action may target: exactly those whose reset value
+#: has an attested ``<clear-option>`` serialization. Deselecting has to reset the parameter
+#: (:func:`features.serialize_clear_value`), or a panel the parameter reveals has nothing to
+#: hide it again and the viewer is stuck - so a type we could not serialize the reset for is
+#: rejected rather than built without it. ``real``, ``date`` and ``datetime`` are the ones
+#: still out (issue #49).
+PARAMETER_ACTION_TARGET_TYPES = frozenset(CLEAR_VALUE_TAGS)
+
+#: Which field types may feed which parameter data type. A parameter action writes the
+#: clicked mark's value straight into the parameter with no conversion, and Desktop's Change
+#: Parameter editor only offers fields of the parameter's own type - a workbook pairing them
+#: otherwise is one Desktop refuses on open. Whole and decimal numbers count as one type
+#: here, the way Tableau's own number family does. Keys mirror
+#: :data:`PARAMETER_ACTION_TARGET_TYPES`; the lookup below relies on that.
+PARAMETER_ACTION_FIELD_TYPES: dict[str, frozenset[str]] = {
+    "string": frozenset({"string"}),
+    "integer": frozenset({"integer", "real"}),
+    "boolean": frozenset({"boolean"}),
+}
 
 # A data-source heading in DATA-MODEL.md: "## Data source: `sales.csv`" -> "sales.csv".
 _DATASOURCE_HEADING = re.compile(
@@ -1080,7 +1091,7 @@ def _validate_actions(
         actions: The manifest's ``actions`` value.
         known_ids: Element ids an action may point at (the layout's zones).
         parameter_types: ``{declared parameter name: data type}`` - a parameter action's
-            targets, and the types :data:`PARAMETER_ACTION_TARGET_TYPE` is checked against.
+            targets, and the types :data:`PARAMETER_ACTION_TARGET_TYPES` is checked against.
         views: ``{element id: ViewZone}`` - the zones an action may run from or to.
         field_types: ``{datasource: {field: type}}``, for a parameter action's source field.
         errors: Accumulator for validation errors.
@@ -1142,6 +1153,15 @@ def _validate_actions(
                     f"'{source}'s datasource '{views[source].datasource}'"
                 )
 
+        # The clicked mark's field is what lands in the parameter, so the targets loop
+        # below needs its type as well as the target's. Empty when either end is already
+        # broken - that error is reported once, above, rather than again per target.
+        source_field = _bare_field(action.get("field")) or ""
+        source_field_type = (
+            field_types.get(views[source].datasource, {}).get(source_field, "")
+            if action_type == "parameter" and source in views else ""
+        )
+
         targets = action.get("targets", [])
         target_names = [
             str(target).strip()
@@ -1168,15 +1188,27 @@ def _validate_actions(
                 )
             elif (
                 action_type == "parameter"
-                and parameter_types[target] != PARAMETER_ACTION_TARGET_TYPE
+                and parameter_types[target] not in PARAMETER_ACTION_TARGET_TYPES
             ):
                 errors.append(
                     f"{label}: target parameter '{target}' is "
-                    f"'{parameter_types[target]}' - a parameter action's target must be "
-                    f"'{PARAMETER_ACTION_TARGET_TYPE}', because only a string's reset value "
-                    f"has an attested serialization and without the reset a zone the "
-                    f"parameter reveals never hides again. Declare it as "
-                    f"'{PARAMETER_ACTION_TARGET_TYPE}' with a 'values' domain"
+                    f"'{parameter_types[target]}' - a parameter action's target must be one "
+                    f"of {', '.join(sorted(PARAMETER_ACTION_TARGET_TYPES))}, because only "
+                    f"those have an attested reset-value serialization and without the reset "
+                    f"a zone the parameter reveals never hides again. Redeclare it as "
+                    f"whichever of those the value really is, with a 'values' domain"
+                )
+            elif (
+                action_type == "parameter"
+                and source_field_type
+                and source_field_type
+                not in PARAMETER_ACTION_FIELD_TYPES[parameter_types[target]]
+            ):
+                errors.append(
+                    f"{label}: field '{source_field}' is '{source_field_type}' but target "
+                    f"parameter '{target}' is '{parameter_types[target]}' - a parameter "
+                    f"action writes the clicked mark's value straight into the parameter, so "
+                    f"Desktop only offers fields of the parameter's own type. Match them"
                 )
 
 

--- a/skills/tableau-build/scripts/twb.py
+++ b/skills/tableau-build/scripts/twb.py
@@ -37,7 +37,7 @@ from typing import NamedTuple
 import features
 import worksheet
 import zones
-from manifest import documented_field_types
+from manifest import VISIBILITY_TYPE, documented_field_types
 
 logger = logging.getLogger(__name__)
 
@@ -583,9 +583,13 @@ def _plan_actions(
                 )
                 if parameter is None or reference is None:
                     continue
-                # The action reads a field off the clicked mark, so the sheet has to declare
-                # it even when it is not on a shelf.
-                source.plan.declared.append(reference)
+                # The action reads the field off the clicked mark, so it has to be *on* the
+                # source sheet's Detail shelf - declaring it in the sheet's dependencies is
+                # not enough. Without it Desktop opens the workbook and the action silently
+                # never fires (verified in Desktop 2025.1.10).
+                if not any(existing.instance_name == reference.instance_name
+                           for existing in source.plan.detail):
+                    source.plan.detail.append(reference)
                 interactions.parameter_actions.append(features.ParameterAction(
                     name=name, caption=caption, source=source.plan.name,
                     source_field=source.plan.reference_of(reference),
@@ -1072,15 +1076,21 @@ def _plan_zone_visibility(
 ) -> list[features.ZoneVisibility]:
     """Qualify each ``visibility`` field against the datasource that declares it.
 
+    A boolean **parameter** is qualified against ``[Parameters]`` instead, which is what
+    Desktop writes when the zone is driven by a parameter action directly (attested in
+    ``SalesMRR.twbx`` and three others - see
+    ``references/snippets/dashboard/CLEAR-OPTION-ATTESTATION.md``). It needs no sheet: a
+    parameter is view-independent, so there is nothing to put on a Detail shelf.
+
     Args:
         manifest_document: The parsed build manifest.
-        controlled: ``{zone id: calculated field name}`` from the layout walk.
+        controlled: ``{zone id: calculated field or parameter name}`` from the layout walk.
 
     Returns:
-        One :class:`features.ZoneVisibility` per controlled zone, in zone order. A field no
-        ``calculated_fields`` entry declares is dropped - ``validate_manifest`` has already
-        named it, and a datagraph pointing at a field Tableau cannot find hides the zone for
-        good.
+        One :class:`features.ZoneVisibility` per controlled zone, in zone order. A name
+        neither ``calculated_fields`` nor ``parameters`` declares is dropped -
+        ``validate_manifest`` has already named it, and a datagraph pointing at a field
+        Tableau cannot find hides the zone for good.
     """
     owner: dict[str, str] = {}
     for entry in manifest_document.get("calculated_fields") or []:
@@ -1090,15 +1100,26 @@ def _plan_zone_visibility(
         source = str(entry.get("datasource", "")).strip()
         if name and source:
             owner.setdefault(name, source)
+    boolean_parameters = {
+        str(entry.get("name", "")).strip()
+        for entry in manifest_document.get("parameters") or []
+        if isinstance(entry, dict)
+        and str(entry.get("data_type", "")).strip().lower() == VISIBILITY_TYPE
+    }
 
     visibilities: list[features.ZoneVisibility] = []
     for zone_id in sorted(controlled, key=int):
         field_name = controlled[zone_id]
         source = owner.get(field_name)
         if source:
-            visibilities.append(features.ZoneVisibility(
-                zone_id=zone_id, field=f"[{datasource_id(source)}].[{field_name}]"
-            ))
+            qualified = f"[{datasource_id(source)}].[{field_name}]"
+        elif field_name in boolean_parameters:
+            qualified = f"[{features.PARAMETERS_DATASOURCE}].[{field_name}]"
+        else:
+            continue
+        visibilities.append(
+            features.ZoneVisibility(zone_id=zone_id, field=qualified)
+        )
     return visibilities
 
 
@@ -1127,7 +1148,9 @@ def _element_ids(node: dict) -> list[str]:
     return ids
 
 
-def _attach_visibility_fields(layout: dict, plans: list[PlannedWorksheet]) -> None:
+def _attach_visibility_fields(
+    layout: dict, plans: list[PlannedWorksheet], parameter_names: frozenset[str]
+) -> None:
     """Put every zone-visibility field on the Detail shelf of a sheet that can resolve it.
 
     Dynamic Zone Visibility evaluates the field off the *view*: a boolean no sheet in the
@@ -1140,12 +1163,15 @@ def _attach_visibility_fields(layout: dict, plans: list[PlannedWorksheet]) -> No
     Args:
         layout: The manifest's ``layout`` value.
         plans: The resolved worksheets (mutated).
+        parameter_names: Declared parameter names - a zone driven by one needs no sheet.
     """
     by_element = {
         str(planned.entry.get("element_id", "")).strip(): planned
         for planned in plans if str(planned.entry.get("element_id", "")).strip()
     }
     for node, field_name in _visibility_requests(layout.get("root")):
+        if field_name in parameter_names:
+            continue  # a parameter is view-independent; no sheet has to carry it
         candidates = [by_element[element_id] for element_id in _element_ids(node)
                       if element_id in by_element]
         candidates += [planned for planned in plans if planned not in candidates]
@@ -1205,7 +1231,9 @@ def render_workbook(
     interactions = _plan_interactions(manifest_document, plans, parameters)
     # Before _attach_parameters: a visibility field's formula reads a parameter, and the sheet
     # it lands on has to declare that parameter or Tableau cannot resolve the calculation.
-    _attach_visibility_fields(layout, plans)
+    _attach_visibility_fields(
+        layout, plans, frozenset(parameter.name for parameter in parameters)
+    )
     _attach_parameters(plans, parameters)
     derived = _collect_derived_columns(manifest_document, resolvers, plans)
 

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -982,14 +982,12 @@ class WorksheetPlan:
         parameters: Parameters the worksheet's calculations read - the view must declare them
             or Tableau cannot resolve the calculation. Filled in by :mod:`twb`, which owns
             the manifest's parameter list.
-        declared: Fields the worksheet must declare without placing them on the view - a
-            parameter action's source field, which is read off the clicked mark. Filled in by
-            :mod:`twb` when it resolves the actions.
-        detail: Fields pinned to the Detail shelf that no encoding names - the boolean a
-            zone's Dynamic Zone Visibility reads, which Tableau evaluates off the *view* of a
-            sheet in the dashboard. Filled in by :mod:`twb` from the layout's ``visibility``
-            keys. A DZV field is a single value (a parameter comparison), so it never splits
-            the marks.
+        detail: Fields pinned to the Detail shelf that no encoding names, filled in by
+            :mod:`twb`: the boolean a zone's Dynamic Zone Visibility reads (from the layout's
+            ``visibility`` keys), which Tableau evaluates off the *view* of a sheet in the
+            dashboard, and a parameter action's source field (from the actions), which the
+            action reads off the clicked mark. Neither splits the marks - a DZV field is a
+            single value, and an action's source field is read with ATTR.
     """
 
     name: str
@@ -1001,7 +999,6 @@ class WorksheetPlan:
     filters: list[FilterPlan] = field(default_factory=list)
     reference_lines: list[ReferenceLinePlan] = field(default_factory=list)
     parameters: list[Parameter] = field(default_factory=list)
-    declared: list[FieldRef] = field(default_factory=list)
     detail: list[FieldRef] = field(default_factory=list)
     sort: Optional[SortPlan] = None
     tooltip: list[tuple[str, FieldRef]] = field(default_factory=list)
@@ -1037,7 +1034,6 @@ class WorksheetPlan:
         references += [reference for _, reference in self.tooltip]
         references += [reference for reference, _ in self.number_formats]
         references += [line.reference for line in self.reference_lines]
-        references += self.declared
         references += self.detail
         return references
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -675,13 +675,46 @@ def test_an_action_this_builder_cannot_emit_is_rejected(action_type):
     assert any(action_type in error for error in _errors(actions=actions))
 
 
-def test_a_parameter_action_targeting_a_non_string_parameter_is_rejected():
-    """Only a string's clear value has an attested serialization. A non-string target would
-    build an action that never resets - and a DZV panel it reveals would never hide again."""
+def test_a_parameter_action_targeting_an_unattested_type_is_rejected():
+    """A 'real' clear value has no attested serialization, so the action would never reset -
+    and a DZV panel it reveals would never hide again. Rejected rather than built."""
+    parameters = json.loads(json.dumps(PARAMETERS))
+    parameters.append({"name": "Threshold", "data_type": "real", "current_value": 0.5})
+    actions = json.loads(json.dumps(ACTIONS))
+    actions[-1]["targets"] = ["Threshold"]
+    errors = _errors(parameters=parameters, actions=actions)
+
+    assert any("Threshold" in error and "real" in error for error in errors)
+
+
+def test_a_parameter_action_targeting_an_attested_type_is_accepted():
+    """The string-only narrowing is lifted: integer and boolean resets are attested too
+    (references/snippets/dashboard/CLEAR-OPTION-ATTESTATION.md, issue #49)."""
     actions = json.loads(json.dumps(ACTIONS))
     actions[-1]["targets"] = ["Top N"]
+    actions[-1]["field"] = "revenue"
 
-    assert any("Top N" in error and "string" in error for error in _errors(actions=actions))
+    assert not [error for error in _errors(actions=actions) if "Top N" in error]
+
+
+def test_a_parameter_action_whose_field_and_parameter_types_disagree_is_rejected():
+    """The action writes the mark's value straight in, so Desktop only offers fields of the
+    parameter's own type - a string field into an integer parameter is one it refuses."""
+    actions = json.loads(json.dumps(ACTIONS))
+    actions[-1]["targets"] = ["Top N"]
+    actions[-1]["field"] = "region"
+    errors = _errors(actions=actions)
+
+    assert any("region" in error and "Top N" in error for error in errors)
+
+
+def test_the_parameter_action_type_tables_cover_the_same_types():
+    """The field-compatibility lookup is indexed by the target's type without a default, so
+    a type allowed as a target but missing a field rule would raise instead of validate."""
+    assert (
+        frozenset(manifest.PARAMETER_ACTION_FIELD_TYPES)
+        == manifest.PARAMETER_ACTION_TARGET_TYPES
+    )
 
 
 # --- Quick filters and parameter controls (AC #3) ------------------------------
@@ -883,16 +916,36 @@ def test_the_dzv_format_flags_are_present_and_alphabetical():
     assert flags == sorted(flags)
 
 
-def test_a_non_string_parameter_keeps_the_attested_clear_option():
-    """Only a string parameter's reset serialization is attested; guessing the tag for the
-    others is what makes Desktop refuse to open the action editor at all."""
+@pytest.mark.parametrize("data_type, current, expected", [
+    ("string", "All", "s:LROOT:All"),
+    ("integer", 10, "i:10"),
+    ("boolean", True, "b:true"),
+    ("boolean", False, "b:false"),
+])
+def test_the_clear_value_serialization_is_pinned_per_type(data_type, current, expected):
+    """The tag is the data type's own letter and only a string adds LROOT:; the value after
+    it is undelimited. Read off Desktop-saved workbooks - see the attestation note beside
+    references/snippets/dashboard/parameter-action.twb (issue #49)."""
+    assert features.serialize_clear_value(current, data_type) == expected
+
+
+@pytest.mark.parametrize("data_type", ["real", "date", "datetime"])
+def test_an_unattested_type_gets_no_clear_value(data_type):
+    """Guessing a tag Desktop does not write is what makes it refuse the action editor, so
+    an unattested type serializes to nothing and the caller falls back to do-nothing."""
+    assert features.serialize_clear_value(1, data_type) == ""
+
+
+def test_a_parameter_action_on_an_attested_non_string_type_still_resets():
+    """An integer target now carries a real reset, not a do-nothing - which is what keeps a
+    zone the parameter reveals closable."""
     actions = json.loads(json.dumps(ACTIONS))
     actions[-1]["targets"] = ["Top N"]
     actions[-1]["field"] = "revenue"
     root = ET.fromstring(_render(_manifest(actions=actions)))
 
     assert root.find("actions/edit-parameter-action/clear-option").attrib == {
-        "type": "do-nothing", "value": features.CLEAR_VALUE_PREFIX,
+        "type": "assign-fixed-value", "value": "i:10",
     }
 
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -588,14 +588,20 @@ def test_a_parameter_action_writes_a_field_into_a_parameter():
     }
 
 
-def test_a_parameter_actions_source_field_is_declared_by_its_sheet():
-    """The action reads the field off the clicked mark, so the sheet has to declare it even
-    though nothing places it on a shelf."""
-    dependencies = _worksheet_element("Detail Table").find(
-        "table/view/datasource-dependencies"
-    )
+def test_a_parameter_actions_source_field_is_on_its_sheets_detail_shelf():
+    """The action reads the field off the clicked mark, so it has to be *on* the source
+    sheet's Detail shelf - <lod> in the pane encodings. Declaring it in the sheet's
+    dependencies is not enough: Desktop 2025.1.10 opens the workbook and the action then
+    silently never fires."""
+    sheet = _worksheet_element("Detail Table")
+    dependencies = sheet.find("table/view/datasource-dependencies")
+    details = [
+        element.get("column")
+        for element in sheet.findall("table/panes/pane/encodings/lod")
+    ]
 
     assert dependencies.find("column-instance[@name='[none:region:nk]']") is not None
+    assert f"[{DATASOURCE_ID}].[none:region:nk]" in details
 
 
 def test_parameter_actions_come_after_the_sheet_actions():
@@ -1113,3 +1119,58 @@ def test_the_manifest_template_example_validates():
     assert manifest.validate_manifest(
         json.loads(example), DATA_MODEL, TARGET_VERSION
     ) == []
+
+
+# --- Dynamic Zone Visibility driven by a boolean parameter (issue #49) ---------
+
+def _boolean_parameter_manifest() -> dict:
+    """A manifest whose DZV zone is driven by a boolean parameter, with no comparison calc.
+
+    This is the shape Desktop writes when a parameter action drives the zone: the datagraph
+    binds straight to ``[Parameters].[<name>]`` (attested in ``SalesMRR.twbx``).
+    """
+    parameters = json.loads(json.dumps(PARAMETERS))
+    parameters.append({"name": "Show Panel", "data_type": "boolean",
+                       "current_value": False, "values": [True, False]})
+    calculated = json.loads(json.dumps(CALCULATED_FIELDS))
+    calculated.append({"name": "Panel Toggle", "formula": "TRUE",
+                       "datasource": "sales_orders", "type": "boolean"})
+    actions = json.loads(json.dumps(ACTIONS))
+    actions[-1]["targets"] = ["Show Panel"]
+    actions[-1]["field"] = "Panel Toggle"
+    layout = json.loads(json.dumps(LAYOUT))
+
+    def _mark(node):
+        if node.get("id") == "chart-category":
+            node["visibility"] = "Show Panel"
+        for child in node.get("children", []):
+            _mark(child)
+
+    _mark(layout["root"])
+    return _manifest(parameters=parameters, calculated_fields=calculated,
+                     actions=actions, layout=layout)
+
+
+def test_a_boolean_parameter_can_drive_zone_visibility_directly():
+    """Desktop binds the visibility node straight to the parameter - the comparison calc a
+    string parameter needs (`<> "All"`) is dead weight when the parameter is already boolean."""
+    document = _boolean_parameter_manifest()
+
+    assert not manifest.validate_manifest(document, DATA_MODEL, TARGET_VERSION)
+
+    root = ET.fromstring(_render(document))
+    node = root.find("datagraph/graph/nodes/single-value-field-node")
+
+    assert node.get("fieldname") == "[Parameters].[Show Panel]"
+
+
+def test_a_parameter_driven_zone_puts_nothing_on_a_detail_shelf():
+    """A parameter is view-independent, so unlike a boolean calc it needs no sheet to carry
+    it - attaching it to one would add a field the view never uses."""
+    root = ET.fromstring(_render(_boolean_parameter_manifest()))
+    details = [
+        element.get("column")
+        for element in root.findall("worksheets/worksheet/table/panes/pane/encodings/lod")
+    ]
+
+    assert not [column for column in details if "Show Panel" in column]


### PR DESCRIPTION
Closes #49.

## What the issue asked

Read the `<clear-option value>` serialization for a non-string parameter off a
Desktop-saved workbook, then lift `PARAMETER_ACTION_TARGET_TYPE = "string"` from a
rejection to a data-type → tag table.

## What it turned out to be

No Desktop session was needed — eight already-saved workbooks on the analyst's machine
pinned it. The leading letter **is** a data-type tag, and only a string carries the extra
`LROOT:` segment:

| parameter type | `<clear-option value>` | attested from |
| --- | --- | --- |
| `string` | `s:LROOT:All` | `dashboard_dzv_clear_unselected.twbx` |
| `integer` | `i:1` / `i:0` / `i:2` | `Logistics Dashboard_v2025.1`, `Clear All Button_v2023.3`, `Art of HR…` |
| `boolean` | `b:false` | `SalesMRR`, `Churns Analysis`, `US Penetration Overview`, `Rapaport Subscriptions Waterfall` |
| `real` / `date` | none found | — |

`real` and `date` stay rejected. The one `r:::1` in the corpus sits on a `do-nothing`
clear-option targeting an **integer** parameter, so that slot holds stale junk and is no
evidence of a `real` tag.

The attestation is a markdown note rather than vendored workbooks: the only boolean
samples are customer dashboards, one carrying a live Salesforce account URL as a
parameter's current value.

## Beyond the issue

Three further defects, all found by building a boolean-DZV workbook off the demo and
**opening it in Desktop 2025.1.10** — every one of them passed all three validators first.

1. **A parameter action's source field must be on the source sheet's Detail shelf.** It
   was only declared in `<datasource-dependencies>`. The workbook opens, the action editor
   looks correct, and the action silently never fires. The builder already knew this rule
   for a DZV field; the comment at the action call site asserted the opposite.
2. **A boolean parameter drives DZV directly** — Desktop binds
   `<single-value-field-node fieldname='[Parameters].[Name]'>` straight into the zone, with
   no comparison calc and no sheet carrying it. The `<> "All"` calc was the only possible
   shape while a parameter action could target a string alone, so this is what the widening
   unlocks.
3. **The source `field`'s type was never checked against the target parameter's** (caught
   in review). Near-harmless while only `string` targets were legal; with `integer` and
   `boolean` targets a string field into an integer parameter would validate and build an
   action Desktop refuses on open.

## Verification

A boolean-DZV dashboard was built from the demo manifest and opened in Desktop 2025.1.10.
Confirmed by hand: the workbook loads, the zone starts hidden, clicking a mark reveals it,
clearing the selection hides it again, and the action editor shows
"Clearing the selection will: Set value to → False".

643 tests pass.

## Acceptance criteria

- [x] The type tag is known for `integer` and `boolean`
- [x] Attestation lives under `skills/tableau-build/references/snippets/` (CONTRACT.md §7)
- [x] `PARAMETER_ACTION_TARGET_TYPE` replaced by `PARAMETER_ACTION_TARGET_TYPES = frozenset(CLEAR_VALUE_TAGS)`, so validator and serializer cannot drift
- [x] Tests pin the serialization for each newly attested type

🤖 Generated with [Claude Code](https://claude.com/claude-code)
