### PR TITLE
fix(build): the gantt mark class is "GanttBar", one word (#76)

### DIFF
--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -779,7 +779,7 @@ CHART_SPECS: dict[str, ChartSpec] = {
     "histogram": ChartSpec(mark_class="Bar"),
     "treemap": ChartSpec(mark_class="Square", label_marks=True),
     "bullet": ChartSpec(mark_class="Bar"),
-    "gantt": ChartSpec(mark_class="Gantt"),
+    "gantt": ChartSpec(mark_class="GanttBar"),
     "boxplot": ChartSpec(mark_class="Circle"),
     "dual-axis": ChartSpec(dual=True),
     "combo": ChartSpec(dual=True, pane_marks=("Bar", "Line")),

--- a/tests/fixtures/charts/gantt.xml
+++ b/tests/fixtures/charts/gantt.xml
@@ -1,0 +1,49 @@
+<worksheet name="Gantt">
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor="#7f56d9" fontname="Open Sans" fontsize="14">&lt;Sheet Name&gt;</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption="sales_orders" name="federated.b2993893834e8f0306a282d0a717d7a9" />
+          </datasources>
+          <datasource-dependencies datasource="federated.b2993893834e8f0306a282d0a717d7a9">
+            <column caption="Order Date" datatype="date" name="[order_date]" role="dimension" type="ordinal" />
+            <column caption="Product Category" datatype="string" name="[product_category]" role="dimension" type="nominal" />
+            <column caption="Revenue" datatype="real" name="[revenue]" role="measure" type="quantitative" />
+            <column-instance column="[product_category]" derivation="None" name="[none:product_category:nk]" pivot="key" type="nominal" />
+            <column-instance column="[revenue]" derivation="Sum" name="[sum:revenue:qk]" pivot="key" type="quantitative" />
+            <column-instance column="[order_date]" derivation="Month-Trunc" name="[tmn:order_date:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+          <aggregation value="true" />
+        </view>
+        <style>
+          <style-rule element="mark">
+            <format attr="mark-color" value="#1b4f72" />
+          </style-rule>
+          <style-rule element="worksheet">
+            <format attr="font-family" value="Open Sans" />
+            <format attr="display-field-labels" scope="cols" value="false" />
+            <format attr="display-field-labels" scope="rows" value="false" />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option="selection-relaxation-allow">
+            <view>
+              <breakdown value="auto" />
+            </view>
+            <mark class="GanttBar" />
+            <encodings>
+              <size column="[federated.b2993893834e8f0306a282d0a717d7a9].[sum:revenue:qk]" />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[federated.b2993893834e8f0306a282d0a717d7a9].[none:product_category:nk]</rows>
+        <cols>[federated.b2993893834e8f0306a282d0a717d7a9].[tmn:order_date:qk]</cols>
+      </table>
+      <simple-id uuid="{F25AA523-0C46-5080-9AC5-991D62B6FA75}" />
+    </worksheet>

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -158,6 +158,13 @@ CHART_CASES: list[tuple[str, dict]] = [
         "columns": [{"field": "order_date", "date_part": "month"}],
         "rows": ["revenue", "profit"],
     })),
+    # Issue #76: gantt shipped a mark class ("Gantt") that is not in the XSD enum, because
+    # no test had ever built one. A golden per chart type is what stops the next
+    # never-exercised type from inventing a mark name.
+    ("gantt", _sheet("Gantt", "gantt", shelves={
+        "columns": [{"field": "order_date", "date_part": "month"}],
+        "rows": ["product_category"],
+    }, encodings={"size": "revenue"})),
     ("custom-tooltip", _sheet(
         "Custom Tooltip", "bar",
         shelves={"columns": ["product_category"], "rows": ["revenue"]},
@@ -331,6 +338,33 @@ def test_every_legacy_pattern_has_a_case():
     }
 
 
+def test_every_mark_class_is_in_the_xsd_enumeration():
+    """Every mark class the assembler can emit is a member of the XSD's PrimitiveType-ST.
+
+    Issue #76: a mark class the enumeration does not list is a fatal gate error, and a chart
+    type nothing ever builds hides one forever - gantt shipped "Gantt" for "GanttBar". This
+    reads the enumeration once and covers every spec, including the types with no golden
+    case. Stdlib-only on purpose: importing validate_twb_xsd without lxml exits the process.
+    """
+    # Whatever twb_*.xsd the skill ships - no version string to keep in sync with the
+    # validator's own XSD_PATH.
+    xsd_dir = Path(worksheet.__file__).parent.parent / "references" / "xsd"
+    namespace = {"xs": "http://www.w3.org/2001/XMLSchema"}
+    schema = ET.parse(sorted(xsd_dir.glob("twb_*.xsd"))[-1])
+    mark_class_enum = schema.find(".//xs:simpleType[@name='PrimitiveType-ST']", namespace)
+    assert mark_class_enum is not None, "PrimitiveType-ST is gone from the XSD"
+    legal = {
+        enumeration.get("value")
+        for enumeration in mark_class_enum.findall("xs:restriction/xs:enumeration", namespace)
+    }
+
+    emitted = set()
+    for spec in worksheet.CHART_SPECS.values():
+        emitted.add(spec.mark_class)
+        emitted.update(spec.pane_marks)
+    assert emitted <= legal, f"mark class(es) not in PrimitiveType-ST: {sorted(emitted - legal)}"
+
+
 def test_every_chart_type_is_buildable():
     """Every type manifest.CHART_TYPES accepts has a spec - otherwise validate lets through
     a chart the assembler renders as a bare Automatic mark."""
@@ -374,6 +408,7 @@ def test_the_same_manifest_rebuilds_byte_identical():
     ("Kpi Card", "Text"),
     ("Histogram", "Bar"),
     ("Map", "Automatic"),
+    ("Gantt", "GanttBar"),
 ])
 def test_mark_class_per_chart_type(sheet_name, mark_class):
     """The mark class is what makes Tableau draw the right shape; every single-pane type
@@ -1485,3 +1520,9 @@ def test_build_packages_a_workbook_holding_every_chart_type(tmp_path):
             (project / result.twb_path).read_text(encoding="utf-8")
         ).findall("worksheets/worksheet")
     ) == len(CHART_CASES)
+
+    # Issue #76: the gate, not the build, is what an analyst hits - a gantt chart's invalid
+    # mark class passed assembly and died here. All three validators, over every type.
+    report = build.run_gate(project / result.twb_path, document, TARGET_VERSION)
+    assert set(report.results) == set(build.GATE_VALIDATORS)
+    assert report.ok, report.errors

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -408,6 +408,9 @@ def test_the_same_manifest_rebuilds_byte_identical():
     ("Kpi Card", "Text"),
     ("Histogram", "Bar"),
     ("Map", "Automatic"),
+    # Do not derive these from CHART_SPECS - each row is a hand-checked pin against the
+    # XSD, and a test that reads its expected value out of the code under test always
+    # passes - issue #76 is exactly CHART_SPECS holding the wrong value.
     ("Gantt", "GanttBar"),
 ])
 def test_mark_class_per_chart_type(sheet_name, mark_class):


### PR DESCRIPTION
Closes #76.

`CHART_SPECS["gantt"]` emitted mark class `Gantt`. `PrimitiveType-ST` in
`references/xsd/twb_2026.1.0.xsd` spells it `GanttBar`, so every gantt chart failed the
schema validator with a fatal enumeration error on both target versions. The blast radius
was a **blocked build** — an analyst who asked for a gantt chart got a red gate and no
`.twbx`. Nothing caught it because nothing had ever built a gantt sheet.

## Bug Fixes

- `skills/tableau-build/scripts/worksheet.py` — `"gantt": ChartSpec(mark_class="GanttBar")`.

## Enhancements

- `tests/test_charts.py` — a `gantt` case joins `CHART_CASES` (dimension on Rows, a
  month-truncated date on Cols, the measure on Size), with its golden at
  `tests/fixtures/charts/gantt.xml` and a `("Gantt", "GanttBar")` row on
  `test_mark_class_per_chart_type`.
- `tests/test_charts.py` — `test_every_mark_class_is_in_the_xsd_enumeration` reads
  `PrimitiveType-ST` once and asserts every `mark_class` **and** `pane_marks` entry is a
  member. This catches the whole class of bug without anyone thinking about gantt charts,
  and covers the four types that still have no golden case (heatmap, treemap, bullet,
  boxplot). Stdlib-only and version-agnostic (globs `twb_*.xsd`) — importing
  `validate_twb_xsd` without lxml calls `sys.exit(2)`.
- `tests/test_charts.py` — `test_build_packages_a_workbook_holding_every_chart_type` now
  runs `build.run_gate`. The gate, not the build, is where an invalid mark class actually
  kills an analyst's run.

## Documentation

- A comment on the `test_mark_class_per_chart_type` rows: do not derive them from
  `CHART_SPECS`. Each is a hand-checked pin against the XSD, and a test that reads its
  expected value out of the code under test can never fail.

## Verification

- `python -m pytest -q` → **646 passed**.
- Reintroducing `"Gantt"` fails 5 tests: the golden, the mark-class row, the XSD
  enumeration guard, the all-charts XSD test, and the packaging/gate test.
- The rendered gantt worksheet passes `validate_twb_xsd` with zero errors; `run_gate`
  reports all 3 validators passed over a workbook containing a gantt sheet.

## Known limitation

The golden puts `SUM(revenue)` on Size, where a real gantt bar's length means duration —
the test data model has no duration field. Structurally right, semantically odd, and
irrelevant to what the golden pins.

The XSD says `GanttBar` is *legal*; only Desktop says it is what Desktop writes. If a gantt
ever renders wrong despite a green gate, the answer is the usual save-and-diff. Not a
blocker — the previous value was provably invalid either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)