### PR TITLE
fix(build): attest all eight TABLE_CALC_PREFIXES against Desktop output (#50)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ skill/tableau-dashboard-creator/scripts/__pycache__/
 **/.env
 **/.env.local
 **/.env.*.local
+
+# Scratch Tableau workbooks used while attesting Desktop behaviour - never committed.
+# The attestation copies that *are* tracked live under skills/*/references/snippets/.
+tests/temp-workbooks-for-tests/

--- a/skill/tableau-dashboard-creator/references/snippets/dashboard/action-filter.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/dashboard/action-filter.twb
@@ -24,7 +24,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -258,7 +258,7 @@
         </groupfilter>
       </group>
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/dashboard/highlight-action.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/dashboard/highlight-action.twb
@@ -24,7 +24,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -258,7 +258,7 @@
         </groupfilter>
       </group>
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/dashboard/multi-sheet-layout.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/dashboard/multi-sheet-layout.twb
@@ -25,7 +25,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -254,7 +254,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/dashboard/parameter-action.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/dashboard/parameter-action.twb
@@ -27,7 +27,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -267,7 +267,7 @@
         </groupfilter>
       </group>
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/dashboard/single-sheet-layout.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/dashboard/single-sheet-layout.twb
@@ -24,7 +24,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -253,7 +253,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/data-model/multi-csv-join.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/data-model/multi-csv-join.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.088jbb100rppdo1c7uw7519si2hd'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation join='inner' type='join'>
@@ -428,7 +428,7 @@
       <column caption='Segment' datatype='string' name='[segment]' role='dimension' type='nominal' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='false' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders+join.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:43:00 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders+join.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:43:00 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <cols>
             <map key='[account_manager]' value='[Extract].[account_manager]' />

--- a/skill/tableau-dashboard-creator/references/snippets/data-model/multi-csv-relationship.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/data-model/multi-csv-relationship.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.12bnsfy08qdr5q166cgcy17wyvfv'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation type='collection'>
@@ -423,7 +423,7 @@
       <column caption='Segment' datatype='string' name='[segment]' role='dimension' type='nominal' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='false' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders+.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:40:18 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders+.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:40:18 AM' username='tableau_internal_user'>
           <relation type='collection'>
             <relation name='sales_orders.csv_C3927FFD250247008EE17F1CFB32D376' table='[Extract].[sales_orders.csv_C3927FFD250247008EE17F1CFB32D376]' type='table' />
             <relation name='customer_segments.csv_5DE042A67D634D95BF1DE82CF2911BC7' table='[Extract].[customer_segments.csv_5DE042A67D634D95BF1DE82CF2911BC7]' type='table' />

--- a/skill/tableau-dashboard-creator/references/snippets/data-model/single-csv.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/data-model/single-csv.twb
@@ -19,7 +19,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>

--- a/skill/tableau-dashboard-creator/references/snippets/features/FEATURES.md
+++ b/skill/tableau-dashboard-creator/references/snippets/features/FEATURES.md
@@ -198,14 +198,23 @@ Table calculations are **view-level computations** — they don't create new dat
 
 ### Table Calculation Types
 
+> **Corrected against Desktop output (issue #50).** This table was inferred, and most of it
+> was wrong: `PctTotal` is `pcto:`, not `pct:`; `PctDiff` is `pcdf:`, not `pctdiff:`; the type
+> is `Difference`, not `Diff`; and `CumAvg` is not a `TCType-ST` value at all. The attested
+> table lives in `skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md` with the
+> workbook each prefix was read from. **Do not infer a prefix from the type name** - four of
+> seven guesses missed.
+
 | `type` | Name Prefix | Description |
 |--------|-------------|-------------|
 | `CumTotal` | `cum:sum:` | Running/cumulative total |
-| `CumAvg` | `cum:avg:` | Running average |
-| `PctTotal` | `pct:sum:` | Percent of total |
-| `Diff` | `diff:sum:` | Difference from previous |
-| `PctDiff` | `pctdiff:sum:` | Percent difference from previous |
+| `WindowTotal` | `win:sum:` | Moving calculation |
+| `Difference` | `diff:sum:` | Difference from previous |
+| `PctDiff` | `pcdf:sum:` | Percent difference from previous |
+| `PctValue` | `pcva:sum:` | Percent from |
+| `PctTotal` | `pcto:sum:` | Percent of total |
 | `Rank` | `rank:sum:` | Rank |
+| `PctRank` | `pcrk:sum:` | Percentile |
 
 ### Ordering
 

--- a/skill/tableau-dashboard-creator/references/snippets/features/calculated-field.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/features/calculated-field.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -253,7 +253,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/features/lod-expression.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/features/lod-expression.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -253,7 +253,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/features/parameter-control.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/features/parameter-control.twb
@@ -30,7 +30,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -265,7 +265,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/features/reference-line.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/features/reference-line.twb
@@ -23,7 +23,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -252,7 +252,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/features/tablea-calculation.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/features/tablea-calculation.twb
@@ -20,7 +20,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.111z53a09ghhme106lu810g7616r'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.111z53a09ghhme106lu810g7616r' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>

--- a/skill/tableau-dashboard-creator/references/snippets/scaffold/workbook-skeleton.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/scaffold/workbook-skeleton.twb
@@ -23,7 +23,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/area-chart.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/area-chart.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -250,7 +250,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/bar-chart-filtered.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/bar-chart-filtered.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -250,7 +250,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/bar-chart-sorted.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/bar-chart-sorted.twb
@@ -22,7 +22,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -251,7 +251,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/bar-chart-styled.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/bar-chart-styled.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -250,7 +250,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/bar-chart.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/bar-chart.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -250,7 +250,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/combo-chart.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/combo-chart.twb
@@ -20,7 +20,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.111z53a09ghhme106lu810g7616r'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.111z53a09ghhme106lu810g7616r' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/custom-tooltip.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/custom-tooltip.twb
@@ -22,7 +22,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -251,7 +251,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/dual-axis.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/dual-axis.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -250,7 +250,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/histogram.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/histogram.twb
@@ -20,7 +20,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.111z53a09ghhme106lu810g7616r'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.111z53a09ghhme106lu810g7616r' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/line-chart.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/line-chart.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -250,7 +250,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/map-chart.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/map-chart.twb
@@ -22,7 +22,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -251,7 +251,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/pie-chart.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/pie-chart.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -250,7 +250,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/scatter-plot.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/scatter-plot.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -250,7 +250,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/stacked-bar-chart.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/stacked-bar-chart.twb
@@ -22,7 +22,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -251,7 +251,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skill/tableau-dashboard-creator/references/snippets/worksheets/text-table.twb
+++ b/skill/tableau-dashboard-creator/references/snippets/worksheets/text-table.twb
@@ -21,7 +21,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -250,7 +250,7 @@
       <column caption='Revenue' datatype='real' name='[revenue]' role='measure' type='quantitative' />
       <column caption='Unit Price' datatype='real' name='[unit_price]' role='measure' type='quantitative' />
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skills/tableau-build/references/snippets/dashboard/parameter-action.twb
+++ b/skills/tableau-build/references/snippets/dashboard/parameter-action.twb
@@ -27,7 +27,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='sales_orders' name='textscan.16xkalt18d1a7p1cjzge51xf66r6'>
-            <connection class='textscan' directory='C:/Users/lavid/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
+            <connection class='textscan' directory='C:/Users/%USERNAME%/PyCharmMiscProject/tableau-skills/tableau-dashboard-creator-skill/demo/input/sample-data' filename='sales_orders.csv' password='' server='' />
           </named-connection>
         </named-connections>
         <relation connection='textscan.16xkalt18d1a7p1cjzge51xf66r6' name='sales_orders.csv' table='[sales_orders#csv]' type='table'>
@@ -267,7 +267,7 @@
         </groupfilter>
       </group>
       <extract _.fcp.VConnDownstreamExtractsWithWarnings.true...user-specific='false' count='-1' enabled='true' object-id='' units='records'>
-        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/lavid/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
+        <connection access_mode='readonly' authentication='auth-none' author-locale='en_US' class='hyper' dbname='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/sales_orders.hyper' default-settings='yes' schema='Extract' sslmode='' tablename='Extract' update-time='03/16/2026 06:44:43 AM' username='tableau_internal_user'>
           <relation name='Extract' table='[Extract].[Extract]' type='table' />
           <refresh>
             <refresh-event add-from-file-path='sales_orders' increment-value='%null%' refresh-type='create' rows-inserted='40' timestamp-start='2026-03-16 06:44:42.736' />

--- a/skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md
+++ b/skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md
@@ -100,6 +100,15 @@ drift from this file without a test failing.
 </column-instance>
 ```
 
+### The builder emits the name, not the options
+
+Read the fragments above for the prefixes only. Desktop also writes per-type options that
+carry the calculation's *meaning* - `aggregation`, `diff-options` plus an `<address>` child,
+`rank-options`, and `from` / `to` / `window-options` - and the builder emits none of them.
+All are optional per the XSD, so both validators pass, but a `WindowTotal` with no `from` /
+`to` is an unbounded window rather than a moving average. Tracked as issue #85; the prefixes
+this file attests are unaffected.
+
 ### The Calculation Type menu, mapped
 
 Desktop 2025.1.10's dropdown offers eight entries, all now traced. There is no "Total"
@@ -118,9 +127,10 @@ entry - that is the formula path above.
 
 ## Attested from the wider corpus
 
-Two prefixes are not in the reference workbook. They come from a 195-workbook sweep of
-`~/Downloads`, `~/Documents/My Tableau Repository/Workbooks` and this repo. Fragments
-verbatim; `source-build` is each workbook's own. All are `version='18.1'`.
+The reference workbook settles five prefixes - `1a-total` is the untyped formula case, so six
+sheets yield five types. The other **three** come from a 195-workbook sweep of `~/Downloads`,
+`~/Documents/My Tableau Repository/Workbooks` and this repo. Fragments verbatim;
+`source-build` is each workbook's own. All are `version='18.1'`.
 
 ### `PctDiff` -> `pcdf`
 
@@ -145,6 +155,18 @@ saved its own guess - the original attestation.
 <column-instance column='[Sales]' derivation='Sum' name='[pcto:sum:Sales:qk]' pivot='key' type='quantitative'>
 ```
 
+### `Rank` -> `rank`
+
+`Embedded Filters Test.twbx`, 2024.2.10, win. Note `ordering-type='Columns'` here - the
+addressing is part of the calculation, not of the prefix, and the prefix is the same either
+way.
+
+```xml
+<column-instance column='[Sales]' derivation='Sum' name='[rank:sum:Sales:qk]' pivot='key' type='quantitative'>
+  <table-calc ordering-type='Columns' rank-options='Competition,Descending' type='Rank' />
+</column-instance>
+```
+
 ### Nesting
 
 A percent-of-total *of* a running total nests both prefixes, outermost first:
@@ -157,7 +179,7 @@ A percent-of-total *of* a running total nests both prefixes, outermost first:
 `TCType-ST` enumerates ten values. `TABLE_CALC_PREFIXES` holds eight:
 
 - **`None`** - "no table calc", so there is nothing to prefix.
-- **`Custom`** - appears in none of the 196 workbooks swept, and no dropdown entry produces
+- **`Custom`** - appears in none of the 195 workbooks swept, and no dropdown entry produces
   it. Unattested, so `manifest.TABLE_CALCS` rejects it rather than guessing a prefix.
 
 ## How to attest a new one

--- a/skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md
+++ b/skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md
@@ -6,28 +6,56 @@ instance `name`. `worksheet.TABLE_CALC_PREFIXES` holds that prefix per `TCType-S
 
 The prefix is cosmetic: a wrong one makes Desktop rewrite the name on open, it does not
 refuse the workbook. That is why a guess survives both validators - only a Desktop-saved
-workbook settles it. The rows below are read out of real Desktop output.
+workbook settles it. Of the eight prefixes, five were originally guessed and **three of
+those five were wrong**, which is the measure of how little the naming can be inferred.
 
-## Attested
+**The percent family is `pc` + two letters - four characters.** `pcto`, `pcdf`, `pcva`,
+`pcrk`. Not `pct` + verb, which is the shape every guess reached for. The non-percent calcs
+have no shared shape at all: `cum`, `diff`, `rank`.
 
-Each fragment is copied verbatim from the named workbook. `source-build` is that workbook's
-`<workbook source-build='...'>`; all four are `version='18.1'`.
+## `table-calculations-attestation.twb`
 
-### `CumTotal` -> `cum`
+The workbook beside this file, authored in **Desktop 2025.1.10 (20251.25.1121.1650), win**,
+for issue #50. Four sheets, one calculation each, identical base setup: `Order Date`
+(continuous Month) on Columns, `SUM(Sales)` on Rows, `Sample - Superstore`.
 
-`FINANCIAL SERVICES - Trading.twbx`, source-build 2023.3.0, win.
+`tests/test_features.py::test_the_attested_prefixes_match_desktops_own_output` parses it and
+asserts `FieldRef.instance_name` reproduces Desktop's `<rows>` shelf byte for byte, so the
+table cannot drift from this file without a test failing.
+
+| sheet | `<table-calc type>` | Desktop's instance name | prefix |
+|---|---|---|---|
+| `1-total` | `CumTotal` | `[cum:sum:Sales:qk]` | `cum` |
+| `2-difference` | `Difference` | `[diff:sum:Sales:qk]` | `diff` |
+| `3-percent-from` | `PctValue` | `[pcva:sum:Sales:qk]` | `pcva` |
+| `4-percentile` | `PctRank` | `[pcrk:sum:Sales:qk]` | `pcrk` |
+
+Sheet `1-total` is named for the *requested* calculation but carries **Running Total** -
+`type='CumTotal'`. It re-attests `CumTotal` and leaves `WindowTotal` unsettled.
 
 ```xml
-<column-instance column='[LinPack_215363864742895389]' derivation='User' name='[cum:usr:LinPack_215363864742895389:qk]' pivot='key' type='quantitative'>
-  <table-calc aggregation='Sum' ordering-type='Rows' type='CumTotal' />
-</column-instance>
+<!-- 2-difference -->
+<column-instance column='[Sales]' derivation='Sum' name='[diff:sum:Sales:qk]' pivot='key' type='quantitative'>
+  <table-calc diff-options='Relative' ordering-type='Rows' type='Difference'>
+
+<!-- 3-percent-from -->
+<column-instance column='[Sales]' derivation='Sum' name='[pcva:sum:Sales:qk]' pivot='key' type='quantitative'>
+  <table-calc diff-options='Relative' ordering-type='Rows' type='PctValue'>
+
+<!-- 4-percentile -->
+<column-instance column='[Sales]' derivation='Sum' name='[pcrk:sum:Sales:qk]' pivot='key' type='quantitative'>
+  <table-calc ordering-type='Rows' rank-options='Competition,Ascending' type='PctRank' />
 ```
+
+## Attested from the wider corpus
+
+Three more come from a 195-workbook sweep of the local corpus (`~/Downloads`,
+`~/Documents/My Tableau Repository/Workbooks`, this repo). Fragments verbatim; the
+`source-build` is that workbook's own. All are `version='18.1'`.
 
 ### `PctDiff` -> `pcdf`
 
-`20250818-appsfortableau_HierarchyFilter demo workbook-demo-workbook.twbx`, source-build
-2024.3.0, mac. Note the prefix is `pcdf`, not `pctdiff` - it does not follow the
-`pct` + verb shape the other percent calcs suggest.
+`20250818-appsfortableau_HierarchyFilter demo workbook-demo-workbook.twbx`, 2024.3.0, mac.
 
 ```xml
 <column-instance column='[Sales]' derivation='Sum' name='[pcdf:sum:Sales:qk]' pivot='key' type='quantitative'>
@@ -41,20 +69,16 @@ Each fragment is copied verbatim from the named workbook. `source-build` is that
 
 ### `PctTotal` -> `pcto`
 
-`lavi_webpage_test.twbx`, source-build 2025.2.0. Also the one Desktop 2025.1 renamed on
-save when the builder wrote its own guess - the original attestation.
+`lavi_webpage_test.twbx`, 2025.2.0. Also the prefix Desktop 2025.1 rewrote when the builder
+saved its own guess - the original attestation.
 
 ```xml
 <column-instance column='[Sales]' derivation='Sum' name='[pcto:sum:Sales:qk]' pivot='key' type='quantitative'>
 ```
 
-A percent-of-total *of* a running total nests both prefixes, outermost first:
-`name='[pcto:cum:usr:LinPack_215363864742895389:qk]'` - which is exactly what
-`FieldRef.instance_name` builds by prepending one prefix to `self.prefix`.
-
 ### `Rank` -> `rank`
 
-`Embedded Filters Test.twbx`, source-build 2024.2.10, win.
+`Embedded Filters Test.twbx`, 2024.2.10, win.
 
 ```xml
 <column-instance column='[Sales]' derivation='Sum' name='[rank:sum:Sales:qk]' pivot='key' type='quantitative'>
@@ -62,13 +86,18 @@ A percent-of-total *of* a running total nests both prefixes, outermost first:
 </column-instance>
 ```
 
+### Nesting
+
+A percent-of-total *of* a running total nests both prefixes, outermost first:
+`name='[pcto:cum:usr:LinPack_215363864742895389:qk]'` (`FINANCIAL SERVICES - Trading.twbx`,
+2023.3.0) - which is what `FieldRef.instance_name` builds by prepending one prefix to
+`self.prefix`.
+
 ## Still inferred
 
-`WindowTotal` (`wnd`), `Difference` (`diff`), `PctValue` (`pctval`) and `PctRank`
-(`pctrank`) do not appear in any Desktop workbook checked so far - a 195-workbook sweep of
-the local corpus (`~/Downloads`, `~/Documents/My Tableau Repository/Workbooks`, this
-repo) turned up only the four above. They stay in the table as guesses. Issue #50 has the
-sheet-by-sheet steps for authoring the workbook that would settle them.
+`WindowTotal` (`wnd`) is the last guess. It appears in no workbook checked. To settle it:
+apply **Add Table Calculation -> Calculation Type = Total** to a `SUM(Sales)` pill, save as
+`.twb`, and read the `<rows>` shelf.
 
 ## How to attest a new one
 
@@ -82,5 +111,5 @@ BLOCK = re.compile(
 # group(1).split(":")[0] is the prefix, group(3) is the TCType.
 ```
 
-Match `type=` with a lookbehind or a leading-space group - a bare `\btype=` also matches
+Match `type=` with a leading-space group or a lookbehind - a bare `\btype=` also matches
 `ordering-type=`, which reports `Rows`/`Columns`/`Field` as calculation types.

--- a/skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md
+++ b/skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md
@@ -55,6 +55,13 @@ for issue #50. Six sheets, one calculation each, identical base setup: `Order Da
 asserts `FieldRef.instance_name` reproduces Desktop's `<rows>` shelf, so the table cannot
 drift from this file without a test failing.
 
+**One edit was made to Desktop's output, and only one.** The `<connection>` element recorded
+the author's local data path, `C:/Users/<name>/Documents/My Tableau Repository/...`; the
+username is replaced by `%USERNAME%`. This is a public repository, so a real home-directory
+path does not belong in it. Nothing else was altered - every `<column>`, `<column-instance>`
+and `<table-calc>` below is byte-for-byte what Desktop 2025.1.10 wrote. The same masking was
+applied to the other tracked `.twb` snippets, which carried the same path.
+
 | sheet | applied as | `<table-calc type>` | Desktop's instance name | prefix |
 |---|---|---|---|---|
 | `1a-total` | `TOTAL(sum([Sales]))` formula | *absent* | `[usr:Calculation_1660139451271188481:qk]` | *none* |

--- a/skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md
+++ b/skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md
@@ -16,22 +16,20 @@ have no shared shape at all: `cum`, `diff`, `rank`.
 ## `table-calculations-attestation.twb`
 
 The workbook beside this file, authored in **Desktop 2025.1.10 (20251.25.1121.1650), win**,
-for issue #50. Four sheets, one calculation each, identical base setup: `Order Date`
+for issue #50. Five sheets, one calculation each, identical base setup: `Order Date`
 (continuous Month) on Columns, `SUM(Sales)` on Rows, `Sample - Superstore`.
 
 `tests/test_features.py::test_the_attested_prefixes_match_desktops_own_output` parses it and
-asserts `FieldRef.instance_name` reproduces Desktop's `<rows>` shelf byte for byte, so the
-table cannot drift from this file without a test failing.
+asserts `FieldRef.instance_name` reproduces Desktop's `<rows>` shelf, so the table cannot
+drift from this file without a test failing.
 
-| sheet | `<table-calc type>` | Desktop's instance name | prefix |
-|---|---|---|---|
-| `1-total` | `CumTotal` | `[cum:sum:Sales:qk]` | `cum` |
-| `2-difference` | `Difference` | `[diff:sum:Sales:qk]` | `diff` |
-| `3-percent-from` | `PctValue` | `[pcva:sum:Sales:qk]` | `pcva` |
-| `4-percentile` | `PctRank` | `[pcrk:sum:Sales:qk]` | `pcrk` |
-
-Sheet `1-total` is named for the *requested* calculation but carries **Running Total** -
-`type='CumTotal'`. It re-attests `CumTotal` and leaves `WindowTotal` unsettled.
+| sheet | applied as | `<table-calc type>` | Desktop's instance name | prefix |
+|---|---|---|---|---|
+| `1a-total` | `TOTAL(sum([Sales]))` | *absent* | `[usr:Calculation_1660139451271188481:qk]` | *none* |
+| `1b-running-total` | Running Total | `CumTotal` | `[cum:sum:Sales:qk]` | `cum` |
+| `2-difference` | Difference | `Difference` | `[diff:sum:Sales:qk]` | `diff` |
+| `3-percent-from` | Percent From | `PctValue` | `[pcva:sum:Sales:qk]` | `pcva` |
+| `4-percentile` | Percentile | `PctRank` | `[pcrk:sum:Sales:qk]` | `pcrk` |
 
 ```xml
 <!-- 2-difference -->
@@ -46,6 +44,44 @@ Sheet `1-total` is named for the *requested* calculation but carries **Running T
 <column-instance column='[Sales]' derivation='Sum' name='[pcrk:sum:Sales:qk]' pivot='key' type='quantitative'>
   <table-calc ordering-type='Rows' rank-options='Competition,Ascending' type='PctRank' />
 ```
+
+### A window total has no type and no prefix
+
+Sheet `1a-total` is the important negative result. Desktop's **Total** is not a
+Quick Table Calculation - it is authored as a **calculated field**, and the
+`<table-calc>` it carries has **no `type` attribute at all**, only addressing:
+
+```xml
+<column caption='Total Sales' datatype='real' name='[Calculation_1660139451271188481]' role='measure' type='quantitative'>
+  <calculation class='tableau' formula='TOTAL(sum([Sales]))'>
+    <table-calc ordering-type='Rows' />
+  </calculation>
+</column>
+<column-instance column='[Calculation_1660139451271188481]' derivation='User' name='[usr:Calculation_1660139451271188481:qk]' pivot='key' type='quantitative'>
+  <table-calc ordering-type='Rows' />
+</column-instance>
+```
+
+The instance keeps the plain `usr` prefix a calculated field always gets - it gains no
+table-calc prefix. So the builder's way to express a window total is a **calculated field
+with the `TOTAL(...)` formula**, not `table_calc: WindowTotal`.
+`test_a_total_table_calc_is_a_calculated_field_with_no_type` pins this.
+
+### The Calculation Type menu, mapped
+
+Desktop 2025.1.10's **Add Table Calculation -> Calculation Type** dropdown offers eight
+entries. Seven map to an attested `TCType-ST`; there is **no "Total" entry**.
+
+| menu entry | `TCType-ST` | prefix |
+|---|---|---|
+| Difference From | `Difference` | `diff` |
+| Percent Difference From | `PctDiff` | `pcdf` |
+| Percent From | `PctValue` | `pcva` |
+| Percent of Total | `PctTotal` | `pcto` |
+| Rank | `Rank` | `rank` |
+| Percentile | `PctRank` | `pcrk` |
+| Running Total | `CumTotal` | `cum` |
+| Moving Calculation | *unchecked* - the `WindowTotal` candidate | *unknown* |
 
 ## Attested from the wider corpus
 
@@ -95,9 +131,23 @@ A percent-of-total *of* a running total nests both prefixes, outermost first:
 
 ## Still inferred
 
-`WindowTotal` (`wnd`) is the last guess. It appears in no workbook checked. To settle it:
-apply **Add Table Calculation -> Calculation Type = Total** to a `SUM(Sales)` pill, save as
-`.twb`, and read the `<rows>` shelf.
+`WindowTotal` -> `wnd` is the last guess, and the weakest thing in this table. What is known:
+
+- It is in the XSD's `TCType-ST`, so Tableau does write it somewhere.
+- It appears in **none of the 196 workbooks** swept. Neither does `Custom`, the other
+  `TCType-ST` value the builder does not offer, nor the `window-options` attribute.
+- Desktop's `TOTAL(...)` - the function an analyst means by "window total" - does **not**
+  produce it. See the negative result above.
+- Of the eight Calculation Type entries, **Moving Calculation** is the only one not yet
+  traced to a type. `WindowOptions-ST` is `IncludeCurrent` / `NullIfIncomplete`, which are
+  exactly Moving Calculation's two checkboxes, and `window-options` sits beside `type` on
+  the same element. That makes Moving Calculation the strong candidate for `WindowTotal`.
+
+To settle it: apply **Quick Table Calculation -> Moving Average** (or **Add Table
+Calculation -> Moving Calculation**) to a `SUM(Sales)` pill, save as `.twb`, and read the
+`<rows>` shelf. If it writes `WindowTotal`, correct the prefix and note that the type means
+*moving calculation*, not *total*. If it writes something else, `WindowTotal` is unreachable
+from the UI and should be dropped from the table and rejected at validation.
 
 ## How to attest a new one
 

--- a/skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md
+++ b/skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md
@@ -1,22 +1,54 @@
 # Table-calculation instance-name prefixes
 
-A table calculation does not get a `<column>` of its own. It lives on the
-`<column-instance>` as a `<table-calc>` child, and Tableau puts an extra prefix on the
-instance `name`. `worksheet.TABLE_CALC_PREFIXES` holds that prefix per `TCType-ST` value.
+A table calculation applied through **Add Table Calculation** does not get a `<column>` of
+its own. It lives on the `<column-instance>` as a `<table-calc>` child, and Tableau puts an
+extra prefix on the instance `name`. `worksheet.TABLE_CALC_PREFIXES` holds that prefix per
+`TCType-ST` value.
 
 The prefix is cosmetic: a wrong one makes Desktop rewrite the name on open, it does not
 refuse the workbook. That is why a guess survives both validators - only a Desktop-saved
-workbook settles it. Of the eight prefixes, five were originally guessed and **three of
-those five were wrong**, which is the measure of how little the naming can be inferred.
+workbook settles it. **All eight are now attested.** Of the seven originally guessed, four
+were wrong.
 
-**The percent family is `pc` + two letters - four characters.** `pcto`, `pcdf`, `pcva`,
-`pcrk`. Not `pct` + verb, which is the shape every guess reached for. The non-percent calcs
-have no shared shape at all: `cum`, `diff`, `rank`.
+## Do not extend this table by analogy
+
+That is the lesson of issue #50, and the four-of-seven failure rate is the evidence.
+
+| type | the guess | Desktop |
+|---|---|---|
+| `CumTotal` | `cum` | `cum` |
+| `Difference` | `diff` | `diff` |
+| `Rank` | `rank` | `rank` |
+| `PctDiff` | `pctdiff` | **`pcdf`** |
+| `PctValue` | `pctval` | **`pcva`** |
+| `PctRank` | `pctrank` | **`pcrk`** |
+| `WindowTotal` | `wnd` | **`win`** |
+
+A short type name passes through (`cum`, `diff`, `rank`). A long one is squeezed to four
+characters with the vowels dropped first (`pcto`, `pcdf`, `pcva`, `pcrk`). `WindowTotal`
+becomes `win` - neither rule predicts it. Read a new one off Desktop.
+
+## Two authoring paths, only one of which takes a prefix
+
+Both produce a table calculation. They serialize differently:
+
+| | applied via **Add Table Calculation** | written as a **formula** |
+|---|---|---|
+| carrier | the `<column-instance>` | a calculated field `<column>` |
+| `<table-calc type>` | present (`CumTotal`, `PctDiff`, ...) | **absent** - addressing only |
+| instance prefix | the type's prefix (`cum:`, `pcdf:`, ...) | the ordinary `usr:` |
+| in a manifest | `table_calc: <type>` | a calculated field's `formula` |
+
+`TOTAL(...)`, `WINDOW_SUM(...)` and the rest of that family *are* table calculations; they
+are simply not offered by the dialog, so they take the formula path. `TABLE_CALC_PREFIXES`
+governs the dialog-driven ones only.
+`tests/test_features.py::test_a_total_table_calc_is_a_calculated_field_with_no_type` pins
+that boundary.
 
 ## `table-calculations-attestation.twb`
 
 The workbook beside this file, authored in **Desktop 2025.1.10 (20251.25.1121.1650), win**,
-for issue #50. Five sheets, one calculation each, identical base setup: `Order Date`
+for issue #50. Six sheets, one calculation each, identical base setup: `Order Date`
 (continuous Month) on Columns, `SUM(Sales)` on Rows, `Sample - Superstore`.
 
 `tests/test_features.py::test_the_attested_prefixes_match_desktops_own_output` parses it and
@@ -25,13 +57,18 @@ drift from this file without a test failing.
 
 | sheet | applied as | `<table-calc type>` | Desktop's instance name | prefix |
 |---|---|---|---|---|
-| `1a-total` | `TOTAL(sum([Sales]))` | *absent* | `[usr:Calculation_1660139451271188481:qk]` | *none* |
+| `1a-total` | `TOTAL(sum([Sales]))` formula | *absent* | `[usr:Calculation_1660139451271188481:qk]` | *none* |
 | `1b-running-total` | Running Total | `CumTotal` | `[cum:sum:Sales:qk]` | `cum` |
 | `2-difference` | Difference | `Difference` | `[diff:sum:Sales:qk]` | `diff` |
 | `3-percent-from` | Percent From | `PctValue` | `[pcva:sum:Sales:qk]` | `pcva` |
 | `4-percentile` | Percentile | `PctRank` | `[pcrk:sum:Sales:qk]` | `pcrk` |
+| `5-moving-average` | Moving Average | `WindowTotal` | `[win:sum:Sales:qk]` | `win` |
 
 ```xml
+<!-- 1b-running-total -->
+<column-instance column='[Sales]' derivation='Sum' name='[cum:sum:Sales:qk]' pivot='key' type='quantitative'>
+  <table-calc aggregation='Sum' ordering-type='Rows' type='CumTotal' />
+
 <!-- 2-difference -->
 <column-instance column='[Sales]' derivation='Sum' name='[diff:sum:Sales:qk]' pivot='key' type='quantitative'>
   <table-calc diff-options='Relative' ordering-type='Rows' type='Difference'>
@@ -43,13 +80,14 @@ drift from this file without a test failing.
 <!-- 4-percentile -->
 <column-instance column='[Sales]' derivation='Sum' name='[pcrk:sum:Sales:qk]' pivot='key' type='quantitative'>
   <table-calc ordering-type='Rows' rank-options='Competition,Ascending' type='PctRank' />
+
+<!-- 5-moving-average: WindowTotal is what Moving Calculation writes. 'from'/'to' are the
+     window bounds and window-options is the "include current value" checkbox. -->
+<column-instance column='[Sales]' derivation='Sum' name='[win:sum:Sales:qk]' pivot='key' type='quantitative'>
+  <table-calc aggregation='Avg' from='-2' ordering-type='Rows' to='0' type='WindowTotal' window-options='IncludeCurrent' />
 ```
 
-### A window total has no type and no prefix
-
-Sheet `1a-total` is the important negative result. Desktop's **Total** is not a
-Quick Table Calculation - it is authored as a **calculated field**, and the
-`<table-calc>` it carries has **no `type` attribute at all**, only addressing:
+`1a-total` takes the formula path, so it has no `type` and no prefix:
 
 ```xml
 <column caption='Total Sales' datatype='real' name='[Calculation_1660139451271188481]' role='measure' type='quantitative'>
@@ -62,15 +100,10 @@ Quick Table Calculation - it is authored as a **calculated field**, and the
 </column-instance>
 ```
 
-The instance keeps the plain `usr` prefix a calculated field always gets - it gains no
-table-calc prefix. So the builder's way to express a window total is a **calculated field
-with the `TOTAL(...)` formula**, not `table_calc: WindowTotal`.
-`test_a_total_table_calc_is_a_calculated_field_with_no_type` pins this.
-
 ### The Calculation Type menu, mapped
 
-Desktop 2025.1.10's **Add Table Calculation -> Calculation Type** dropdown offers eight
-entries. Seven map to an attested `TCType-ST`; there is **no "Total" entry**.
+Desktop 2025.1.10's dropdown offers eight entries, all now traced. There is no "Total"
+entry - that is the formula path above.
 
 | menu entry | `TCType-ST` | prefix |
 |---|---|---|
@@ -81,13 +114,13 @@ entries. Seven map to an attested `TCType-ST`; there is **no "Total" entry**.
 | Rank | `Rank` | `rank` |
 | Percentile | `PctRank` | `pcrk` |
 | Running Total | `CumTotal` | `cum` |
-| Moving Calculation | *unchecked* - the `WindowTotal` candidate | *unknown* |
+| Moving Calculation | `WindowTotal` | `win` |
 
 ## Attested from the wider corpus
 
-Three more come from a 195-workbook sweep of the local corpus (`~/Downloads`,
-`~/Documents/My Tableau Repository/Workbooks`, this repo). Fragments verbatim; the
-`source-build` is that workbook's own. All are `version='18.1'`.
+Two prefixes are not in the reference workbook. They come from a 195-workbook sweep of
+`~/Downloads`, `~/Documents/My Tableau Repository/Workbooks` and this repo. Fragments
+verbatim; `source-build` is each workbook's own. All are `version='18.1'`.
 
 ### `PctDiff` -> `pcdf`
 
@@ -112,16 +145,6 @@ saved its own guess - the original attestation.
 <column-instance column='[Sales]' derivation='Sum' name='[pcto:sum:Sales:qk]' pivot='key' type='quantitative'>
 ```
 
-### `Rank` -> `rank`
-
-`Embedded Filters Test.twbx`, 2024.2.10, win.
-
-```xml
-<column-instance column='[Sales]' derivation='Sum' name='[rank:sum:Sales:qk]' pivot='key' type='quantitative'>
-  <table-calc ordering-type='Columns' rank-options='Competition,Descending' type='Rank' />
-</column-instance>
-```
-
 ### Nesting
 
 A percent-of-total *of* a running total nests both prefixes, outermost first:
@@ -129,25 +152,13 @@ A percent-of-total *of* a running total nests both prefixes, outermost first:
 2023.3.0) - which is what `FieldRef.instance_name` builds by prepending one prefix to
 `self.prefix`.
 
-## Still inferred
+## The two TCType-ST values the builder does not offer
 
-`WindowTotal` -> `wnd` is the last guess, and the weakest thing in this table. What is known:
+`TCType-ST` enumerates ten values. `TABLE_CALC_PREFIXES` holds eight:
 
-- It is in the XSD's `TCType-ST`, so Tableau does write it somewhere.
-- It appears in **none of the 196 workbooks** swept. Neither does `Custom`, the other
-  `TCType-ST` value the builder does not offer, nor the `window-options` attribute.
-- Desktop's `TOTAL(...)` - the function an analyst means by "window total" - does **not**
-  produce it. See the negative result above.
-- Of the eight Calculation Type entries, **Moving Calculation** is the only one not yet
-  traced to a type. `WindowOptions-ST` is `IncludeCurrent` / `NullIfIncomplete`, which are
-  exactly Moving Calculation's two checkboxes, and `window-options` sits beside `type` on
-  the same element. That makes Moving Calculation the strong candidate for `WindowTotal`.
-
-To settle it: apply **Quick Table Calculation -> Moving Average** (or **Add Table
-Calculation -> Moving Calculation**) to a `SUM(Sales)` pill, save as `.twb`, and read the
-`<rows>` shelf. If it writes `WindowTotal`, correct the prefix and note that the type means
-*moving calculation*, not *total*. If it writes something else, `WindowTotal` is unreachable
-from the UI and should be dropped from the table and rejected at validation.
+- **`None`** - "no table calc", so there is nothing to prefix.
+- **`Custom`** - appears in none of the 196 workbooks swept, and no dropdown entry produces
+  it. Unattested, so `manifest.TABLE_CALCS` rejects it rather than guessing a prefix.
 
 ## How to attest a new one
 

--- a/skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md
+++ b/skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md
@@ -1,0 +1,86 @@
+# Table-calculation instance-name prefixes
+
+A table calculation does not get a `<column>` of its own. It lives on the
+`<column-instance>` as a `<table-calc>` child, and Tableau puts an extra prefix on the
+instance `name`. `worksheet.TABLE_CALC_PREFIXES` holds that prefix per `TCType-ST` value.
+
+The prefix is cosmetic: a wrong one makes Desktop rewrite the name on open, it does not
+refuse the workbook. That is why a guess survives both validators - only a Desktop-saved
+workbook settles it. The rows below are read out of real Desktop output.
+
+## Attested
+
+Each fragment is copied verbatim from the named workbook. `source-build` is that workbook's
+`<workbook source-build='...'>`; all four are `version='18.1'`.
+
+### `CumTotal` -> `cum`
+
+`FINANCIAL SERVICES - Trading.twbx`, source-build 2023.3.0, win.
+
+```xml
+<column-instance column='[LinPack_215363864742895389]' derivation='User' name='[cum:usr:LinPack_215363864742895389:qk]' pivot='key' type='quantitative'>
+  <table-calc aggregation='Sum' ordering-type='Rows' type='CumTotal' />
+</column-instance>
+```
+
+### `PctDiff` -> `pcdf`
+
+`20250818-appsfortableau_HierarchyFilter demo workbook-demo-workbook.twbx`, source-build
+2024.3.0, mac. Note the prefix is `pcdf`, not `pctdiff` - it does not follow the
+`pct` + verb shape the other percent calcs suggest.
+
+```xml
+<column-instance column='[Sales]' derivation='Sum' name='[pcdf:sum:Sales:qk]' pivot='key' type='quantitative'>
+  <table-calc diff-options='Relative' level-address='[Sample - Superstore].[yr:Order Date:ok]' ordering-field='[Sample - Superstore].[Order Date]' ordering-type='Field' type='PctDiff'>
+    <address>
+      <value>-1</value>
+    </address>
+  </table-calc>
+</column-instance>
+```
+
+### `PctTotal` -> `pcto`
+
+`lavi_webpage_test.twbx`, source-build 2025.2.0. Also the one Desktop 2025.1 renamed on
+save when the builder wrote its own guess - the original attestation.
+
+```xml
+<column-instance column='[Sales]' derivation='Sum' name='[pcto:sum:Sales:qk]' pivot='key' type='quantitative'>
+```
+
+A percent-of-total *of* a running total nests both prefixes, outermost first:
+`name='[pcto:cum:usr:LinPack_215363864742895389:qk]'` - which is exactly what
+`FieldRef.instance_name` builds by prepending one prefix to `self.prefix`.
+
+### `Rank` -> `rank`
+
+`Embedded Filters Test.twbx`, source-build 2024.2.10, win.
+
+```xml
+<column-instance column='[Sales]' derivation='Sum' name='[rank:sum:Sales:qk]' pivot='key' type='quantitative'>
+  <table-calc ordering-type='Columns' rank-options='Competition,Descending' type='Rank' />
+</column-instance>
+```
+
+## Still inferred
+
+`WindowTotal` (`wnd`), `Difference` (`diff`), `PctValue` (`pctval`) and `PctRank`
+(`pctrank`) do not appear in any Desktop workbook checked so far - a 195-workbook sweep of
+the local corpus (`~/Downloads`, `~/Documents/My Tableau Repository/Workbooks`, this
+repo) turned up only the four above. They stay in the table as guesses. Issue #50 has the
+sheet-by-sheet steps for authoring the workbook that would settle them.
+
+## How to attest a new one
+
+The pairing is `<table-calc type='X'>` inside a `<column-instance name='[prefix:...]'>`, so
+one sweep reads them all:
+
+```python
+BLOCK = re.compile(
+    r"<column-instance\b[^>]*name='\[([^']*)'[^>]*>\s*"
+    r"<table-calc\b((?:[^>]*?\s)?)type='([^']*)'", re.S)
+# group(1).split(":")[0] is the prefix, group(3) is the TCType.
+```
+
+Match `type=` with a lookbehind or a leading-space group - a bare `\btype=` also matches
+`ordering-type=`, which reports `Rows`/`Columns`/`Field` as calculation types.

--- a/skills/tableau-build/references/snippets/worksheets/table-calculations-attestation.twb
+++ b/skills/tableau-build/references/snippets/worksheets/table-calculations-attestation.twb
@@ -1,0 +1,3849 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<!-- build 20251.25.1121.1650                               -->
+<workbook original-version='18.1' source-build='2025.1.10 (20251.25.1121.1650)' source-platform='win' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <document-format-change-manifest>
+    <AnimationOnByDefault />
+    <MarkAnimation />
+    <ObjectModelEncapsulateLegacy />
+    <ObjectModelTableType />
+    <SchemaViewerObjectModel />
+    <SheetIdentifierTracking />
+    <WindowsPersistSimpleIdentifiers />
+  </document-format-change-manifest>
+  <preferences>
+    <preference name='ui.encoding.shelf.height' value='24' />
+    <preference name='ui.shelf.height' value='26' />
+  </preferences>
+  <datasources>
+    <datasource hasconnection='false' inline='true' name='Parameters' version='18.1'>
+      <aliases enabled='yes' />
+      <column caption='Top Customers' datatype='integer' name='[Parameter 1]' param-domain-type='range' role='measure' type='quantitative' value='5'>
+        <calculation class='tableau' formula='5' />
+        <range granularity='5' max='20' min='5' />
+      </column>
+      <column caption='Profit Bin Size' datatype='integer' name='[Parameter 2]' param-domain-type='range' role='measure' type='quantitative' value='200'>
+        <calculation class='tableau' formula='200' />
+        <range granularity='50' max='200' min='50' />
+      </column>
+    </datasource>
+    <datasource inline='true' name='Sample - Superstore' version='18.1'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='Sample - Superstore' name='excel-direct.0ozsbj20cdelf51evvdk71kugqg0'>
+            <connection class='excel-direct' cleaning='no' compat='no' dataRefreshTime='' filename='C:/Users/lavid/Documents/My Tableau Repository/Datasources/2025.1/en_US-US/Sample - Superstore.xls' interpretationMode='0' password='' server='' validate='no' />
+          </named-connection>
+        </named-connections>
+        <relation type='collection'>
+          <relation connection='excel-direct.0ozsbj20cdelf51evvdk71kugqg0' name='Orders' table='[Orders$]' type='table'>
+            <columns gridOrigin='A1:U10195:no:A1:U10195:0' header='yes' outcome='2'>
+              <column datatype='integer' name='Row ID' ordinal='0' />
+              <column datatype='string' name='Order ID' ordinal='1' />
+              <column datatype='date' name='Order Date' ordinal='2' />
+              <column datatype='date' name='Ship Date' ordinal='3' />
+              <column datatype='string' name='Ship Mode' ordinal='4' />
+              <column datatype='string' name='Customer ID' ordinal='5' />
+              <column datatype='string' name='Customer Name' ordinal='6' />
+              <column datatype='string' name='Segment' ordinal='7' />
+              <column datatype='string' name='Country/Region' ordinal='8' />
+              <column datatype='string' name='City' ordinal='9' />
+              <column datatype='string' name='State/Province' ordinal='10' />
+              <column datatype='string' name='Postal Code' ordinal='11' />
+              <column datatype='string' name='Region' ordinal='12' />
+              <column datatype='string' name='Product ID' ordinal='13' />
+              <column datatype='string' name='Category' ordinal='14' />
+              <column datatype='string' name='Sub-Category' ordinal='15' />
+              <column datatype='string' name='Product Name' ordinal='16' />
+              <column datatype='real' name='Sales' ordinal='17' />
+              <column datatype='integer' name='Quantity' ordinal='18' />
+              <column datatype='real' name='Discount' ordinal='19' />
+              <column datatype='real' name='Profit' ordinal='20' />
+            </columns>
+          </relation>
+          <relation connection='excel-direct.0ozsbj20cdelf51evvdk71kugqg0' name='People' table='[People$]' type='table'>
+            <columns gridOrigin='A1:B5:no:A1:B5:0' header='yes' outcome='6'>
+              <column datatype='string' name='Regional Manager' ordinal='0' />
+              <column datatype='string' name='Region' ordinal='1' />
+            </columns>
+          </relation>
+          <relation connection='excel-direct.0ozsbj20cdelf51evvdk71kugqg0' name='Returns' table='[Returns$]' type='table'>
+            <columns gridOrigin='A1:B297:no:A1:B297:0' header='yes' outcome='6'>
+              <column datatype='string' name='Order ID' ordinal='0' />
+              <column datatype='string' name='Returned' ordinal='1' />
+            </columns>
+          </relation>
+        </relation>
+        <cols>
+          <map key='[Category]' value='[Orders].[Category]' />
+          <map key='[City]' value='[Orders].[City]' />
+          <map key='[Country/Region]' value='[Orders].[Country/Region]' />
+          <map key='[Customer ID]' value='[Orders].[Customer ID]' />
+          <map key='[Customer Name]' value='[Orders].[Customer Name]' />
+          <map key='[Discount]' value='[Orders].[Discount]' />
+          <map key='[Order Date]' value='[Orders].[Order Date]' />
+          <map key='[Order ID (Returns)]' value='[Returns].[Order ID]' />
+          <map key='[Order ID]' value='[Orders].[Order ID]' />
+          <map key='[Postal Code]' value='[Orders].[Postal Code]' />
+          <map key='[Product ID]' value='[Orders].[Product ID]' />
+          <map key='[Product Name]' value='[Orders].[Product Name]' />
+          <map key='[Profit]' value='[Orders].[Profit]' />
+          <map key='[Quantity]' value='[Orders].[Quantity]' />
+          <map key='[Region (People)]' value='[People].[Region]' />
+          <map key='[Region]' value='[Orders].[Region]' />
+          <map key='[Regional Manager]' value='[People].[Regional Manager]' />
+          <map key='[Returned]' value='[Returns].[Returned]' />
+          <map key='[Row ID]' value='[Orders].[Row ID]' />
+          <map key='[Sales]' value='[Orders].[Sales]' />
+          <map key='[Segment]' value='[Orders].[Segment]' />
+          <map key='[Ship Date]' value='[Orders].[Ship Date]' />
+          <map key='[Ship Mode]' value='[Orders].[Ship Mode]' />
+          <map key='[State/Province]' value='[Orders].[State/Province]' />
+          <map key='[Sub-Category]' value='[Orders].[Sub-Category]' />
+        </cols>
+        <metadata-records>
+          <metadata-record class='capability'>
+            <remote-name />
+            <remote-type>0</remote-type>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias />
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='context'>2</attribute>
+              <attribute datatype='string' name='gridOrigin'>&quot;A1:U10195:no:A1:U10195:0&quot;</attribute>
+              <attribute datatype='boolean' name='header'>true</attribute>
+              <attribute datatype='integer' name='outcome'>2</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='capability'>
+            <remote-name />
+            <remote-type>0</remote-type>
+            <parent-name>[People]</parent-name>
+            <remote-alias />
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='context'>0</attribute>
+              <attribute datatype='string' name='gridOrigin'>&quot;A1:B5:no:A1:B5:0&quot;</attribute>
+              <attribute datatype='boolean' name='header'>true</attribute>
+              <attribute datatype='integer' name='outcome'>6</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='capability'>
+            <remote-name />
+            <remote-type>0</remote-type>
+            <parent-name>[Returns]</parent-name>
+            <remote-alias />
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='context'>2</attribute>
+              <attribute datatype='string' name='gridOrigin'>&quot;A1:B297:no:A1:B297:0&quot;</attribute>
+              <attribute datatype='boolean' name='header'>true</attribute>
+              <attribute datatype='integer' name='outcome'>6</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Row ID</remote-name>
+            <remote-type>20</remote-type>
+            <local-name>[Row ID]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Row ID</remote-alias>
+            <ordinal>0</ordinal>
+            <local-type>integer</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;I8&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Order ID</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Order ID]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Order ID</remote-alias>
+            <ordinal>1</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Order Date</remote-name>
+            <remote-type>7</remote-type>
+            <local-name>[Order Date]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Order Date</remote-alias>
+            <ordinal>2</ordinal>
+            <local-type>date</local-type>
+            <aggregation>Year</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;DATE&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Ship Date</remote-name>
+            <remote-type>7</remote-type>
+            <local-name>[Ship Date]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Ship Date</remote-alias>
+            <ordinal>3</ordinal>
+            <local-type>date</local-type>
+            <aggregation>Year</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;DATE&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Ship Mode</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Ship Mode]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Ship Mode</remote-alias>
+            <ordinal>4</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Customer ID</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Customer ID]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Customer ID</remote-alias>
+            <ordinal>5</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Customer Name</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Customer Name]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Customer Name</remote-alias>
+            <ordinal>6</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Segment</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Segment]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Segment</remote-alias>
+            <ordinal>7</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Country/Region</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Country/Region]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Country/Region</remote-alias>
+            <ordinal>8</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>City</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[City]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>City</remote-alias>
+            <ordinal>9</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>State/Province</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[State/Province]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>State/Province</remote-alias>
+            <ordinal>10</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Postal Code</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Postal Code]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Postal Code</remote-alias>
+            <ordinal>11</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Region</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Region]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Region</remote-alias>
+            <ordinal>12</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Product ID</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Product ID]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Product ID</remote-alias>
+            <ordinal>13</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Category</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Category]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Category</remote-alias>
+            <ordinal>14</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Sub-Category</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Sub-Category]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Sub-Category</remote-alias>
+            <ordinal>15</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Product Name</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Product Name]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Product Name</remote-alias>
+            <ordinal>16</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Sales</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[Sales]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Sales</remote-alias>
+            <ordinal>17</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <precision>15</precision>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;R8&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Quantity</remote-name>
+            <remote-type>20</remote-type>
+            <local-name>[Quantity]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Quantity</remote-alias>
+            <ordinal>18</ordinal>
+            <local-type>integer</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;I8&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Discount</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[Discount]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Discount</remote-alias>
+            <ordinal>19</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <precision>15</precision>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;R8&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Profit</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[Profit]</local-name>
+            <parent-name>[Orders]</parent-name>
+            <remote-alias>Profit</remote-alias>
+            <ordinal>20</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <precision>15</precision>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;R8&quot;</attribute>
+            </attributes>
+            <object-id>[Orders_ECFCA1FB690A41FE803BC071773BA862]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Regional Manager</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Regional Manager]</local-name>
+            <parent-name>[People]</parent-name>
+            <remote-alias>Regional Manager</remote-alias>
+            <ordinal>21</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[People_D73023733B004CC1B3CB1ACF62F4A965]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Region</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Region (People)]</local-name>
+            <parent-name>[People]</parent-name>
+            <remote-alias>Region</remote-alias>
+            <ordinal>22</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[People_D73023733B004CC1B3CB1ACF62F4A965]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Order ID</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Order ID (Returns)]</local-name>
+            <parent-name>[Returns]</parent-name>
+            <remote-alias>Order ID</remote-alias>
+            <ordinal>23</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Returns_2AA0FE4D737A4F63970131D0E7480A03]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Returned</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[Returned]</local-name>
+            <parent-name>[Returns]</parent-name>
+            <remote-alias>Returned</remote-alias>
+            <ordinal>24</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <collation flag='1' name='LEN_RUS_S2' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;WSTR&quot;</attribute>
+            </attributes>
+            <object-id>[Returns_2AA0FE4D737A4F63970131D0E7480A03]</object-id>
+          </metadata-record>
+        </metadata-records>
+      </connection>
+      <aliases enabled='yes' />
+      <column caption='Profit Ratio' datatype='real' name='[Calculation_1368249927221915648]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='SUM([Profit])/SUM([Sales])' />
+      </column>
+      <column datatype='string' name='[City]' role='dimension' semantic-role='[City].[Name]' type='nominal' />
+      <column datatype='string' name='[Country/Region]' role='dimension' semantic-role='[Country].[ISO3166_2]' type='nominal' />
+      <column datatype='string' hidden='true' name='[Customer ID]' role='dimension' type='nominal' />
+      <column datatype='string' name='[Customer Name]' role='dimension' type='nominal' />
+      <column datatype='string' hidden='true' name='[Order ID (Returns)]' role='dimension' type='nominal' />
+      <column datatype='string' default-format='*00000' name='[Postal Code]' role='dimension' semantic-role='[ZipCode].[Name]' type='nominal' />
+      <column datatype='string' hidden='true' name='[Product ID]' role='dimension' type='nominal' />
+      <column caption='Manufacturer' datatype='string' name='[Product Name (group)]' role='dimension' type='nominal'>
+        <calculation class='categorical-bin' column='[Product Name]' new-bin='true'>
+          <bin default-name='false' value='&quot;3D Systems&quot;'>
+            <value>&quot;3D Systems Cube Printer, 2nd Generation, Magenta&quot;</value>
+            <value>&quot;3D Systems Cube Printer, 2nd Generation, White&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;3M&quot;'>
+            <value>&quot;3M Hangers With Command Adhesive&quot;</value>
+            <value>&quot;3M Office Air Cleaner&quot;</value>
+            <value>&quot;3M Organizer Strips&quot;</value>
+            <value>&quot;3M Polarizing Light Filter Sleeves&quot;</value>
+            <value>&quot;3M Polarizing Task Lamp with Clamp Arm, Light Gray&quot;</value>
+            <value>&quot;3M Replacement Filter for Office Air Cleaner for 20&apos; x 33&apos; Room&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Acco&quot;'>
+            <value>&quot;Acco 3-Hole Punch&quot;</value>
+            <value>&quot;Acco 6 Outlet Guardian Basic Surge Suppressor&quot;</value>
+            <value>&quot;Acco 6 Outlet Guardian Premium Plus Surge Suppressor&quot;</value>
+            <value>&quot;Acco 6 Outlet Guardian Premium Surge Suppressor&quot;</value>
+            <value>&quot;Acco 6 Outlet Guardian Standard Surge Suppressor&quot;</value>
+            <value>&quot;Acco 7-Outlet Masterpiece Power Center, Wihtout Fax/Phone Line Protection&quot;</value>
+            <value>&quot;Acco Banker&apos;s Clasps, 5 3/4\&quot;-Long&quot;</value>
+            <value>&quot;Acco Clips to Go Binder Clips, 24 Clips in Two Sizes&quot;</value>
+            <value>&quot;Acco D-Ring Binder w/DublLock&quot;</value>
+            <value>&quot;Acco Data Flex Cable Posts For Top &amp; Bottom Load Binders, 6\&quot; Capacity&quot;</value>
+            <value>&quot;Acco Economy Flexible Poly Round Ring Binder&quot;</value>
+            <value>&quot;Acco Expandable Hanging Binders&quot;</value>
+            <value>&quot;Acco Flexible ACCOHIDE Square Ring Data Binder, Dark Blue, 11 1/2\&quot; X 14\&quot; 7/8\&quot;&quot;</value>
+            <value>&quot;Acco Four Pocket Poly Ring Binder with Label Holder, Smoke, 1\&quot;&quot;</value>
+            <value>&quot;Acco Glide Clips&quot;</value>
+            <value>&quot;Acco Hanging Data Binders&quot;</value>
+            <value>&quot;Acco Hot Clips Clips to Go&quot;</value>
+            <value>&quot;Acco Perma 2700 Stacking Storage Drawers&quot;</value>
+            <value>&quot;Acco Perma 3000 Stacking Storage Drawers&quot;</value>
+            <value>&quot;Acco Perma 4000 Stacking Storage Drawers&quot;</value>
+            <value>&quot;Acco Pressboard Covers with Storage Hooks, 14 7/8\&quot; x 11\&quot;, Dark Blue&quot;</value>
+            <value>&quot;Acco Pressboard Covers with Storage Hooks, 14 7/8\&quot; x 11\&quot;, Executive Red&quot;</value>
+            <value>&quot;Acco Pressboard Covers with Storage Hooks, 14 7/8\&quot; x 11\&quot;, Light Blue&quot;</value>
+            <value>&quot;Acco Pressboard Covers with Storage Hooks, 9 1/2\&quot; x 11\&quot;, Executive Red&quot;</value>
+            <value>&quot;Acco PRESSTEX Data Binder with Storage Hooks, Dark Blue, 14 7/8\&quot; X 11\&quot;&quot;</value>
+            <value>&quot;Acco PRESSTEX Data Binder with Storage Hooks, Dark Blue, 9 1/2\&quot; X 11\&quot;&quot;</value>
+            <value>&quot;Acco PRESSTEX Data Binder with Storage Hooks, Light Blue, 9 1/2\&quot; X 11\&quot;&quot;</value>
+            <value>&quot;Acco Recycled 2\&quot; Capacity Laser Printer Hanging Data Binders&quot;</value>
+            <value>&quot;Acco Side-Punched Conventional Columnar Pads&quot;</value>
+            <value>&quot;Acco Six-Outlet Power Strip, 4&apos; Cord Length&quot;</value>
+            <value>&quot;Acco Smartsocket Color-Coded Six-Outlet AC Adapter Model Surge Protectors&quot;</value>
+            <value>&quot;Acco Smartsocket Table Surge Protector, 6 Color-Coded Adapter Outlets&quot;</value>
+            <value>&quot;Acco Suede Grain Vinyl Round Ring Binder&quot;</value>
+            <value>&quot;Acco Translucent Poly Ring Binders&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;ACCOHIDE&quot;'>
+            <value>&quot;ACCOHIDE 3-Ring Binder, Blue, 1\&quot;&quot;</value>
+            <value>&quot;ACCOHIDE Binder by Acco&quot;</value>
+            <value>&quot;Accohide Poly Flexible Ring Binders&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Acme&quot;'>
+            <value>&quot;Acme 10\&quot; Easy Grip Assistive Scissors&quot;</value>
+            <value>&quot;Acme 8\&quot; Straight Scissors&quot;</value>
+            <value>&quot;Acme Box Cutter Scissors&quot;</value>
+            <value>&quot;Acme Design Line 8\&quot; Stainless Steel Bent Scissors w/Champagne Handles, 3-1/8\&quot; Cut&quot;</value>
+            <value>&quot;Acme Design Stainless Steel Bent Scissors&quot;</value>
+            <value>&quot;Acme Elite Stainless Steel Scissors&quot;</value>
+            <value>&quot;Acme Forged Steel Scissors with Black Enamel Handles&quot;</value>
+            <value>&quot;Acme Galleria Hot Forged Steel Scissors with Colored Handles&quot;</value>
+            <value>&quot;Acme Hot Forged Carbon Steel Scissors with Nickel-Plated Handles, 3 7/8\&quot; Cut, 8\&quot;L&quot;</value>
+            <value>&quot;Acme Kleen Earth Office Shears&quot;</value>
+            <value>&quot;Acme Kleencut Forged Steel Scissors&quot;</value>
+            <value>&quot;Acme Office Executive Series Stainless Steel Trimmers&quot;</value>
+            <value>&quot;Acme Preferred Stainless Steel Scissors&quot;</value>
+            <value>&quot;Acme Rosewood Handle Letter Opener&quot;</value>
+            <value>&quot;Acme Serrated Blade Letter Opener&quot;</value>
+            <value>&quot;Acme Softgrip Scissors&quot;</value>
+            <value>&quot;Acme Stainless Steel Office Snips&quot;</value>
+            <value>&quot;Acme Tagit Stainless Steel Antibacterial Scissors&quot;</value>
+            <value>&quot;Acme Titanium Bonded Scissors&quot;</value>
+            <value>&quot;Acme Value Line Scissors&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Adams&quot;'>
+            <value>&quot;Adams \&quot;While You Were Out\&quot; Message Pads&quot;</value>
+            <value>&quot;Adams Phone Message Book, 200 Message Capacity, 8 1/16” x 11”&quot;</value>
+            <value>&quot;Adams Phone Message Book, Professional, 400 Message Capacity, 5 3/6” x 11”&quot;</value>
+            <value>&quot;Adams Telephone Message Book W/Dividers/Space For Phone Numbers, 5 1/4\&quot;X8 1/2\&quot;, 200/Messages&quot;</value>
+            <value>&quot;Adams Telephone Message Book W/Dividers/Space For Phone Numbers, 5 1/4\&quot;X8 1/2\&quot;, 300/Messages&quot;</value>
+            <value>&quot;Adams Telephone Message Book w/Frequently-Called Numbers Space, 400 Messages per Book&quot;</value>
+            <value>&quot;Adams Telephone Message Books, 5 1/4” x 11”&quot;</value>
+            <value>&quot;Adams Write n&apos; Stick Phone Message Book, 11\&quot; X 5 1/4\&quot;, 200 Messages&quot;</value>
+            <value>&quot;Spiral Phone Message Books with Labels by Adams&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Advantus&quot;'>
+            <value>&quot;Advantus 10-Drawer Portable Organizer, Chrome Metal Frame, Smoke Drawers&quot;</value>
+            <value>&quot;Advantus Employee of the Month Certificate Frame, 11 x 13-1/2&quot;</value>
+            <value>&quot;Advantus Map Pennant Flags and Round Head Tacks&quot;</value>
+            <value>&quot;Advantus Motivational Note Cards&quot;</value>
+            <value>&quot;Advantus Panel Wall Acrylic Frame&quot;</value>
+            <value>&quot;Advantus Panel Wall Certificate Holder - 8.5x11&quot;</value>
+            <value>&quot;Advantus Plastic Paper Clips&quot;</value>
+            <value>&quot;Advantus Push Pins&quot;</value>
+            <value>&quot;Advantus Push Pins, Aluminum Head&quot;</value>
+            <value>&quot;Advantus Rolling Drawer Organizers&quot;</value>
+            <value>&quot;Advantus Rolling Storage Box&quot;</value>
+            <value>&quot;Advantus SlideClip Paper Clips&quot;</value>
+            <value>&quot;Advantus T-Pin Paper Clips&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Akro&quot;'>
+            <value>&quot;Akro Stacking Bins&quot;</value>
+            <value>&quot;Akro-Mils 12-Gallon Tote&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Alliance&quot;'>
+            <value>&quot;Alliance Big Bands Rubber Bands, 12/Pack&quot;</value>
+            <value>&quot;Alliance Rubber Bands&quot;</value>
+            <value>&quot;Alliance Super-Size Bands, Assorted Sizes&quot;</value>
+            <value>&quot;Sterling Rubber Bands by Alliance&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Ampad&quot;'>
+            <value>&quot;Ampad \#10 Peel &amp; Seel Holiday Envelopes&quot;</value>
+            <value>&quot;Ampad Evidence Wirebond Steno Books, 6\&quot; x 9\&quot;&quot;</value>
+            <value>&quot;Ampad Gold Fibre Wirebound Steno Books, 6\&quot; x 9\&quot;, Gregg Ruled&quot;</value>
+            <value>&quot;Ampad Phone Message Book, Recycled, 400 Message Capacity, 5 ¾” x 11”&quot;</value>
+            <value>&quot;Ampad Poly Cover Wirebound Steno Book, 6\&quot; x 9\&quot; Assorted Colors, Gregg Ruled&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Angle-D&quot;'>
+            <value>&quot;Angle-D Binders with Locking Rings, Label Holders&quot;</value>
+            <value>&quot;Angle-D Ring Binders&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Anker&quot;'>
+            <value>&quot;Anker 24W Portable Micro USB Car Charger&quot;</value>
+            <value>&quot;Anker 36W 4-Port USB Wall Charger Travel Power Adapter for iPhone 5s 5c 5&quot;</value>
+            <value>&quot;Anker Astro 15000mAh USB Portable Charger&quot;</value>
+            <value>&quot;Anker Astro Mini 3000mAh Ultra-Compact Portable Charger&quot;</value>
+            <value>&quot;Anker Ultra-Slim Mini Bluetooth 3.0 Wireless Keyboard&quot;</value>
+            <value>&quot;Anker Ultrathin Bluetooth Wireless Keyboard Aluminum Cover with Stand&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Apple&quot;'>
+            <value>&quot;Apple EarPods with Remote and Mic&quot;</value>
+            <value>&quot;Apple iPhone 5&quot;</value>
+            <value>&quot;Apple iPhone 5C&quot;</value>
+            <value>&quot;Apple iPhone 5S&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Array&quot;'>
+            <value>&quot;Array Memo Cubes&quot;</value>
+            <value>&quot;Array Parchment Paper, Assorted Colors&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;AT&amp;T&quot;'>
+            <value>&quot;AT&amp;T 1070 Corded Phone&quot;</value>
+            <value>&quot;AT&amp;T 1080 Corded phone&quot;</value>
+            <value>&quot;AT&amp;T 1080 Phone&quot;</value>
+            <value>&quot;AT&amp;T 17929 Lendline Telephone&quot;</value>
+            <value>&quot;AT&amp;T 841000 Phone&quot;</value>
+            <value>&quot;AT&amp;T CL2909&quot;</value>
+            <value>&quot;AT&amp;T CL82213&quot;</value>
+            <value>&quot;AT&amp;T CL83451 4-Handset Telephone&quot;</value>
+            <value>&quot;AT&amp;T EL51110 DECT&quot;</value>
+            <value>&quot;AT&amp;T SB67148 SynJ&quot;</value>
+            <value>&quot;AT&amp;T TR1909W&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Ativa&quot;'>
+            <value>&quot;Ativa D5772 2-Line 5.8GHz Digital Expandable Corded/Cordless Phone System with Answering &amp; Caller ID/Call Waiting, Black/Silver&quot;</value>
+            <value>&quot;Ativa MDM8000 8-Sheet Micro-Cut Shredder&quot;</value>
+            <value>&quot;Ativa V4110MDD Micro-Cut Shredder&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Atlantic&quot;'>
+            <value>&quot;Atlantic Metals Mobile 2-Shelf Bookcases, Custom Colors&quot;</value>
+            <value>&quot;Atlantic Metals Mobile 3-Shelf Bookcases, Custom Colors&quot;</value>
+            <value>&quot;Atlantic Metals Mobile 4-Shelf Bookcases, Custom Colors&quot;</value>
+            <value>&quot;Atlantic Metals Mobile 5-Shelf Bookcases, Custom Colors&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Avanti&quot;'>
+            <value>&quot;Avanti 1.7 Cu. Ft. Refrigerator&quot;</value>
+            <value>&quot;Avanti 4.4 Cu. Ft. Refrigerator&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Avaya&quot;'>
+            <value>&quot;Avaya 4621SW VoIP phone&quot;</value>
+            <value>&quot;Avaya 5410 Digital phone&quot;</value>
+            <value>&quot;Avaya 5420 Digital phone&quot;</value>
+            <value>&quot;Avaya IP Phone 1140E VoIP phone&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Avery&quot;'>
+            <value>&quot;Avery 05222 Permanent Self-Adhesive File Folder Labels for Typewriters, on Rolls, White, 250/Roll&quot;</value>
+            <value>&quot;Avery 3 1/2\&quot; Diskette Storage Pages, 10/Pack&quot;</value>
+            <value>&quot;Avery 4027 File Folder Labels for Dot Matrix Printers, 5000 Labels per Box, White&quot;</value>
+            <value>&quot;Avery 473&quot;</value>
+            <value>&quot;Avery 474&quot;</value>
+            <value>&quot;Avery 475&quot;</value>
+            <value>&quot;Avery 476&quot;</value>
+            <value>&quot;Avery 477&quot;</value>
+            <value>&quot;Avery 478&quot;</value>
+            <value>&quot;Avery 479&quot;</value>
+            <value>&quot;Avery 48&quot;</value>
+            <value>&quot;Avery 480&quot;</value>
+            <value>&quot;Avery 481&quot;</value>
+            <value>&quot;Avery 482&quot;</value>
+            <value>&quot;Avery 483&quot;</value>
+            <value>&quot;Avery 484&quot;</value>
+            <value>&quot;Avery 485&quot;</value>
+            <value>&quot;Avery 486&quot;</value>
+            <value>&quot;Avery 487&quot;</value>
+            <value>&quot;Avery 488&quot;</value>
+            <value>&quot;Avery 489&quot;</value>
+            <value>&quot;Avery 49&quot;</value>
+            <value>&quot;Avery 490&quot;</value>
+            <value>&quot;Avery 491&quot;</value>
+            <value>&quot;Avery 492&quot;</value>
+            <value>&quot;Avery 493&quot;</value>
+            <value>&quot;Avery 494&quot;</value>
+            <value>&quot;Avery 495&quot;</value>
+            <value>&quot;Avery 496&quot;</value>
+            <value>&quot;Avery 497&quot;</value>
+            <value>&quot;Avery 498&quot;</value>
+            <value>&quot;Avery 499&quot;</value>
+            <value>&quot;Avery 5&quot;</value>
+            <value>&quot;Avery 50&quot;</value>
+            <value>&quot;Avery 500&quot;</value>
+            <value>&quot;Avery 501&quot;</value>
+            <value>&quot;Avery 502&quot;</value>
+            <value>&quot;Avery 503&quot;</value>
+            <value>&quot;Avery 504&quot;</value>
+            <value>&quot;Avery 505&quot;</value>
+            <value>&quot;Avery 506&quot;</value>
+            <value>&quot;Avery 507&quot;</value>
+            <value>&quot;Avery 508&quot;</value>
+            <value>&quot;Avery 509&quot;</value>
+            <value>&quot;Avery 51&quot;</value>
+            <value>&quot;Avery 510&quot;</value>
+            <value>&quot;Avery 511&quot;</value>
+            <value>&quot;Avery 512&quot;</value>
+            <value>&quot;Avery 513&quot;</value>
+            <value>&quot;Avery 514&quot;</value>
+            <value>&quot;Avery 515&quot;</value>
+            <value>&quot;Avery 516&quot;</value>
+            <value>&quot;Avery 517&quot;</value>
+            <value>&quot;Avery 518&quot;</value>
+            <value>&quot;Avery 519&quot;</value>
+            <value>&quot;Avery 52&quot;</value>
+            <value>&quot;Avery 520&quot;</value>
+            <value>&quot;Avery Address/Shipping Labels for Typewriters, 4\&quot; x 2\&quot;&quot;</value>
+            <value>&quot;Avery Arch Ring Binders&quot;</value>
+            <value>&quot;Avery Binder Labels&quot;</value>
+            <value>&quot;Avery Binding System Hidden Tab Executive Style Index Sets&quot;</value>
+            <value>&quot;Avery Durable Binders&quot;</value>
+            <value>&quot;Avery Durable Plastic 1\&quot; Binders&quot;</value>
+            <value>&quot;Avery Durable Poly Binders&quot;</value>
+            <value>&quot;Avery Durable Slant Ring Binders&quot;</value>
+            <value>&quot;Avery Durable Slant Ring Binders With Label Holder&quot;</value>
+            <value>&quot;Avery Durable Slant Ring Binders, No Labels&quot;</value>
+            <value>&quot;Avery File Folder Labels&quot;</value>
+            <value>&quot;Avery Flip-Chart Easel Binder, Black&quot;</value>
+            <value>&quot;Avery Fluorescent Highlighter Four-Color Set&quot;</value>
+            <value>&quot;Avery Framed View Binder, EZD Ring (Locking), Navy, 1 1/2\&quot;&quot;</value>
+            <value>&quot;Avery Hanging File Binders&quot;</value>
+            <value>&quot;Avery Heavy-Duty EZD  Binder With Locking Rings&quot;</value>
+            <value>&quot;Avery Heavy-Duty EZD View Binder with Locking Rings&quot;</value>
+            <value>&quot;Avery Hi-Liter Comfort Grip Fluorescent Highlighter, Yellow Ink&quot;</value>
+            <value>&quot;Avery Hi-Liter EverBold Pen Style Fluorescent Highlighters, 4/Pack&quot;</value>
+            <value>&quot;Avery Hi-Liter Fluorescent Desk Style Markers&quot;</value>
+            <value>&quot;Avery Hi-Liter GlideStik Fluorescent Highlighter, Yellow Ink&quot;</value>
+            <value>&quot;Avery Hi-Liter Pen Style Six-Color Fluorescent Set&quot;</value>
+            <value>&quot;Avery Hi-Liter Smear-Safe Highlighters&quot;</value>
+            <value>&quot;Avery Hidden Tab Dividers for Binding Systems&quot;</value>
+            <value>&quot;Avery Hole Reinforcements&quot;</value>
+            <value>&quot;Avery Legal 4-Ring Binder&quot;</value>
+            <value>&quot;Avery Metallic Poly Binders&quot;</value>
+            <value>&quot;Avery Non-Stick Binders&quot;</value>
+            <value>&quot;Avery Non-Stick Heavy Duty View Round Locking Ring Binders&quot;</value>
+            <value>&quot;Avery Personal Creations Heavyweight Cards&quot;</value>
+            <value>&quot;Avery Poly Binder Pockets&quot;</value>
+            <value>&quot;Avery Premier Heavy-Duty Binder with Round Locking Rings&quot;</value>
+            <value>&quot;Avery Printable Repositionable Plastic Tabs&quot;</value>
+            <value>&quot;Avery Recycled Flexi-View Covers for Binding Systems&quot;</value>
+            <value>&quot;Avery Reinforcements for Hole-Punch Pages&quot;</value>
+            <value>&quot;Avery Round Ring Poly Binders&quot;</value>
+            <value>&quot;Avery Self-Adhesive Photo Pockets for Polaroid Photos&quot;</value>
+            <value>&quot;Avery Trapezoid Extra Heavy Duty 4\&quot; Binders&quot;</value>
+            <value>&quot;Avery Trapezoid Ring Binder, 3\&quot; Capacity, Black, 1040 sheets&quot;</value>
+            <value>&quot;Avery Triangle Shaped Sheet Lifters, Black, 2/Pack&quot;</value>
+            <value>&quot;Avery White Multi-Purpose Labels&quot;</value>
+            <value>&quot;Black Avery Memo-Size 3-Ring Binder, 5 1/2\&quot; x 8 1/2\&quot;&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Balt&quot;'>
+            <value>&quot;Balt Solid Wood Rectangular Table&quot;</value>
+            <value>&quot;Balt Solid Wood Round Tables&quot;</value>
+            <value>&quot;Balt Split Level Computer Training Table&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Barricks&quot;'>
+            <value>&quot;Barricks 18\&quot; x 48\&quot; Non-Folding Utility Table with Bottom Storage Shelf&quot;</value>
+            <value>&quot;Barricks Non-Folding Utility Table with Steel Legs, Laminate Tops&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Belkin&quot;'>
+            <value>&quot;Belkin 19\&quot; Center-Weighted Shelf, Gray&quot;</value>
+            <value>&quot;Belkin 19\&quot; Vented Equipment Shelf, Black&quot;</value>
+            <value>&quot;Belkin 325VA UPS Surge Protector, 6&apos;&quot;</value>
+            <value>&quot;Belkin 5 Outlet SurgeMaster Power Centers&quot;</value>
+            <value>&quot;Belkin 6 Outlet Metallic Surge Strip&quot;</value>
+            <value>&quot;Belkin 7 Outlet SurgeMaster II&quot;</value>
+            <value>&quot;Belkin 7 Outlet SurgeMaster Surge Protector with Phone Protection&quot;</value>
+            <value>&quot;Belkin 7-Outlet SurgeMaster Home Series&quot;</value>
+            <value>&quot;Belkin 8 Outlet Surge Protector&quot;</value>
+            <value>&quot;Belkin 8 Outlet SurgeMaster II Gold Surge Protector&quot;</value>
+            <value>&quot;Belkin 8 Outlet SurgeMaster II Gold Surge Protector with Phone Protection&quot;</value>
+            <value>&quot;Belkin 8-Outlet Premiere SurgeMaster II Surge Protectors&quot;</value>
+            <value>&quot;Belkin F5C206VTEL 6 Outlet Surge&quot;</value>
+            <value>&quot;Belkin F8E887 USB Wired Ergonomic Keyboard&quot;</value>
+            <value>&quot;Belkin F9G930V10-GRY 9 Outlet Surge&quot;</value>
+            <value>&quot;Belkin F9H710-06 7 Outlet SurgeMaster Surge Protector&quot;</value>
+            <value>&quot;Belkin F9M820V08 8 Outlet Surge&quot;</value>
+            <value>&quot;Belkin F9S820V06 8 Outlet Surge&quot;</value>
+            <value>&quot;Belkin Grip Candy Sheer Case / Cover for iPhone 5 and 5S&quot;</value>
+            <value>&quot;Belkin iPhone and iPad Lightning Cable&quot;</value>
+            <value>&quot;Belkin OmniView SE Rackmount Kit&quot;</value>
+            <value>&quot;Belkin Premiere Surge Master II 8-outlet surge protector&quot;</value>
+            <value>&quot;Belkin QODE FastFit Bluetooth Keyboard&quot;</value>
+            <value>&quot;Belkin SportFit Armband For iPhone 5s/5c, Fuchsia&quot;</value>
+            <value>&quot;Belkin Standard 104 key USB Keyboard&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Berol&quot;'>
+            <value>&quot;Berol Giant Pencil Sharpener&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Bestar&quot;'>
+            <value>&quot;Bestar Classic Bookcase&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Bevis&quot;'>
+            <value>&quot;Bevis 36 x 72 Conference Tables&quot;</value>
+            <value>&quot;Bevis 44 x 96 Conference Tables&quot;</value>
+            <value>&quot;Bevis Boat-Shaped Conference Table&quot;</value>
+            <value>&quot;Bevis Oval Conference Table, Walnut&quot;</value>
+            <value>&quot;Bevis Rectangular Conference Tables&quot;</value>
+            <value>&quot;Bevis Round Bullnose 29\&quot; High Table Top&quot;</value>
+            <value>&quot;Bevis Round Conference Room Tables and Bases&quot;</value>
+            <value>&quot;Bevis Round Conference Table Top &amp; Single Column Base&quot;</value>
+            <value>&quot;Bevis Round Conference Table Top, X-Base&quot;</value>
+            <value>&quot;Bevis Steel Folding Chairs&quot;</value>
+            <value>&quot;Bevis Traditional Conference Table Top, Plinth Base&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;BIC&quot;'>
+            <value>&quot;BIC Brite Liner Grip Highlighters&quot;</value>
+            <value>&quot;BIC Brite Liner Grip Highlighters, Assorted, 5/Pack&quot;</value>
+            <value>&quot;BIC Brite Liner Highlighters&quot;</value>
+            <value>&quot;BIC Brite Liner Highlighters, Chisel Tip&quot;</value>
+            <value>&quot;BIC Liqua Brite Liner&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Binney &amp; Smith&quot;'>
+            <value>&quot;Binney &amp; Smith Crayola Metallic Colored Pencils, 8-Color Set&quot;</value>
+            <value>&quot;Binney &amp; Smith Crayola Metallic Crayons, 16-Color Pack&quot;</value>
+            <value>&quot;Binney &amp; Smith inkTank Desk Highlighter, Chisel Tip, Yellow, 12/Box&quot;</value>
+            <value>&quot;Binney &amp; Smith inkTank Erasable Desk Highlighter, Chisel Tip, Yellow, 12/Box&quot;</value>
+            <value>&quot;Binney &amp; Smith inkTank Erasable Pocket Highlighter, Chisel Tip, Yellow&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Bionaire&quot;'>
+            <value>&quot;Bionaire 99.97\% HEPA Air Cleaner&quot;</value>
+            <value>&quot;Bionaire Personal Warm Mist Humidifier/Vaporizer&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Boston&quot;'>
+            <value>&quot;Boston 1645 Deluxe Heavier-Duty Electric Pencil Sharpener&quot;</value>
+            <value>&quot;Boston 16701 Slimline Battery Pencil Sharpener&quot;</value>
+            <value>&quot;Boston 16750 Black Compact Battery Pencil Sharpener&quot;</value>
+            <value>&quot;Boston 16765 Mini Stand Up Battery Pencil Sharpener&quot;</value>
+            <value>&quot;Boston 16801 Nautilus Battery Pencil Sharpener&quot;</value>
+            <value>&quot;Boston 1730 StandUp Electric Pencil Sharpener&quot;</value>
+            <value>&quot;Boston 1799 Powerhouse Electric Pencil Sharpener&quot;</value>
+            <value>&quot;Boston 1827 Commercial Additional Cutter, Drive Gear &amp; Gear Rack for 1606&quot;</value>
+            <value>&quot;Boston 1900 Electric Pencil Sharpener&quot;</value>
+            <value>&quot;Boston 19500 Mighty Mite Electric Pencil Sharpener&quot;</value>
+            <value>&quot;Boston Electric Pencil Sharpener, Model 1818, Charcoal Black&quot;</value>
+            <value>&quot;Boston Heavy-Duty Trimline Electric Pencil Sharpeners&quot;</value>
+            <value>&quot;Boston Home &amp; Office Model 2000 Electric Pencil Sharpeners&quot;</value>
+            <value>&quot;Boston KS Multi-Size Manual Pencil Sharpener&quot;</value>
+            <value>&quot;Boston Model 1800 Electric Pencil Sharpener, Gray&quot;</value>
+            <value>&quot;BOSTON Model 1800 Electric Pencil Sharpeners, Putty/Woodgrain&quot;</value>
+            <value>&quot;BOSTON Ranger \#55 Pencil Sharpener, Black&quot;</value>
+            <value>&quot;Boston School Pro Electric Pencil Sharpener, 1670&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Bretford&quot;'>
+            <value>&quot;Bretford “Just In Time” Height-Adjustable Multi-Task Work Tables&quot;</value>
+            <value>&quot;Bretford CR4500 Series Slim Rectangular Table&quot;</value>
+            <value>&quot;Bretford CR8500 Series Meeting Room Furniture&quot;</value>
+            <value>&quot;Bretford Rectangular Conference Table Tops&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Brother&quot;'>
+            <value>&quot;Brother DCP1000 Digital 3 in 1 Multifunction Machine&quot;</value>
+            <value>&quot;Brother IntelliFAX-2840 Laser Fax&quot;</value>
+            <value>&quot;Brother IntelliFAX-5750e Plain Paper Fax Machine&quot;</value>
+            <value>&quot;Brother MFC-9340CDW LED All-In-One Printer, Copier Scanner&quot;</value>
+            <value>&quot;Brother MFC-J470DW Inkjet All-In-One Printer, Copier, Scanner&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Bulldog&quot;'>
+            <value>&quot;Bulldog Table or Wall-Mount Pencil Sharpener&quot;</value>
+            <value>&quot;Bulldog Vacuum Base Pencil Sharpener&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Bush&quot;'>
+            <value>&quot;Bush Advantage Collection Racetrack Conference Table&quot;</value>
+            <value>&quot;Bush Advantage Collection Round Conference Table&quot;</value>
+            <value>&quot;Bush Andora Bookcase, Maple/Graphite Gray Finish&quot;</value>
+            <value>&quot;Bush Andora Conference Table, Maple/Graphite Gray Finish&quot;</value>
+            <value>&quot;Bush Birmingham Collection Bookcase, Dark Cherry&quot;</value>
+            <value>&quot;Bush Cubix Collection Bookcases, Fully Assembled&quot;</value>
+            <value>&quot;Bush Cubix Conference Tables, Fully Assembled&quot;</value>
+            <value>&quot;Bush Heritage Pine Collection 5-Shelf Bookcase, Albany Pine Finish, *Special Order&quot;</value>
+            <value>&quot;Bush Mission Pointe Library&quot;</value>
+            <value>&quot;Bush Saratoga Collection 5-Shelf Bookcase, Hanover Cherry, *Special Order&quot;</value>
+            <value>&quot;Bush Somerset Collection Bookcase&quot;</value>
+            <value>&quot;Bush Westfield Collection Bookcases, Dark Cherry Finish&quot;</value>
+            <value>&quot;Bush Westfield Collection Bookcases, Medium Cherry Finish&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;C-Line&quot;'>
+            <value>&quot;C-Line Cubicle Keepers Polyproplyene Holder w/Velcro Back, 8-1/2x11, 25/Bx&quot;</value>
+            <value>&quot;C-Line Cubicle Keepers Polyproplyene Holder With Velcro Backings&quot;</value>
+            <value>&quot;C-Line Magnetic Cubicle Keepers, Clear Polypropylene&quot;</value>
+            <value>&quot;C-Line Peel &amp; Stick Add-On Filing Pockets, 8-3/4 x 5-1/8, 10/Pack&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Canon&quot;'>
+            <value>&quot;Canon Color ImageCLASS MF8580Cdw Wireless Laser All-In-One Printer, Copier, Scanner&quot;</value>
+            <value>&quot;Canon Image Class D660 Copier&quot;</value>
+            <value>&quot;Canon imageCLASS 2200 Advanced Copier&quot;</value>
+            <value>&quot;Canon Imageclass D680 Copier / Fax&quot;</value>
+            <value>&quot;Canon imageCLASS MF7460 Monochrome Digital Laser Multifunction Copier&quot;</value>
+            <value>&quot;Canon PC-428 Personal Copier&quot;</value>
+            <value>&quot;Canon PC1060 Personal Laser Copier&quot;</value>
+            <value>&quot;Canon PC1080F Personal Copier&quot;</value>
+            <value>&quot;Canon PC170 Desktop Personal Copier&quot;</value>
+            <value>&quot;Canon PC940 Copier&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Cardinal&quot;'>
+            <value>&quot;Cardinal EasyOpen D-Ring Binders&quot;</value>
+            <value>&quot;Cardinal Hold-It CD Pocket&quot;</value>
+            <value>&quot;Cardinal Holdit Business Card Pockets&quot;</value>
+            <value>&quot;Cardinal Holdit Data Disk Pockets&quot;</value>
+            <value>&quot;Cardinal HOLDit! Binder Insert Strips,Extra Strips&quot;</value>
+            <value>&quot;Cardinal Poly Pocket Divider Pockets for Ring Binders&quot;</value>
+            <value>&quot;Cardinal Slant-D Ring Binder, Heavy Gauge Vinyl&quot;</value>
+            <value>&quot;Cardinal Slant-D Ring Binders&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Carina&quot;'>
+            <value>&quot;Carina 42\&quot;Hx23 3/4\&quot;W Media Storage Unit&quot;</value>
+            <value>&quot;Carina Double Wide Media Storage Towers in Natural &amp; Black&quot;</value>
+            <value>&quot;Carina Media Storage Towers in Natural &amp; Black&quot;</value>
+            <value>&quot;Carina Mini System Audio Rack, Model AR050B&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Chromcraft&quot;'>
+            <value>&quot;Chromcraft 48\&quot; x 96\&quot; Racetrack Double Pedestal Table&quot;</value>
+            <value>&quot;Chromcraft Bull-Nose Wood 48\&quot; x 96\&quot; Rectangular Conference Tables&quot;</value>
+            <value>&quot;Chromcraft Bull-Nose Wood Oval Conference Tables &amp; Bases&quot;</value>
+            <value>&quot;Chromcraft Bull-Nose Wood Round Conference Table Top, Wood Base&quot;</value>
+            <value>&quot;Chromcraft Rectangular Conference Tables&quot;</value>
+            <value>&quot;Chromcraft Round Conference Tables&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Cisco&quot;'>
+            <value>&quot;Cisco 7975G IP Phone&quot;</value>
+            <value>&quot;Cisco 8961 IP Phone Charcoal&quot;</value>
+            <value>&quot;Cisco 8x8 Inc. 6753i IP Business Phone System&quot;</value>
+            <value>&quot;Cisco 9971 IP Video Phone Charcoal&quot;</value>
+            <value>&quot;Cisco CP-7936 Unified IP Conference Station Phone&quot;</value>
+            <value>&quot;Cisco CP-7937G Unified IP Conference Station Phone&quot;</value>
+            <value>&quot;Cisco Desktop Collaboration Experience DX650 IP Video Phone&quot;</value>
+            <value>&quot;Cisco IP Phone 7961G VoIP phone - Dark gray&quot;</value>
+            <value>&quot;Cisco IP Phone 7961G-GE VoIP phone&quot;</value>
+            <value>&quot;Cisco Small Business SPA 502G VoIP phone&quot;</value>
+            <value>&quot;Cisco SPA 501G IP Phone&quot;</value>
+            <value>&quot;Cisco SPA 502G IP Phone&quot;</value>
+            <value>&quot;Cisco SPA112 2 Port Phone Adapter&quot;</value>
+            <value>&quot;Cisco SPA301&quot;</value>
+            <value>&quot;Cisco SPA508G&quot;</value>
+            <value>&quot;Cisco SPA525G2 5-Line IP Phone&quot;</value>
+            <value>&quot;Cisco SPA525G2 IP Phone - Wireless&quot;</value>
+            <value>&quot;Cisco TelePresence System EX90 Videoconferencing Unit&quot;</value>
+            <value>&quot;Cisco Unified IP Phone 7945G VoIP phone&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;ClearOne&quot;'>
+            <value>&quot;ClearOne CHATAttach 160 - speaker phone&quot;</value>
+            <value>&quot;ClearOne Communications CHAT 70 OC Speaker Phone&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Clearsounds&quot;'>
+            <value>&quot;Clearsounds A400&quot;</value>
+            <value>&quot;ClearSounds CSC500 Amplified Spirit Phone Corded phone&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Crayola&quot;'>
+            <value>&quot;Crayola Anti Dust Chalk, 12/Pack&quot;</value>
+            <value>&quot;Crayola Colored Pencils&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Cubify&quot;'>
+            <value>&quot;Cubify CubeX 3D Printer Double Head Print&quot;</value>
+            <value>&quot;Cubify CubeX 3D Printer Triple Head Print&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Dana&quot;'>
+            <value>&quot;Dana Fluorescent Magnifying Lamp, White, 36\&quot;&quot;</value>
+            <value>&quot;Dana Halogen Swing-Arm Architect Lamp&quot;</value>
+            <value>&quot;Dana Swing-Arm Lamps&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;DAX&quot;'>
+            <value>&quot;DAX Black Cherry Wood-Tone Poster Frame&quot;</value>
+            <value>&quot;DAX Charcoal/Nickel-Tone Document Frame, 5 x 7&quot;</value>
+            <value>&quot;Dax Clear Box Frame&quot;</value>
+            <value>&quot;DAX Clear Channel Poster Frame&quot;</value>
+            <value>&quot;DAX Contemporary Wood Frame with Silver Metal Mat, Desktop, 11 x 14 Size&quot;</value>
+            <value>&quot;DAX Copper Panel Document Frame, 5 x 7 Size&quot;</value>
+            <value>&quot;DAX Cubicle Frames - 8x10&quot;</value>
+            <value>&quot;DAX Cubicle Frames, 8-1/2 x 11&quot;</value>
+            <value>&quot;DAX Executive Solid Wood Document Frame, Desktop or Hang, Mahogany, 5 x 7&quot;</value>
+            <value>&quot;DAX Metal Frame, Desktop, Stepped-Edge&quot;</value>
+            <value>&quot;DAX Natural Wood-Tone Poster Frame&quot;</value>
+            <value>&quot;DAX Solid Wood Frames&quot;</value>
+            <value>&quot;DAX Two-Tone Rosewood/Black Document Frame, Desktop, 5 x 7&quot;</value>
+            <value>&quot;DAX Two-Tone Silver Metal Document Frame&quot;</value>
+            <value>&quot;DAX Value U-Channel Document Frames, Easel Back&quot;</value>
+            <value>&quot;DAX Wood Document Frame&quot;</value>
+            <value>&quot;DAX Wood Document Frame.&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Decoflex&quot;'>
+            <value>&quot;Decoflex Hanging Personal Folder File&quot;</value>
+            <value>&quot;Decoflex Hanging Personal Folder File, Blue&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Deflect-o&quot;'>
+            <value>&quot;Deflect-o DuraMat Antistatic Studded Beveled Mat for Medium Pile Carpeting&quot;</value>
+            <value>&quot;Deflect-o DuraMat Lighweight, Studded, Beveled Mat for Low Pile Carpeting&quot;</value>
+            <value>&quot;Deflect-o EconoMat Nonstudded, No Bevel Mat&quot;</value>
+            <value>&quot;Deflect-o EconoMat Studded, No Bevel Mat for Low Pile Carpeting&quot;</value>
+            <value>&quot;Deflect-o Glass Clear Studded Chair Mats&quot;</value>
+            <value>&quot;Deflect-O Glasstique Clear Desk Accessories&quot;</value>
+            <value>&quot;Deflect-o RollaMat Studded, Beveled Mat for Medium Pile Carpeting&quot;</value>
+            <value>&quot;Deflect-o SuperTray Unbreakable Stackable Tray, Letter, Black&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Dixon&quot;'>
+            <value>&quot;Dixon My First Ticonderoga Pencil, \#2&quot;</value>
+            <value>&quot;DIXON Oriole Pencils&quot;</value>
+            <value>&quot;Dixon Prang Watercolor Pencils, 10-Color Set with Brush&quot;</value>
+            <value>&quot;Dixon Ticonderoga Core-Lock Colored Pencils&quot;</value>
+            <value>&quot;Dixon Ticonderoga Core-Lock Colored Pencils, 48-Color Set&quot;</value>
+            <value>&quot;DIXON Ticonderoga Erasable Checking Pencils&quot;</value>
+            <value>&quot;Dixon Ticonderoga Erasable Colored Pencil Set, 12-Color&quot;</value>
+            <value>&quot;Dixon Ticonderoga Maple Cedar Pencil, \#2&quot;</value>
+            <value>&quot;Dixon Ticonderoga Pencils&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;DMI&quot;'>
+            <value>&quot;DMI Arturo Collection Mission-style Design Wood Chair&quot;</value>
+            <value>&quot;DMI Eclipse Executive Suite Bookcases&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;DXL&quot;'>
+            <value>&quot;DXL Angle-View Binders with Locking Rings by Samsill&quot;</value>
+            <value>&quot;DXL Angle-View Binders with Locking Rings, Black&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Eldon&quot;'>
+            <value>&quot;Eldon \&quot;L\&quot; Workstation Diamond Chairmat&quot;</value>
+            <value>&quot;Eldon 100 Class Desk Accessories&quot;</value>
+            <value>&quot;Eldon 200 Class Desk Accessories&quot;</value>
+            <value>&quot;Eldon 200 Class Desk Accessories, Black&quot;</value>
+            <value>&quot;Eldon 200 Class Desk Accessories, Burgundy&quot;</value>
+            <value>&quot;Eldon 200 Class Desk Accessories, Smoke&quot;</value>
+            <value>&quot;Eldon 300 Class Desk Accessories, Black&quot;</value>
+            <value>&quot;Eldon 400 Class Desk Accessories, Black Carbon&quot;</value>
+            <value>&quot;Eldon 500 Class Desk Accessories&quot;</value>
+            <value>&quot;Eldon Advantage Chair Mats for Low to Medium Pile Carpets&quot;</value>
+            <value>&quot;Eldon Advantage Foldable Chair Mats for Low Pile Carpets&quot;</value>
+            <value>&quot;Eldon Antistatic Chair Mats for Low to Medium Pile Carpets&quot;</value>
+            <value>&quot;Eldon Base for stackable storage shelf, platinum&quot;</value>
+            <value>&quot;Eldon Cleatmat Chair Mats for Medium Pile Carpets&quot;</value>
+            <value>&quot;Eldon Cleatmat Plus Chair Mats for High Pile Carpets&quot;</value>
+            <value>&quot;Eldon ClusterMat Chair Mat with Cordless Antistatic Protection&quot;</value>
+            <value>&quot;Eldon Delta Triangular Chair Mat, 52\&quot; x 58\&quot;, Clear&quot;</value>
+            <value>&quot;Eldon Econocleat Chair Mats for Low Pile Carpets&quot;</value>
+            <value>&quot;Eldon Executive Woodline II Cherry Finish Desk Accessories&quot;</value>
+            <value>&quot;Eldon Executive Woodline II Desk Accessories, Mahogany&quot;</value>
+            <value>&quot;Eldon Expressions Desk Accessory, Wood Pencil Holder, Oak&quot;</value>
+            <value>&quot;Eldon Expressions Desk Accessory, Wood Photo Frame, Mahogany&quot;</value>
+            <value>&quot;Eldon Expressions Mahogany Wood Desk Collection&quot;</value>
+            <value>&quot;Eldon Expressions Punched Metal &amp; Wood Desk Accessories, Black &amp; Cherry&quot;</value>
+            <value>&quot;Eldon Expressions Punched Metal &amp; Wood Desk Accessories, Pewter &amp; Cherry&quot;</value>
+            <value>&quot;Eldon Expressions Wood and Plastic Desk Accessories, Cherry Wood&quot;</value>
+            <value>&quot;Eldon Expressions Wood and Plastic Desk Accessories, Oak&quot;</value>
+            <value>&quot;Eldon Expressions Wood Desk Accessories, Oak&quot;</value>
+            <value>&quot;Eldon File Chest Portable File&quot;</value>
+            <value>&quot;Eldon Fold &apos;N Roll Cart System&quot;</value>
+            <value>&quot;Eldon Gobal File Keepers&quot;</value>
+            <value>&quot;Eldon Image Series Black Desk Accessories&quot;</value>
+            <value>&quot;Eldon Image Series Desk Accessories, Burgundy&quot;</value>
+            <value>&quot;Eldon Imàge Series Desk Accessories, Clear&quot;</value>
+            <value>&quot;Eldon Image Series Desk Accessories, Ebony&quot;</value>
+            <value>&quot;Eldon Jumbo ProFile Portable File Boxes Graphite/Black&quot;</value>
+            <value>&quot;Eldon Mobile Mega Data Cart  Mega Stackable  Add-On Trays&quot;</value>
+            <value>&quot;Eldon Pizzaz Desk Accessories&quot;</value>
+            <value>&quot;Eldon Portable Mobile Manager&quot;</value>
+            <value>&quot;Eldon ProFile File &apos;N Store Portable File Tub Letter/Legal Size Black&quot;</value>
+            <value>&quot;Eldon Radial Chair Mat for Low to Medium Pile Carpets&quot;</value>
+            <value>&quot;Eldon Regeneration Recycled Desk Accessories, Black&quot;</value>
+            <value>&quot;Eldon Regeneration Recycled Desk Accessories, Smoke&quot;</value>
+            <value>&quot;Eldon Shelf Savers Cubes and Bins&quot;</value>
+            <value>&quot;Eldon Simplefile Box Office&quot;</value>
+            <value>&quot;Eldon Spacemaker Box, Quick-Snap Lid, Clear&quot;</value>
+            <value>&quot;Eldon Stackable Tray, Side-Load, Legal, Smoke&quot;</value>
+            <value>&quot;Eldon Wave Desk Accessories&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Electrix&quot;'>
+            <value>&quot;Electrix 20W Halogen Replacement Bulb for Zoom-In Desk Lamp&quot;</value>
+            <value>&quot;Electrix Architect&apos;s Clamp-On Swing Arm Lamp, Black&quot;</value>
+            <value>&quot;Electrix Fluorescent Magnifier Lamps &amp; Weighted Base&quot;</value>
+            <value>&quot;Electrix Halogen Magnifier Lamp&quot;</value>
+            <value>&quot;Electrix Incandescent Magnifying Lamp, Black&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Enermax&quot;'>
+            <value>&quot;Enermax Acrylux Wireless Keyboard&quot;</value>
+            <value>&quot;Enermax Aurora Lite Keyboard&quot;</value>
+            <value>&quot;Enermax Briskie RF Wireless Keyboard and Mouse Combo&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Epson&quot;'>
+            <value>&quot;Epson Perfection V600 Photo Scanner&quot;</value>
+            <value>&quot;Epson TM-T88V Direct Thermal Printer - Monochrome - Desktop&quot;</value>
+            <value>&quot;Epson WorkForce WF-2530 All-in-One Printer, Copier Scanner&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Eureka&quot;'>
+            <value>&quot;Eureka Disposable Bags for Sanitaire Vibra Groomer I Upright Vac&quot;</value>
+            <value>&quot;Eureka Hand Vacuum, Bagless&quot;</value>
+            <value>&quot;Eureka Recycled Copy Paper 8 1/2\&quot; x 11\&quot;, Ream&quot;</value>
+            <value>&quot;Eureka Sanitaire  Commercial Upright&quot;</value>
+            <value>&quot;Eureka Sanitaire  Multi-Pro Heavy-Duty Upright, Disposable Bags&quot;</value>
+            <value>&quot;Eureka The Boss Cordless Rechargeable Stick Vac&quot;</value>
+            <value>&quot;Eureka The Boss Lite 10-Amp Upright Vacuum, Blue&quot;</value>
+            <value>&quot;Eureka The Boss Plus 12-Amp Hard Box Upright Vacuum, Red&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Euro Pro&quot;'>
+            <value>&quot;Euro Pro Shark Stick Mini Vacuum&quot;</value>
+            <value>&quot;Euro-Pro Shark Turbo Vacuum&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Executive Impressions&quot;'>
+            <value>&quot;Executive Impressions 10\&quot; Spectator Wall Clock&quot;</value>
+            <value>&quot;Executive Impressions 12\&quot; Wall Clock&quot;</value>
+            <value>&quot;Executive Impressions 13-1/2\&quot; Indoor/Outdoor Wall Clock&quot;</value>
+            <value>&quot;Executive Impressions 13\&quot; Chairman Wall Clock&quot;</value>
+            <value>&quot;Executive Impressions 13\&quot; Clairmont Wall Clock&quot;</value>
+            <value>&quot;Executive Impressions 14\&quot;&quot;</value>
+            <value>&quot;Executive Impressions 14\&quot; Contract Wall Clock&quot;</value>
+            <value>&quot;Executive Impressions 14\&quot; Contract Wall Clock with Quartz Movement&quot;</value>
+            <value>&quot;Executive Impressions 14\&quot; Two-Color Numerals Wall Clock&quot;</value>
+            <value>&quot;Executive Impressions 16-1/2\&quot; Circular Wall Clock&quot;</value>
+            <value>&quot;Executive Impressions 8-1/2\&quot; Career Panel/Partition Cubicle Clock&quot;</value>
+            <value>&quot;Executive Impressions Supervisor Wall Clock&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Fellowes&quot;'>
+            <value>&quot;Fellowes 8 Outlet Superior Workstation Surge Protector&quot;</value>
+            <value>&quot;Fellowes 8 Outlet Superior Workstation Surge Protector w/o Phone/Fax/Modem Protection&quot;</value>
+            <value>&quot;Fellowes Advanced 8 Outlet Surge Suppressor with Phone/Fax Protection&quot;</value>
+            <value>&quot;Fellowes Advanced Computer Series Surge Protectors&quot;</value>
+            <value>&quot;Fellowes Bankers Box Recycled Super Stor/Drawer&quot;</value>
+            <value>&quot;Fellowes Bankers Box Staxonsteel Drawer File/Stacking System&quot;</value>
+            <value>&quot;Fellowes Bankers Box Stor/Drawer Steel Plus&quot;</value>
+            <value>&quot;Fellowes Bases and Tops For Staxonsteel/High-Stak Systems&quot;</value>
+            <value>&quot;Fellowes Basic Home/Office Series Surge Protectors&quot;</value>
+            <value>&quot;Fellowes Binding Cases&quot;</value>
+            <value>&quot;Fellowes Black Plastic Comb Bindings&quot;</value>
+            <value>&quot;Fellowes Command Center 5-outlet power strip&quot;</value>
+            <value>&quot;Fellowes Desktop Hanging File Manager&quot;</value>
+            <value>&quot;Fellowes Econo/Stor Drawers&quot;</value>
+            <value>&quot;Fellowes High-Stak Drawer Files&quot;</value>
+            <value>&quot;Fellowes Mighty 8 Compact Surge Protector&quot;</value>
+            <value>&quot;Fellowes Mobile File Cart, Black&quot;</value>
+            <value>&quot;Fellowes Neat Ideas Storage Cubes&quot;</value>
+            <value>&quot;Fellowes Officeware Wire Shelving&quot;</value>
+            <value>&quot;Fellowes PB200 Plastic Comb Binding Machine&quot;</value>
+            <value>&quot;Fellowes PB300 Plastic Comb Binding Machine&quot;</value>
+            <value>&quot;Fellowes PB500 Electric Punch Plastic Comb Binding Machine with Manual Bind&quot;</value>
+            <value>&quot;Fellowes Personal Hanging Folder Files, Navy&quot;</value>
+            <value>&quot;Fellowes Powershred HS-440 4-Sheet High Security Shredder&quot;</value>
+            <value>&quot;Fellowes Premier Superior Surge Suppressor, 10-Outlet, With Phone and Remote&quot;</value>
+            <value>&quot;Fellowes Presentation Covers for Comb Binding Machines&quot;</value>
+            <value>&quot;Fellowes Recycled Storage Drawers&quot;</value>
+            <value>&quot;Fellowes Smart Surge Ten-Outlet Protector, Platinum&quot;</value>
+            <value>&quot;Fellowes Staxonsteel Drawer Files&quot;</value>
+            <value>&quot;Fellowes Stor/Drawer Steel Plus Storage Drawers&quot;</value>
+            <value>&quot;Fellowes Strictly Business Drawer File, Letter/Legal Size&quot;</value>
+            <value>&quot;Fellowes Super Stor/Drawer&quot;</value>
+            <value>&quot;Fellowes Super Stor/Drawer Files&quot;</value>
+            <value>&quot;Fellowes Superior 10 Outlet Split Surge Protector&quot;</value>
+            <value>&quot;Fellowes Twister Kit, Gray/Clear, 3/pkg&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;First Data&quot;'>
+            <value>&quot;First Data FD10 PIN Pad&quot;</value>
+            <value>&quot;First Data TMFD35 PIN Pad&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Fiskars&quot;'>
+            <value>&quot;Fiskars 8\&quot; Scissors, 2/Pack&quot;</value>
+            <value>&quot;Fiskars Home &amp; Office Scissors&quot;</value>
+            <value>&quot;Fiskars Softgrip Scissors&quot;</value>
+            <value>&quot;Fiskars Spring-Action Scissors&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;G. E.&quot;'>
+            <value>&quot;G.E. Halogen Desk Lamp Bulbs&quot;</value>
+            <value>&quot;G.E. Longer-Life Indoor Recessed Floodlight Bulbs&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;GBC&quot;'>
+            <value>&quot;GBC Binding covers&quot;</value>
+            <value>&quot;GBC Clear Cover, 8-1/2 x 11, unpunched, 25 covers per pack&quot;</value>
+            <value>&quot;GBC DocuBind 200 Manual Binding Machine&quot;</value>
+            <value>&quot;GBC DocuBind 300 Electric Binding Machine&quot;</value>
+            <value>&quot;GBC DocuBind P100 Manual Binding Machine&quot;</value>
+            <value>&quot;GBC DocuBind P400 Electric Binding System&quot;</value>
+            <value>&quot;GBC DocuBind P50 Personal Binding Machine&quot;</value>
+            <value>&quot;GBC DocuBind TL200 Manual Binding Machine&quot;</value>
+            <value>&quot;GBC DocuBind TL300 Electric Binding System&quot;</value>
+            <value>&quot;GBC Durable Plastic Covers&quot;</value>
+            <value>&quot;GBC Ibimaster 500 Manual ProClick Binding System&quot;</value>
+            <value>&quot;GBC Imprintable Covers&quot;</value>
+            <value>&quot;GBC Instant Index System for Binding Systems&quot;</value>
+            <value>&quot;GBC Instant Report Kit&quot;</value>
+            <value>&quot;GBC Laser Imprintable Binding System Covers, Desert Sand&quot;</value>
+            <value>&quot;GBC Linen Binding Covers&quot;</value>
+            <value>&quot;GBC Personal VeloBind Strips&quot;</value>
+            <value>&quot;GBC Plastic Binding Combs&quot;</value>
+            <value>&quot;GBC Plasticlear Binding Covers&quot;</value>
+            <value>&quot;GBC Poly Designer Binding Covers&quot;</value>
+            <value>&quot;GBC Pre-Punched Binding Paper, Plastic, White, 8-1/2\&quot; x 11\&quot;&quot;</value>
+            <value>&quot;GBC Premium Transparent Covers with Diagonal Lined Pattern&quot;</value>
+            <value>&quot;GBC Prepunched Paper, 19-Hole, for Binding Systems, 24-lb&quot;</value>
+            <value>&quot;GBC Prestige Therm-A-Bind Covers&quot;</value>
+            <value>&quot;GBC ProClick 150 Presentation Binding System&quot;</value>
+            <value>&quot;GBC ProClick Punch Binding System&quot;</value>
+            <value>&quot;GBC ProClick Spines for 32-Hole Punch&quot;</value>
+            <value>&quot;GBC Recycled Grain Textured Covers&quot;</value>
+            <value>&quot;GBC Recycled Regency Composition Covers&quot;</value>
+            <value>&quot;GBC Recycled VeloBinder Covers&quot;</value>
+            <value>&quot;GBC Standard Plastic Binding Systems Combs&quot;</value>
+            <value>&quot;GBC Standard Plastic Binding Systems&apos; Combs&quot;</value>
+            <value>&quot;GBC Standard Recycled Report Covers, Clear Plastic Sheets&quot;</value>
+            <value>&quot;GBC Standard Therm-A-Bind Covers&quot;</value>
+            <value>&quot;GBC Therma-A-Bind 250T Electric Binding System&quot;</value>
+            <value>&quot;GBC Twin Loop Wire Binding Elements&quot;</value>
+            <value>&quot;GBC Twin Loop Wire Binding Elements, 9/16\&quot; Spine, Black&quot;</value>
+            <value>&quot;GBC VeloBind Cover Sets&quot;</value>
+            <value>&quot;GBC Velobind Prepunched Cover Sets, Regency Series&quot;</value>
+            <value>&quot;GBC VeloBinder Electric Binding Machine&quot;</value>
+            <value>&quot;GBC VeloBinder Manual Binding System&quot;</value>
+            <value>&quot;GBC VeloBinder Strips&quot;</value>
+            <value>&quot;GBC White Gloss Covers, Plain Front&quot;</value>
+            <value>&quot;GBC Wire Binding Combs&quot;</value>
+            <value>&quot;GBC Wire Binding Strips&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;GE&quot;'>
+            <value>&quot;GE 2-Jack Phone Line Splitter&quot;</value>
+            <value>&quot;GE 30524EE4&quot;</value>
+            <value>&quot;GE 4 Foot Flourescent Tube, 40 Watt&quot;</value>
+            <value>&quot;GE 48\&quot; Fluorescent Tube, Cool White Energy Saver, 34 Watts, 30/Box&quot;</value>
+            <value>&quot;GE DSL Phone Line Filter&quot;</value>
+            <value>&quot;GE General Purpose, Extra Long Life, Showcase &amp; Floodlight Incandescent Bulbs&quot;</value>
+            <value>&quot;GE General Use Halogen Bulbs, 100 Watts, 1 Bulb per Pack&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Global&quot;'>
+            <value>&quot;Global Adaptabilites Bookcase, Cherry/Storm Gray Finish&quot;</value>
+            <value>&quot;Global Adaptabilities Conference Tables&quot;</value>
+            <value>&quot;Global Airflow Leather Mesh Back Chair, Black&quot;</value>
+            <value>&quot;Global Armless Task Chair, Royal Blue&quot;</value>
+            <value>&quot;Global Chrome Stack Chair&quot;</value>
+            <value>&quot;Global Comet Stacking Arm Chair&quot;</value>
+            <value>&quot;Global Comet Stacking Armless Chair&quot;</value>
+            <value>&quot;Global Commerce Series High-Back Swivel/Tilt Chairs&quot;</value>
+            <value>&quot;Global Commerce Series Low-Back Swivel/Tilt Chairs&quot;</value>
+            <value>&quot;Global Deluxe High-Back Manager&apos;s Chair&quot;</value>
+            <value>&quot;Global Deluxe High-Back Office Chair in Storm&quot;</value>
+            <value>&quot;Global Deluxe Office Fabric Chairs&quot;</value>
+            <value>&quot;Global Deluxe Stacking Chair, Gray&quot;</value>
+            <value>&quot;Global Deluxe Steno Chair&quot;</value>
+            <value>&quot;Global Enterprise Series Seating High-Back Swivel/Tilt Chairs&quot;</value>
+            <value>&quot;Global Enterprise Series Seating Low-Back Swivel/Tilt Chairs&quot;</value>
+            <value>&quot;Global Ergonomic Managers Chair&quot;</value>
+            <value>&quot;Global Executive Mid-Back Manager&apos;s Chair&quot;</value>
+            <value>&quot;Global Fabric Manager&apos;s Chair, Dark Gray&quot;</value>
+            <value>&quot;Global Geo Office Task Chair, Gray&quot;</value>
+            <value>&quot;Global High-Back Leather Tilter, Burgundy&quot;</value>
+            <value>&quot;Global Highback Leather Tilter in Burgundy&quot;</value>
+            <value>&quot;Global Italian Leather Office Chair&quot;</value>
+            <value>&quot;Global Leather &amp; Oak Executive Chair, Burgundy&quot;</value>
+            <value>&quot;Global Leather and Oak Executive Chair, Black&quot;</value>
+            <value>&quot;Global Leather Executive Chair&quot;</value>
+            <value>&quot;Global Leather Highback Executive Chair with Pneumatic Height Adjustment, Black&quot;</value>
+            <value>&quot;Global Leather Task Chair, Black&quot;</value>
+            <value>&quot;Global Low Back Tilter Chair&quot;</value>
+            <value>&quot;Global Manager&apos;s Adjustable Task Chair, Storm&quot;</value>
+            <value>&quot;Global Push Button Manager&apos;s Chair, Indigo&quot;</value>
+            <value>&quot;Global Stack Chair with Arms, Black&quot;</value>
+            <value>&quot;Global Stack Chair without Arms, Black&quot;</value>
+            <value>&quot;Global Super Steno Chair&quot;</value>
+            <value>&quot;Global Task Chair, Black&quot;</value>
+            <value>&quot;Global Troy Executive Leather Low-Back Tilter&quot;</value>
+            <value>&quot;Global Value Mid-Back Manager&apos;s Chair, Gray&quot;</value>
+            <value>&quot;Global Value Steno Chair, Gray&quot;</value>
+            <value>&quot;Global Wood Trimmed Manager&apos;s Task Chair, Khaki&quot;</value>
+            <value>&quot;Globe Weis Peel &amp; Seel First Class Envelopes&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Gould Plastics&quot;'>
+            <value>&quot;Gould Plastics 18-Pocket Panel Bin, 34w x 5-1/4d x 20-1/2h&quot;</value>
+            <value>&quot;Gould Plastics 9-Pocket Panel Bin, 18-3/8w x 5-1/4d x 20-1/2h, Black&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Grandstream&quot;'>
+            <value>&quot;Grandstream GXP1160 VoIP phone&quot;</value>
+            <value>&quot;Grandstream GXP2100 Mainstream Business Phone&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Griffin&quot;'>
+            <value>&quot;Griffin GC17055 Auxiliary Audio Cable&quot;</value>
+            <value>&quot;Griffin GC36547 PowerJolt SE Lightning Charger&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Hammermil&quot;'>
+            <value>&quot;Hammermill Color Copier Paper (28Lb. and 96 Bright)&quot;</value>
+            <value>&quot;Hammermill CopyPlus Copy Paper (20Lb. and 84 Bright)&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Harmony&quot;'>
+            <value>&quot;Harmony Air Purifier&quot;</value>
+            <value>&quot;Harmony HEPA Quiet Air Purifiers&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Hewlett-Packard&quot;'>
+            <value>&quot;Hewlett Packard 310 Color Digital Copier&quot;</value>
+            <value>&quot;Hewlett Packard 610 Color Digital Copier / Printer&quot;</value>
+            <value>&quot;Hewlett Packard LaserJet 3310 Copier&quot;</value>
+            <value>&quot;Hewlett-Packard 300S Scientific Calculator&quot;</value>
+            <value>&quot;Hewlett-Packard Deskjet 3050a All-in-One Color Inkjet Printer&quot;</value>
+            <value>&quot;Hewlett-Packard Deskjet 5550 Printer&quot;</value>
+            <value>&quot;Hewlett-Packard Deskjet 6540 Color Inkjet Printer&quot;</value>
+            <value>&quot;Hewlett-Packard Deskjet D4360 Printer&quot;</value>
+            <value>&quot;Hewlett-Packard Deskjet F4180 All-in-One Color Ink-jet - Printer / copier / scanner&quot;</value>
+            <value>&quot;Hewlett-Packard Desktjet 6988DT Refurbished Printer&quot;</value>
+            <value>&quot;HP Designjet T1500 PostScript Inkjet Large Format Printer - 914mm&quot;</value>
+            <value>&quot;HP Designjet T520 Inkjet Large Format Printer - 24\&quot; Color&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Holmes&quot;'>
+            <value>&quot;Holmes 99\% HEPA Air Purifier&quot;</value>
+            <value>&quot;Holmes Cool Mist Humidifier for the Whole House with 8-Gallon Output per Day, Extended Life Filter&quot;</value>
+            <value>&quot;Holmes HEPA Air Purifier&quot;</value>
+            <value>&quot;Holmes Odor Grabber&quot;</value>
+            <value>&quot;Holmes Replacement Filter for HEPA Air Cleaner, Large Room&quot;</value>
+            <value>&quot;Holmes Replacement Filter for HEPA Air Cleaner, Medium Room&quot;</value>
+            <value>&quot;Holmes Replacement Filter for HEPA Air Cleaner, Very Large Room, HEPA Filter&quot;</value>
+            <value>&quot;Holmes Visible Mist Ultrasonic Humidifier with 2.3-Gallon Output per Day, Replacement Filter&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Hon&quot;'>
+            <value>&quot;Hon 2090 “Pillow Soft” Series Mid Back Swivel/Tilt Chairs&quot;</value>
+            <value>&quot;Hon 2111 Invitation Series Corner Table&quot;</value>
+            <value>&quot;Hon 2111 Invitation Series Straight Table&quot;</value>
+            <value>&quot;Hon 30\&quot; x 60\&quot; Table with Locking Drawer&quot;</value>
+            <value>&quot;Hon 4-Shelf Metal Bookcases&quot;</value>
+            <value>&quot;Hon 4060 Series Tables&quot;</value>
+            <value>&quot;Hon 4070 Series Pagoda Armless Upholstered Stacking Chairs&quot;</value>
+            <value>&quot;Hon 4070 Series Pagoda Round Back Stacking Chairs&quot;</value>
+            <value>&quot;Hon 4700 Series Mobuis Mid-Back Task Chairs with Adjustable Arms&quot;</value>
+            <value>&quot;Hon 5100 Series Wood Tables&quot;</value>
+            <value>&quot;HON 5400 Series Task Chairs for Big and Tall&quot;</value>
+            <value>&quot;Hon 61000 Series Interactive Training Tables&quot;</value>
+            <value>&quot;Hon 94000 Series Round Tables&quot;</value>
+            <value>&quot;Hon Comfortask Task/Swivel Chairs&quot;</value>
+            <value>&quot;Hon Deluxe Fabric Upholstered Stacking Chairs&quot;</value>
+            <value>&quot;Hon Deluxe Fabric Upholstered Stacking Chairs, Rounded Back&quot;</value>
+            <value>&quot;Hon Deluxe Fabric Upholstered Stacking Chairs, Squared Back&quot;</value>
+            <value>&quot;Hon Every-Day Chair Series Swivel Task Chairs&quot;</value>
+            <value>&quot;Hon Every-Day Series Multi-Task Chairs&quot;</value>
+            <value>&quot;Hon GuestStacker Chair&quot;</value>
+            <value>&quot;Hon iLevel Computer Training Table&quot;</value>
+            <value>&quot;Hon Metal Bookcases, Black&quot;</value>
+            <value>&quot;Hon Metal Bookcases, Gray&quot;</value>
+            <value>&quot;Hon Metal Bookcases, Putty&quot;</value>
+            <value>&quot;Hon Mobius Operator&apos;s Chair&quot;</value>
+            <value>&quot;Hon Multipurpose Stacking Arm Chairs&quot;</value>
+            <value>&quot;Hon Non-Folding Utility Tables&quot;</value>
+            <value>&quot;Hon Olson Stacker Chairs&quot;</value>
+            <value>&quot;Hon Olson Stacker Stools&quot;</value>
+            <value>&quot;Hon Pagoda Stacking Chairs&quot;</value>
+            <value>&quot;Hon Practical Foundations 30 x 60 Training Table, Light Gray/Charcoal&quot;</value>
+            <value>&quot;Hon Racetrack Conference Tables&quot;</value>
+            <value>&quot;Hon Rectangular Conference Tables&quot;</value>
+            <value>&quot;Hon Valutask Swivel Chairs&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Honeywell&quot;'>
+            <value>&quot;Honeywell Enviracaire Portable Air Cleaner for up to 8 x 10 Room&quot;</value>
+            <value>&quot;Honeywell Enviracaire Portable HEPA Air Cleaner for 16&apos; x 20&apos; Room&quot;</value>
+            <value>&quot;Honeywell Enviracaire Portable HEPA Air Cleaner for 17&apos; x 22&apos; Room&quot;</value>
+            <value>&quot;Honeywell Enviracaire Portable HEPA Air Cleaner for up to 10 x 16 Room&quot;</value>
+            <value>&quot;Honeywell Quietcare HEPA Air Cleaner&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Hoover&quot;'>
+            <value>&quot;Hoover Commercial Lightweight Upright Vacuum&quot;</value>
+            <value>&quot;Hoover Commercial Lightweight Upright Vacuum with E-Z Empty Dirt Cup&quot;</value>
+            <value>&quot;Hoover Commercial Soft Guard Upright Vacuum And Disposable Filtration Bags&quot;</value>
+            <value>&quot;Hoover Commercial SteamVac&quot;</value>
+            <value>&quot;Hoover Portapower Portable Vacuum&quot;</value>
+            <value>&quot;Hoover Replacement Belt for Commercial Guardsman Heavy-Duty Upright Vacuum&quot;</value>
+            <value>&quot;Hoover Replacement Belts For Soft Guard &amp; Commercial Ltweight Upright Vacs, 2/Pk&quot;</value>
+            <value>&quot;Hoover Shoulder Vac Commercial Portable Vacuum&quot;</value>
+            <value>&quot;Hoover Upright Vacuum With Dirt Cup&quot;</value>
+            <value>&quot;Hoover WindTunnel Plus Canister Vacuum&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Howard Miller&quot;'>
+            <value>&quot;Howard Miller 11-1/2\&quot; Diameter Brentwood Wall Clock&quot;</value>
+            <value>&quot;Howard Miller 11-1/2\&quot; Diameter Grantwood Wall Clock&quot;</value>
+            <value>&quot;Howard Miller 11-1/2\&quot; Diameter Ridgewood Wall Clock&quot;</value>
+            <value>&quot;Howard Miller 12-3/4 Diameter Accuwave DS  Wall Clock&quot;</value>
+            <value>&quot;Howard Miller 12\&quot; Round Wall Clock&quot;</value>
+            <value>&quot;Howard Miller 13-1/2\&quot; Diameter Rosebrook Wall Clock&quot;</value>
+            <value>&quot;Howard Miller 13-3/4\&quot; Diameter Brushed Chrome Round Wall Clock&quot;</value>
+            <value>&quot;Howard Miller 13\&quot; Diameter Goldtone Round Wall Clock&quot;</value>
+            <value>&quot;Howard Miller 13\&quot; Diameter Pewter Finish Round Wall Clock&quot;</value>
+            <value>&quot;Howard Miller 14-1/2\&quot; Diameter Chrome Round Wall Clock&quot;</value>
+            <value>&quot;Howard Miller 16\&quot; Diameter Gallery Wall Clock&quot;</value>
+            <value>&quot;Howard Miller Distant Time Traveler Alarm Clock&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;HP&quot;'>
+            <value>&quot;HP Office Paper (20Lb. and 87 Bright)&quot;</value>
+            <value>&quot;HP Office Recycled Paper (20Lb. and 87 Bright)&quot;</value>
+            <value>&quot;HP Officejet Pro 8600 e-All-In-One Printer, Copier, Scanner, Fax&quot;</value>
+            <value>&quot;HP Standard 104 key PS/2 Keyboard&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;HTC&quot;'>
+            <value>&quot;HTC One&quot;</value>
+            <value>&quot;HTC One Mini&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Hunt&quot;'>
+            <value>&quot;Hunt BOSTON Model 1606 High-Volume Electric Pencil Sharpener, Beige&quot;</value>
+            <value>&quot;Hunt Boston Vacuum Mount KS Pencil Sharpener&quot;</value>
+            <value>&quot;Hunt BOSTON Vista Battery-Operated Pencil Sharpener, Black&quot;</value>
+            <value>&quot;Hunt PowerHouse Electric Pencil Sharpener, Blue&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Ibico&quot;'>
+            <value>&quot;Ibico Covers for Plastic or Wire Binding Elements&quot;</value>
+            <value>&quot;Ibico EB-19 Dual Function Manual Binding System&quot;</value>
+            <value>&quot;Ibico EPK-21 Electric Binding System&quot;</value>
+            <value>&quot;Ibico Hi-Tech Manual Binding System&quot;</value>
+            <value>&quot;Ibico Ibimaster 300 Manual Binding System&quot;</value>
+            <value>&quot;Ibico Laser Imprintable Binding System Covers&quot;</value>
+            <value>&quot;Ibico Plastic and Wire Spiral Binding Combs&quot;</value>
+            <value>&quot;Ibico Plastic Spiral Binding Combs&quot;</value>
+            <value>&quot;Ibico Presentation Index for Binding Systems&quot;</value>
+            <value>&quot;Ibico Recycled Grain-Textured Covers&quot;</value>
+            <value>&quot;Ibico Recycled Linen-Style Covers&quot;</value>
+            <value>&quot;Ibico Standard Transparent Covers&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Iceberg&quot;'>
+            <value>&quot;Iceberg Mobile Mega Data/Printer Cart&quot;</value>
+            <value>&quot;Iceberg Nesting Folding Chair, 19w x 6d x 43h&quot;</value>
+            <value>&quot;Iceberg OfficeWorks 42\&quot; Round Tables&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Imation&quot;'>
+            <value>&quot;Imation 16GB Mini TravelDrive USB 2.0 Flash Drive&quot;</value>
+            <value>&quot;Imation 30456 USB Flash Drive 8GB&quot;</value>
+            <value>&quot;Imation 32GB Pocket Pro USB 3.0 Flash Drive - 32 GB - Black - 1 P ...&quot;</value>
+            <value>&quot;Imation 8gb Micro Traveldrive Usb 2.0 Flash Drive&quot;</value>
+            <value>&quot;Imation Bio 2GB USB Flash Drive Imation Corp&quot;</value>
+            <value>&quot;Imation Bio 8GB USB Flash Drive Imation Corp&quot;</value>
+            <value>&quot;Imation Clip USB flash drive - 8 GB&quot;</value>
+            <value>&quot;Imation Secure Drive + Hardware Encrypted USB flash drive - 16 GB&quot;</value>
+            <value>&quot;Imation Secure+ Hardware Encrypted USB 2.0 Flash Drive; 16GB&quot;</value>
+            <value>&quot;Imation Swivel Flash Drive USB flash drive - 8 GB&quot;</value>
+            <value>&quot;Imation USB 2.0 Swivel Flash Drive USB flash drive - 4 GB - Pink&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;iOttie&quot;'>
+            <value>&quot;iOttie HLCRIO102 Car Mount&quot;</value>
+            <value>&quot;iOttie XL Car Mount&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Iris&quot;'>
+            <value>&quot;Iris 3-Drawer Stacking Bin, Black&quot;</value>
+            <value>&quot;Iris Project Case&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Jabra&quot;'>
+            <value>&quot;Jabra BIZ 2300 Duo QD Duo Corded Headset&quot;</value>
+            <value>&quot;Jabra SPEAK 410&quot;</value>
+            <value>&quot;Jabra SPEAK 410 Multidevice Speakerphone&quot;</value>
+            <value>&quot;Jabra Supreme Plus Driver Edition Headset&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Jawbone&quot;'>
+            <value>&quot;Jawbone JAMBOX Wireless Bluetooth Speaker&quot;</value>
+            <value>&quot;Jawbone MINI JAMBOX Wireless Bluetooth Speaker&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Kensington&quot;'>
+            <value>&quot;Kensington 4 Outlet MasterPiece Compact Power Control Center&quot;</value>
+            <value>&quot;Kensington 6 Outlet Guardian Standard Surge Protector&quot;</value>
+            <value>&quot;Kensington 6 Outlet MasterPiece HOMEOFFICE Power Control Center&quot;</value>
+            <value>&quot;Kensington 6 Outlet SmartSocket Surge Protector&quot;</value>
+            <value>&quot;Kensington 7 Outlet MasterPiece HOMEOFFICE Power Control Center&quot;</value>
+            <value>&quot;Kensington 7 Outlet MasterPiece Power Center&quot;</value>
+            <value>&quot;Kensington 7 Outlet MasterPiece Power Center with Fax/Phone Line Protection&quot;</value>
+            <value>&quot;Kensington Expert Mouse Optical USB Trackball for PC or Mac&quot;</value>
+            <value>&quot;Kensington K72356US Mouse-in-a-Box USB Desktop Mouse&quot;</value>
+            <value>&quot;Kensington Orbit Wireless Mobile Trackball for PC and Mac&quot;</value>
+            <value>&quot;Kensington SlimBlade Notebook Wireless Mouse with Nano Receiver&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;KeyTronic&quot;'>
+            <value>&quot;KeyTronic 6101 Series - Keyboard - Black&quot;</value>
+            <value>&quot;KeyTronic E03601U1 - Keyboard - Beige&quot;</value>
+            <value>&quot;KeyTronic KT400U2 - Keyboard - Black&quot;</value>
+            <value>&quot;KeyTronic KT800P2 - Keyboard - Black&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;KI&quot;'>
+            <value>&quot;KI Adjustable-Height Table&quot;</value>
+            <value>&quot;KI Conference Tables&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Kingston&quot;'>
+            <value>&quot;Kingston Digital DataTraveler 16GB USB 2.0&quot;</value>
+            <value>&quot;Kingston Digital DataTraveler 32GB USB 2.0&quot;</value>
+            <value>&quot;Kingston Digital DataTraveler 64GB USB 2.0&quot;</value>
+            <value>&quot;Kingston Digital DataTraveler 8GB USB 2.0&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Lesro&quot;'>
+            <value>&quot;Lesro Round Back Collection Coffee Table, End Table&quot;</value>
+            <value>&quot;Lesro Sheffield Collection Coffee Table, End Table, Center Table, Corner Table&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Lexmark&quot;'>
+            <value>&quot;Lexmark 160 GB Internal Hard Drive&quot;</value>
+            <value>&quot;Lexmark 20R1285 X6650 Wireless All-in-One Printer&quot;</value>
+            <value>&quot;Lexmark Intuition S505 All-in-One Color Inkjet Printer&quot;</value>
+            <value>&quot;Lexmark MarkNet N8150 Wireless Print Server&quot;</value>
+            <value>&quot;Lexmark S315 Color Inkjet Printer&quot;</value>
+            <value>&quot;Lexmark X 9575 Professional All-in-One Color Printer&quot;</value>
+            <value>&quot;Lexmark X8350 All-in-One Color Inkjet  Printer&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;LG&quot;'>
+            <value>&quot;LG Electronics Tone+ HBS-730 Bluetooth Headset&quot;</value>
+            <value>&quot;LG G2&quot;</value>
+            <value>&quot;LG G3&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Linden&quot;'>
+            <value>&quot;Linden 10\&quot; Round Wall Clock, Black&quot;</value>
+            <value>&quot;Linden 12\&quot; Wall Clock With Oak Frame&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Logitech&quot;'>
+            <value>&quot;Logitech 910-002974 M325 Wireless Mouse for Web Scrolling&quot;</value>
+            <value>&quot;Logitech B530 USB Headset - headset - Full size, Binaural&quot;</value>
+            <value>&quot;Logitech ClearChat Comfort/USB Headset H390&quot;</value>
+            <value>&quot;Logitech Desktop MK120 Mouse and keyboard Combo&quot;</value>
+            <value>&quot;Logitech diNovo Edge Keyboard&quot;</value>
+            <value>&quot;Logitech G105 Gaming Keyboard&quot;</value>
+            <value>&quot;Logitech G13 Programmable Gameboard with LCD Display&quot;</value>
+            <value>&quot;Logitech G19 Programmable Gaming Keyboard&quot;</value>
+            <value>&quot;Logitech G35 7.1-Channel Surround Sound Headset&quot;</value>
+            <value>&quot;Logitech G430 Surround Sound Gaming Headset with Dolby 7.1 Technology&quot;</value>
+            <value>&quot;Logitech G500s Laser Gaming Mouse with Adjustable Weight Tuning&quot;</value>
+            <value>&quot;Logitech G600 MMO Gaming Mouse&quot;</value>
+            <value>&quot;Logitech G602 Wireless Gaming Mouse&quot;</value>
+            <value>&quot;Logitech G700s Rechargeable Gaming Mouse&quot;</value>
+            <value>&quot;Logitech Gaming G510s - Keyboard&quot;</value>
+            <value>&quot;Logitech Illuminated - Keyboard&quot;</value>
+            <value>&quot;Logitech Illuminated Ultrathin Keyboard with Backlighting&quot;</value>
+            <value>&quot;Logitech K350 2.4Ghz Wireless Keyboard&quot;</value>
+            <value>&quot;Logitech Keyboard K120&quot;</value>
+            <value>&quot;Logitech LS21 Speaker System - PC Multimedia - 2.1-CH - Wired&quot;</value>
+            <value>&quot;Logitech M510 Wireless Mouse&quot;</value>
+            <value>&quot;Logitech Media Keyboard K200&quot;</value>
+            <value>&quot;Logitech Mobile Speakerphone P710e - speaker phone&quot;</value>
+            <value>&quot;Logitech MX Performance Wireless Mouse&quot;</value>
+            <value>&quot;Logitech P710e Mobile Speakerphone&quot;</value>
+            <value>&quot;Logitech Trackman Marble Mouse&quot;</value>
+            <value>&quot;Logitech VX Revolution Cordless Laser Mouse for Notebooks (Black)&quot;</value>
+            <value>&quot;Logitech Wireless Anywhere Mouse MX for PC and Mac&quot;</value>
+            <value>&quot;Logitech Wireless Boombox Speaker - portable - wireless, wired&quot;</value>
+            <value>&quot;Logitech Wireless Gaming Headset G930&quot;</value>
+            <value>&quot;Logitech Wireless Headset H600 Over-The-Head Design&quot;</value>
+            <value>&quot;Logitech Wireless Headset h800&quot;</value>
+            <value>&quot;Logitech Wireless Keyboard K340&quot;</value>
+            <value>&quot;Logitech Wireless Marathon Mouse M705&quot;</value>
+            <value>&quot;Logitech Wireless Performance Mouse MX for PC and Mac&quot;</value>
+            <value>&quot;Logitech Wireless Touch Keyboard K400&quot;</value>
+            <value>&quot;Logitech Z-906 Speaker sys - home theater - 5.1-CH&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Luxo&quot;'>
+            <value>&quot;Luxo Adjustable Task Clamp Lamp&quot;</value>
+            <value>&quot;Luxo Economy Swing Arm Lamp&quot;</value>
+            <value>&quot;Luxo Professional Combination Clamp-On Lamps&quot;</value>
+            <value>&quot;Luxo Professional Fluorescent Magnifier Lamp with Clamp-Mount Base&quot;</value>
+            <value>&quot;Luxo Professional Magnifying Clamp-On Fluorescent Lamps&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Martin-Yale&quot;'>
+            <value>&quot;Martin Yale Chadless Opener Electric Letter Opener&quot;</value>
+            <value>&quot;Martin-Yale Premier Letter Opener&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Master Caster&quot;'>
+            <value>&quot;Master Caster Door Stop, Brown&quot;</value>
+            <value>&quot;Master Caster Door Stop, Gray&quot;</value>
+            <value>&quot;Master Caster Door Stop, Large Brown&quot;</value>
+            <value>&quot;Master Caster Door Stop, Large Neon Orange&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Maxell&quot;'>
+            <value>&quot;Maxell 4.7GB DVD-R&quot;</value>
+            <value>&quot;Maxell 4.7GB DVD-R 5/Pack&quot;</value>
+            <value>&quot;Maxell 4.7GB DVD-RW 3/Pack&quot;</value>
+            <value>&quot;Maxell 4.7GB DVD+R 5/Pack&quot;</value>
+            <value>&quot;Maxell 4.7GB DVD+RW 3/Pack&quot;</value>
+            <value>&quot;Maxell 74 Minute CD-R Spindle, 50/Pack&quot;</value>
+            <value>&quot;Maxell 74 Minute CDR, 10/Pack&quot;</value>
+            <value>&quot;Maxell CD-R Discs&quot;</value>
+            <value>&quot;Maxell DVD-RAM Discs&quot;</value>
+            <value>&quot;Maxell iVDR EX 500GB Cartridge&quot;</value>
+            <value>&quot;Maxell LTO Ultrium - 800 GB&quot;</value>
+            <value>&quot;Maxell Pro 80 Minute CD-R, 10/Pack&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Memorex&quot;'>
+            <value>&quot;Memorex 25GB 6X Branded Blu-Ray Recordable Disc, 15/Pack&quot;</value>
+            <value>&quot;Memorex 25GB 6X Branded Blu-Ray Recordable Disc, 30/Pack&quot;</value>
+            <value>&quot;Memorex Froggy Flash Drive 4 GB&quot;</value>
+            <value>&quot;Memorex Froggy Flash Drive 8 GB&quot;</value>
+            <value>&quot;Memorex Micro Travel Drive 16 GB&quot;</value>
+            <value>&quot;Memorex Micro Travel Drive 32 GB&quot;</value>
+            <value>&quot;Memorex Micro Travel Drive 4 GB&quot;</value>
+            <value>&quot;Memorex Micro Travel Drive 8 GB&quot;</value>
+            <value>&quot;Memorex Mini Travel Drive 16 GB USB 2.0 Flash Drive&quot;</value>
+            <value>&quot;Memorex Mini Travel Drive 32 GB USB 2.0 Flash Drive&quot;</value>
+            <value>&quot;Memorex Mini Travel Drive 4 GB USB 2.0 Flash Drive&quot;</value>
+            <value>&quot;Memorex Mini Travel Drive 64 GB USB 2.0 Flash Drive&quot;</value>
+            <value>&quot;Memorex Mini Travel Drive 8 GB USB 2.0 Flash Drive&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Message Book&quot;'>
+            <value>&quot;Message Book, Phone, Wirebound Standard Line Memo, 2 3/4\&quot; X 5\&quot;&quot;</value>
+            <value>&quot;Message Book, Standard Line \&quot;While You Were Out\&quot;, 5 1/2\&quot; X 4\&quot;, 200 Sets/Book&quot;</value>
+            <value>&quot;Message Book, Wirebound, Four 5 1/2\&quot; X 4\&quot; Forms/Pg., 200 Dupl. Sets/Book&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Micro Innovations&quot;'>
+            <value>&quot;Micro Innovations USB RF Wireless Keyboard with Mouse&quot;</value>
+            <value>&quot;Micro Innovations Wireless Classic Keyboard with Mouse&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Microsoft&quot;'>
+            <value>&quot;Microsoft Arc Touch Mouse&quot;</value>
+            <value>&quot;Microsoft Natural Ergonomic Keyboard 4000&quot;</value>
+            <value>&quot;Microsoft Natural Keyboard Elite&quot;</value>
+            <value>&quot;Microsoft Sculpt Comfort Mouse&quot;</value>
+            <value>&quot;Microsoft Wireless Mobile Mouse 4000&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Mitel&quot;'>
+            <value>&quot;Mitel 5320 IP Phone VoIP phone&quot;</value>
+            <value>&quot;Mitel MiVoice 5330e IP Phone&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Motorola&quot;'>
+            <value>&quot;Motorla HX550 Universal Bluetooth Headset&quot;</value>
+            <value>&quot;Motorola Droid Maxx&quot;</value>
+            <value>&quot;Motorola HK250 Universal Bluetooth Headset&quot;</value>
+            <value>&quot;Motorola L703CM&quot;</value>
+            <value>&quot;Motorola L804&quot;</value>
+            <value>&quot;Motorola Moto X&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;NETGEAR&quot;'>
+            <value>&quot;NETGEAR AC1750 Dual Band Gigabit Smart WiFi Router&quot;</value>
+            <value>&quot;NETGEAR N750 Dual Band Wi-Fi Gigabit Router&quot;</value>
+            <value>&quot;NETGEAR RangeMax WNR1000 Wireless Router&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Newell&quot;'>
+            <value>&quot;Newell 3-Hole Punched Plastic Slotted Magazine Holders for Binders&quot;</value>
+            <value>&quot;Newell 307&quot;</value>
+            <value>&quot;Newell 308&quot;</value>
+            <value>&quot;Newell 309&quot;</value>
+            <value>&quot;Newell 31&quot;</value>
+            <value>&quot;Newell 310&quot;</value>
+            <value>&quot;Newell 311&quot;</value>
+            <value>&quot;Newell 312&quot;</value>
+            <value>&quot;Newell 313&quot;</value>
+            <value>&quot;Newell 314&quot;</value>
+            <value>&quot;Newell 315&quot;</value>
+            <value>&quot;Newell 316&quot;</value>
+            <value>&quot;Newell 317&quot;</value>
+            <value>&quot;Newell 318&quot;</value>
+            <value>&quot;Newell 319&quot;</value>
+            <value>&quot;Newell 32&quot;</value>
+            <value>&quot;Newell 320&quot;</value>
+            <value>&quot;Newell 321&quot;</value>
+            <value>&quot;Newell 322&quot;</value>
+            <value>&quot;Newell 323&quot;</value>
+            <value>&quot;Newell 324&quot;</value>
+            <value>&quot;Newell 325&quot;</value>
+            <value>&quot;Newell 326&quot;</value>
+            <value>&quot;Newell 327&quot;</value>
+            <value>&quot;Newell 328&quot;</value>
+            <value>&quot;Newell 329&quot;</value>
+            <value>&quot;Newell 33&quot;</value>
+            <value>&quot;Newell 330&quot;</value>
+            <value>&quot;Newell 331&quot;</value>
+            <value>&quot;Newell 332&quot;</value>
+            <value>&quot;Newell 333&quot;</value>
+            <value>&quot;Newell 334&quot;</value>
+            <value>&quot;Newell 335&quot;</value>
+            <value>&quot;Newell 336&quot;</value>
+            <value>&quot;Newell 337&quot;</value>
+            <value>&quot;Newell 338&quot;</value>
+            <value>&quot;Newell 339&quot;</value>
+            <value>&quot;Newell 34&quot;</value>
+            <value>&quot;Newell 340&quot;</value>
+            <value>&quot;Newell 341&quot;</value>
+            <value>&quot;Newell 342&quot;</value>
+            <value>&quot;Newell 343&quot;</value>
+            <value>&quot;Newell 344&quot;</value>
+            <value>&quot;Newell 345&quot;</value>
+            <value>&quot;Newell 346&quot;</value>
+            <value>&quot;Newell 347&quot;</value>
+            <value>&quot;Newell 348&quot;</value>
+            <value>&quot;Newell 349&quot;</value>
+            <value>&quot;Newell 35&quot;</value>
+            <value>&quot;Newell 350&quot;</value>
+            <value>&quot;Newell 351&quot;</value>
+            <value>&quot;Newell Chalk Holder&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Nokia&quot;'>
+            <value>&quot;Nokia Lumia 1020&quot;</value>
+            <value>&quot;Nokia Lumia 521 (T-Mobile)&quot;</value>
+            <value>&quot;Nokia Lumia 925&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Nortel&quot;'>
+            <value>&quot;Nortel Business Series Terminal T7208 Digital phone&quot;</value>
+            <value>&quot;Nortel Meridian M3904 Professional Digital phone&quot;</value>
+            <value>&quot;Nortel Meridian M5316 Digital phone&quot;</value>
+            <value>&quot;Nortel Networks T7316 E Nt8 B27&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Novimex&quot;'>
+            <value>&quot;Novimex Fabric Task Chair&quot;</value>
+            <value>&quot;Novimex High-Tech Fabric Mesh Task Chair&quot;</value>
+            <value>&quot;Novimex Swivel Fabric Task Chair&quot;</value>
+            <value>&quot;Novimex Turbo Task Chair&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Nu-Dell&quot;'>
+            <value>&quot;Nu-Dell Executive Frame&quot;</value>
+            <value>&quot;Nu-Dell EZ-Mount Plastic Wall Frames&quot;</value>
+            <value>&quot;Nu-Dell Float Frame 11 x 14 1/2&quot;</value>
+            <value>&quot;Nu-Dell Leatherette Frames&quot;</value>
+            <value>&quot;Nu-Dell Oak Frame&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;O&apos;Sullivan&quot;'>
+            <value>&quot;O&apos;Sullivan 2-Door Barrister Bookcase in Odessa Pine&quot;</value>
+            <value>&quot;O&apos;Sullivan 2-Shelf Heavy-Duty Bookcases&quot;</value>
+            <value>&quot;O&apos;Sullivan 3-Shelf Heavy-Duty Bookcases&quot;</value>
+            <value>&quot;O&apos;Sullivan 4-Shelf Bookcase in Odessa Pine&quot;</value>
+            <value>&quot;O&apos;Sullivan 5-Shelf Heavy-Duty Bookcases&quot;</value>
+            <value>&quot;O&apos;Sullivan Cherrywood Estates Traditional Barrister Bookcase&quot;</value>
+            <value>&quot;O&apos;Sullivan Cherrywood Estates Traditional Bookcase&quot;</value>
+            <value>&quot;O&apos;Sullivan Elevations Bookcase, Cherry Finish&quot;</value>
+            <value>&quot;O&apos;Sullivan Living Dimensions 2-Shelf Bookcases&quot;</value>
+            <value>&quot;O&apos;Sullivan Living Dimensions 3-Shelf Bookcases&quot;</value>
+            <value>&quot;O&apos;Sullivan Living Dimensions 5-Shelf Bookcases&quot;</value>
+            <value>&quot;O&apos;Sullivan Manor Hill 2-Door Library in Brianna Oak&quot;</value>
+            <value>&quot;O&apos;Sullivan Plantations 2-Door Library in Landvery Oak&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Office Impressions&quot;'>
+            <value>&quot;Office Impressions End Table, 20-1/2\&quot;H x 24\&quot;W x 20\&quot;D&quot;</value>
+            <value>&quot;Office Impressions Heavy Duty Welded Shelving &amp; Multimedia Storage Drawers&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Office Star&quot;'>
+            <value>&quot;Office Star - Contemporary Swivel Chair with Padded Adjustable Arms and Flex Back&quot;</value>
+            <value>&quot;Office Star - Contemporary Task Swivel Chair&quot;</value>
+            <value>&quot;Office Star - Contemporary Task Swivel chair with 2-way adjustable arms, Plum&quot;</value>
+            <value>&quot;Office Star - Contemporary Task Swivel chair with Loop Arms, Charcoal&quot;</value>
+            <value>&quot;Office Star - Ergonomic Mid Back Chair with 2-Way Adjustable Arms&quot;</value>
+            <value>&quot;Office Star - Ergonomically Designed Knee Chair&quot;</value>
+            <value>&quot;Office Star - Mesh Screen back chair with Vinyl seat&quot;</value>
+            <value>&quot;Office Star - Mid Back Dual function Ergonomic High Back Chair with 2-Way Adjustable Arms&quot;</value>
+            <value>&quot;Office Star - Professional Matrix Back Chair with 2-to-1 Synchro Tilt and Mesh Fabric Seat&quot;</value>
+            <value>&quot;Office Star - Task Chair with Contemporary Loop Arms&quot;</value>
+            <value>&quot;Office Star Flex Back Scooter Chair with Aluminum Finish Frame&quot;</value>
+            <value>&quot;Office Star Flex Back Scooter Chair with White Frame&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;OIC&quot;'>
+            <value>&quot;Binder Clips by OIC&quot;</value>
+            <value>&quot;OIC Binder Clips, Mini, 1/4\&quot; Capacity, Black&quot;</value>
+            <value>&quot;OIC Stacking Trays&quot;</value>
+            <value>&quot;OIC Thumb-Tacks&quot;</value>
+            <value>&quot;Translucent Push Pins by OIC&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Okidata&quot;'>
+            <value>&quot;Okidata B400 Printer&quot;</value>
+            <value>&quot;Okidata B401 Printer&quot;</value>
+            <value>&quot;Okidata C331dn Printer&quot;</value>
+            <value>&quot;Okidata C610n Printer&quot;</value>
+            <value>&quot;Okidata CX3535-CX4545 Multifunction Printer&quot;</value>
+            <value>&quot;Okidata MB471w Multifunction Printer&quot;</value>
+            <value>&quot;Okidata MB491 Multifunction Printer&quot;</value>
+            <value>&quot;Okidata MB760 Printer&quot;</value>
+            <value>&quot;Okidata MC362w All-in-One Printer&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Other&quot;'>
+            <value>&quot;\&quot;While you Were Out\&quot; Message Book, One Form per Page&quot;</value>
+            <value>&quot;\#10 Gummed Flap White Envelopes, 100/Box&quot;</value>
+            <value>&quot;\#10 Self-Seal White Envelopes&quot;</value>
+            <value>&quot;\#10 White Business Envelopes,4 1/8 x 9 1/2&quot;</value>
+            <value>&quot;\#10- 4 1/8\&quot; x 9 1/2\&quot; Recycled Envelopes&quot;</value>
+            <value>&quot;\#10- 4 1/8\&quot; x 9 1/2\&quot; Security-Tint Envelopes&quot;</value>
+            <value>&quot;\#10-4 1/8\&quot; x 9 1/2\&quot; Premium Diagonal Seam Envelopes&quot;</value>
+            <value>&quot;\#6 3/4 Gummed Flap White Envelopes&quot;</value>
+            <value>&quot;1.7 Cubic Foot Compact \&quot;Cube\&quot; Office Refrigerators&quot;</value>
+            <value>&quot;1/4 Fold Party Design Invitations &amp; White Envelopes, 24 8-1/2\&quot; X 11\&quot; Cards, 25 Env./Pack&quot;</value>
+            <value>&quot;12 Colored Short Pencils&quot;</value>
+            <value>&quot;12-1/2 Diameter Round Wall Clock&quot;</value>
+            <value>&quot;14-7/8 x 11 Blue Bar Computer Printout Paper&quot;</value>
+            <value>&quot;2300 Heavy-Duty Transfer File Systems by Perma&quot;</value>
+            <value>&quot;24 Capacity Maxi Data Binder Racks, Pearl&quot;</value>
+            <value>&quot;24-Hour Round Wall Clock&quot;</value>
+            <value>&quot;3.6 Cubic Foot Counter Height Office Refrigerator&quot;</value>
+            <value>&quot;36X48 HARDFLOOR CHAIRMAT&quot;</value>
+            <value>&quot;4009 Highlighters&quot;</value>
+            <value>&quot;4009 Highlighters by Sanford&quot;</value>
+            <value>&quot;50 Colored Long Pencils&quot;</value>
+            <value>&quot;6\&quot; Cubicle Wall Clock, Black&quot;</value>
+            <value>&quot;9-3/4 Diameter Round Wall Clock&quot;</value>
+            <value>&quot;Aastra 57i VoIP phone&quot;</value>
+            <value>&quot;Aastra 6757i CT Wireless VoIP phone&quot;</value>
+            <value>&quot;Acrylic Self-Standing Desk Frames&quot;</value>
+            <value>&quot;Adjustable Depth Letter/Legal Cart&quot;</value>
+            <value>&quot;Adjustable Personal File Tote&quot;</value>
+            <value>&quot;Adtran 1202752G1&quot;</value>
+            <value>&quot;Airmail Envelopes&quot;</value>
+            <value>&quot;Alphabetical Labels for Top Tab Filing&quot;</value>
+            <value>&quot;Aluminum Document Frame&quot;</value>
+            <value>&quot;Aluminum Screw Posts&quot;</value>
+            <value>&quot;AmazonBasics 3-Button USB Wired Mouse&quot;</value>
+            <value>&quot;American Pencil&quot;</value>
+            <value>&quot;Ames Color-File Green Diamond Border X-ray Mailers&quot;</value>
+            <value>&quot;Anderson Hickey Conga Table Tops &amp; Accessories&quot;</value>
+            <value>&quot;APC 7 Outlet Network SurgeArrest Surge Protector&quot;</value>
+            <value>&quot;ARKON Windshield Dashboard Air Vent Car Mount Holder&quot;</value>
+            <value>&quot;Artistic Insta-Plaque&quot;</value>
+            <value>&quot;Assorted Color Push Pins&quot;</value>
+            <value>&quot;Astroparche Fine Business Paper&quot;</value>
+            <value>&quot;Avoid Verbal Orders Carbonless Minifold Book&quot;</value>
+            <value>&quot;Bady BDG101FRU Card Printer&quot;</value>
+            <value>&quot;Bagged Rubber Bands&quot;</value>
+            <value>&quot;Barrel Sharpener&quot;</value>
+            <value>&quot;Binder Posts&quot;</value>
+            <value>&quot;Binding Machine Supplies&quot;</value>
+            <value>&quot;Black &amp; Decker Filter for Double Action Dustbuster Cordless Vac BLDV7210&quot;</value>
+            <value>&quot;Black Print Carbonless 8 1/2\&quot; x 8 1/4\&quot; Rapid Memo Book&quot;</value>
+            <value>&quot;Black Print Carbonless Snap-Off Rapid Letter, 8 1/2\&quot; x 7\&quot;&quot;</value>
+            <value>&quot;BlackBerry Q10&quot;</value>
+            <value>&quot;Blackstonian Pencils&quot;</value>
+            <value>&quot;Blue Parrot B250XT Professional Grade Wireless Bluetooth Headset with&quot;</value>
+            <value>&quot;Blue String-Tie &amp; Button Interoffice Envelopes, 10 x 13&quot;</value>
+            <value>&quot;BlueLounge Milo Smartphone Stand, White/Metallic&quot;</value>
+            <value>&quot;Bose SoundLink Bluetooth Speaker&quot;</value>
+            <value>&quot;BoxOffice By Design Rectangular and Half-Moon Meeting Room Tables&quot;</value>
+            <value>&quot;BPI Conference Tables&quot;</value>
+            <value>&quot;Bravo II Megaboss 12-Amp Hard Body Upright, Replacement Belts, 2 Belts per Pack&quot;</value>
+            <value>&quot;Brites Rubber Bands, 1 1/2 oz. Box&quot;</value>
+            <value>&quot;Brown Kraft Recycled Envelopes&quot;</value>
+            <value>&quot;Bush Westfield Collection Bookcases, Dark Cherry Finish, Fully Assembled&quot;</value>
+            <value>&quot;Bush Westfield Collection Bookcases, Fully Assembled&quot;</value>
+            <value>&quot;Cameo Buff Policy Envelopes&quot;</value>
+            <value>&quot;Canvas Sectional Post Binders&quot;</value>
+            <value>&quot;Career Cubicle Clock, 8 1/4\&quot;, Black&quot;</value>
+            <value>&quot;Case Logic 2.4GHz Wireless Keyboard&quot;</value>
+            <value>&quot;Catalog Binders with Expanding Posts&quot;</value>
+            <value>&quot;Cherry 142-key Programmable Keyboard&quot;</value>
+            <value>&quot;Clarity 53712&quot;</value>
+            <value>&quot;Classic Ivory Antique Telephone ZL1810&quot;</value>
+            <value>&quot;Clear Mylar Reinforcing Strips&quot;</value>
+            <value>&quot;Col-Erase Pencils with Erasers&quot;</value>
+            <value>&quot;Color-Coded Legal Exhibit Labels&quot;</value>
+            <value>&quot;Colored Envelopes&quot;</value>
+            <value>&quot;Colored Push Pins&quot;</value>
+            <value>&quot;Coloredge Poster Frame&quot;</value>
+            <value>&quot;Colorific Watercolor Pencils&quot;</value>
+            <value>&quot;Commercial WindTunnel Clean Air Upright Vacuum, Replacement Belts, Filtration Bags&quot;</value>
+            <value>&quot;Compact Automatic Electric Letter Opener&quot;</value>
+            <value>&quot;Companion Letter/Legal File, Black&quot;</value>
+            <value>&quot;Computer Printout Index Tabs&quot;</value>
+            <value>&quot;Computer Printout Paper with Letter-Trim Fine Perforations&quot;</value>
+            <value>&quot;Computer Printout Paper with Letter-Trim Perforations&quot;</value>
+            <value>&quot;Computer Room Manger, 14\&quot;&quot;</value>
+            <value>&quot;Conquest 14 Commercial Heavy-Duty Upright Vacuum, Collection System, Accessory Kit&quot;</value>
+            <value>&quot;Contemporary Borderless Frame&quot;</value>
+            <value>&quot;Contemporary Wood/Metal Frame&quot;</value>
+            <value>&quot;Contico 72\&quot;H Heavy-Duty Storage System&quot;</value>
+            <value>&quot;Contract Clock, 14\&quot;, Brown&quot;</value>
+            <value>&quot;Convenience Packs of Business Envelopes&quot;</value>
+            <value>&quot;Crate-A-Files&quot;</value>
+            <value>&quot;Cush Cases Heavy Duty Rugged Cover Case for Samsung Galaxy S5 - Purple&quot;</value>
+            <value>&quot;Cyber Acoustics AC-202b Speech Recognition Stereo Headset&quot;</value>
+            <value>&quot;DataProducts Ampli Magnifier Task Lamp, Black,&quot;</value>
+            <value>&quot;Dell Slim USB Multimedia Keyboard&quot;</value>
+            <value>&quot;Deluxe Chalkboard Eraser Cleaner&quot;</value>
+            <value>&quot;Deluxe Heavy-Duty Vinyl Round Ring Binder&quot;</value>
+            <value>&quot;Deluxe Rollaway Locking File with Drawer&quot;</value>
+            <value>&quot;Design Ebony Sketching Pencil&quot;</value>
+            <value>&quot;Desktop 3-Pocket Hot File&quot;</value>
+            <value>&quot;Dexim XPower Skin Super-Thin Power Case for iPhone 5 - Black&quot;</value>
+            <value>&quot;Digium D40 VoIP phone&quot;</value>
+            <value>&quot;Disposable Triple-Filter Dust Bags&quot;</value>
+            <value>&quot;Document Clip Frames&quot;</value>
+            <value>&quot;Dot Matrix Printer Tape Reel Labels, White, 5000/Box&quot;</value>
+            <value>&quot;Dual Level, Single-Width Filing Carts&quot;</value>
+            <value>&quot;Durable Pressboard Binders&quot;</value>
+            <value>&quot;DYMO CardScan Personal V9 Business Card Scanner&quot;</value>
+            <value>&quot;Eaton Premium Continuous-Feed Paper, 25\% Cotton, Letter Size, White, 1000 Shts/Box&quot;</value>
+            <value>&quot;Eberhard Faber 3 1/2\&quot; Golf Pencils&quot;</value>
+            <value>&quot;Economy \#2 Pencils&quot;</value>
+            <value>&quot;Economy Binders&quot;</value>
+            <value>&quot;Economy Rollaway Files&quot;</value>
+            <value>&quot;EcoTones Memo Sheets&quot;</value>
+            <value>&quot;Elite 5\&quot; Scissors&quot;</value>
+            <value>&quot;Embossed Ink Jet Note Cards&quot;</value>
+            <value>&quot;Faber Castell Col-Erase Pencils&quot;</value>
+            <value>&quot;Fashion Color Clasp Envelopes&quot;</value>
+            <value>&quot;File Shuttle I and Handi-File&quot;</value>
+            <value>&quot;File Shuttle II and Handi-File, Black&quot;</value>
+            <value>&quot;Filing/Storage Totes and Swivel Casters&quot;</value>
+            <value>&quot;Flat Face Poster Frame&quot;</value>
+            <value>&quot;Flexible Leather- Look Classic Collection Ring Binder&quot;</value>
+            <value>&quot;Floodlight Indoor Halogen Bulbs, 1 Bulb per Pack, 60 Watts&quot;</value>
+            <value>&quot;Fluorescent Highlighters by Dixon&quot;</value>
+            <value>&quot;Fujitsu fi-5015C Sheetfed Scanner&quot;</value>
+            <value>&quot;GE 30522EE2&quot;</value>
+            <value>&quot;Gear Head AU3700S Headset&quot;</value>
+            <value>&quot;Geemarc AmpliPOWER60&quot;</value>
+            <value>&quot;Geographics Note Cards, Blank, White, 8 1/2\&quot; x 11\&quot;&quot;</value>
+            <value>&quot;Google Nexus 5&quot;</value>
+            <value>&quot;Great White Multi-Use Recycled Paper (20Lb. and 84 Bright)&quot;</value>
+            <value>&quot;Green Bar Computer Printout Paper&quot;</value>
+            <value>&quot;Green Canvas Binder for 8-1/2\&quot; x 14\&quot; Sheets&quot;</value>
+            <value>&quot;Grip Seal Envelopes&quot;</value>
+            <value>&quot;GuestStacker Chair with Chrome Finish Legs&quot;</value>
+            <value>&quot;Hand-Finished Solid Wood Document Frame&quot;</value>
+            <value>&quot;Hanging Personal Folder File&quot;</value>
+            <value>&quot;Harbour Creations 67200 Series Stacking Chairs&quot;</value>
+            <value>&quot;Harbour Creations Steel Folding Chair&quot;</value>
+            <value>&quot;Heavy-Duty E-Z-D Binders&quot;</value>
+            <value>&quot;High Speed Automatic Electric Letter Opener&quot;</value>
+            <value>&quot;High-Back Leather Manager&apos;s Chair&quot;</value>
+            <value>&quot;Holmes Harmony HEPA Air Purifier for 17 x 20 Room&quot;</value>
+            <value>&quot;Home/Office Personal File Carts&quot;</value>
+            <value>&quot;Hot File 7-Pocket, Floor Stand&quot;</value>
+            <value>&quot;Hypercom P1300 Pinpad&quot;</value>
+            <value>&quot;I Need&apos;s 3d Hello Kitty Hybrid Silicone Case Cover for HTC One X 4g with 3d Hello Kitty Stylus Pen Green/pink&quot;</value>
+            <value>&quot;I.R.I.S IRISCard Anywhere 5 Card Scanner&quot;</value>
+            <value>&quot;i.Sound Portable Power - 8000 mAh&quot;</value>
+            <value>&quot;IBM Multi-Purpose Copy Paper, 8 1/2 x 11\&quot;, Case&quot;</value>
+            <value>&quot;Ideal Clamps&quot;</value>
+            <value>&quot;iHome FM Clock Radio with Lightning Dock&quot;</value>
+            <value>&quot;iKross Bluetooth Portable Keyboard + Cell Phone Stand Holder + Brush for Apple iPhone 5S 5C 5, 4S 4&quot;</value>
+            <value>&quot;Imation 8GB Mini TravelDrive USB 2.0 Flash Drive&quot;</value>
+            <value>&quot;Important Message Pads, 50 4-1/4 x 5-1/2 Forms per Pad&quot;</value>
+            <value>&quot;Ink Jet Note and Greeting Cards, 8-1/2\&quot; x 5-1/2\&quot; Card Size&quot;</value>
+            <value>&quot;Innergie mMini Combo Duo USB Travel Charging Kit&quot;</value>
+            <value>&quot;Insertable Tab Indexes For Data Binders&quot;</value>
+            <value>&quot;Insertable Tab Post Binder Dividers&quot;</value>
+            <value>&quot;Inter-Office Recycled Envelopes, Brown Kraft, Button-String,10\&quot; x 13\&quot; , 100/Box&quot;</value>
+            <value>&quot;invisibleSHIELD by ZAGG Smudge-Free Screen Protector&quot;</value>
+            <value>&quot;It&apos;s Hot Message Books with Stickers, 2 3/4\&quot; x 5\&quot;&quot;</value>
+            <value>&quot;Jackery Bar Premium Fast-charging Portable Charger&quot;</value>
+            <value>&quot;JBL Micro Wireless Portable Bluetooth Speaker&quot;</value>
+            <value>&quot;Jensen SMPS-640 - speaker phone&quot;</value>
+            <value>&quot;Jet-Pak Recycled Peel &apos;N&apos; Seal Padded Mailers&quot;</value>
+            <value>&quot;Jiffy Padded Mailers with Self-Seal Closure&quot;</value>
+            <value>&quot;JM Magazine Binder&quot;</value>
+            <value>&quot;KLD Oscar II Style Snap-on Ultra Thin Side Flip Synthetic Leather Cover Case for HTC One HTC M7&quot;</value>
+            <value>&quot;Kleencut Forged Office Shears by Acme United Corporation&quot;</value>
+            <value>&quot;Konftel 250 Conference phone - Charcoal black&quot;</value>
+            <value>&quot;Konica Minolta magicolor 1690MF Multifunction Printer&quot;</value>
+            <value>&quot;Laminate Occasional Tables&quot;</value>
+            <value>&quot;Large Capacity Hanging Post Binders&quot;</value>
+            <value>&quot;Laser &amp; Ink Jet Business Envelopes&quot;</value>
+            <value>&quot;Leather Task Chair, Black&quot;</value>
+            <value>&quot;Lenovo 17-Key USB Numeric Keypad&quot;</value>
+            <value>&quot;Letter or Legal Size Expandable Poly String Tie Envelopes&quot;</value>
+            <value>&quot;Letter Size Cart&quot;</value>
+            <value>&quot;Letter Size File&quot;</value>
+            <value>&quot;Letter Slitter&quot;</value>
+            <value>&quot;Letter/Legal File Tote with Clear Snap-On Lid, Black Granite&quot;</value>
+            <value>&quot;Lexmark MX611dhe Monochrome Laser Printer&quot;</value>
+            <value>&quot;LF Elite 3D Dazzle Designer Hard Case Cover, Lf Stylus Pen and Wiper For Apple Iphone 5c Mini Lite&quot;</value>
+            <value>&quot;LG Exalt&quot;</value>
+            <value>&quot;Lifetime Advantage Folding Chairs, 4/Carton&quot;</value>
+            <value>&quot;Lock-Up Easel &apos;Spel-Binder&apos;&quot;</value>
+            <value>&quot;Longer-Life Soft White Bulbs&quot;</value>
+            <value>&quot;Loose Memo Sheets&quot;</value>
+            <value>&quot;Lumber Crayons&quot;</value>
+            <value>&quot;Lunatik TT5L-002 Taktik Strike Impact Protection System for iPhone 5&quot;</value>
+            <value>&quot;Macally Suction Cup Mount&quot;</value>
+            <value>&quot;Magna Visual Magnetic Picture Hangers&quot;</value>
+            <value>&quot;Magnifier Swing Arm Lamp&quot;</value>
+            <value>&quot;Manco Dry-Lighter Erasable Highlighter&quot;</value>
+            <value>&quot;Manila Recycled Extra-Heavyweight Clasp Envelopes, 6\&quot; x 9\&quot;&quot;</value>
+            <value>&quot;Master Big Foot Doorstop, Beige&quot;</value>
+            <value>&quot;Master Giant Foot Doorstop, Safety Yellow&quot;</value>
+            <value>&quot;Mead 1st Gear 2\&quot; Zipper Binder, Asst. Colors&quot;</value>
+            <value>&quot;Mediabridge Sport Armband iPhone 5s&quot;</value>
+            <value>&quot;Memo Book, 100 Message Capacity, 5 3/8” x 11”&quot;</value>
+            <value>&quot;Metal Folding Chairs, Beige, 4/Carton&quot;</value>
+            <value>&quot;Micropad Numeric Keypads&quot;</value>
+            <value>&quot;Mini 13-1/2 Capacity Data Binder Rack, Pearl&quot;</value>
+            <value>&quot;Mobile Personal File Cube&quot;</value>
+            <value>&quot;Model L Table or Wall-Mount Pencil Sharpener&quot;</value>
+            <value>&quot;Mophie Juice Pack Helium for iPhone&quot;</value>
+            <value>&quot;Multi-Use Personal File Cart and Caster Set, Three Stacking Bins&quot;</value>
+            <value>&quot;Multicolor Computer Printout Paper&quot;</value>
+            <value>&quot;Multimedia Mailers&quot;</value>
+            <value>&quot;Neat Ideas Personal Hanging Folder Files, Black&quot;</value>
+            <value>&quot;NeatDesk Desktop Scanner &amp; Digital Filing System&quot;</value>
+            <value>&quot;netTALK DUO VoIP Telephone Service&quot;</value>
+            <value>&quot;Nontoxic Chalk&quot;</value>
+            <value>&quot;OIC \#2 Pencils, Medium Soft&quot;</value>
+            <value>&quot;OIC Binder Clips&quot;</value>
+            <value>&quot;OIC Bulk Pack Metal Binder Clips&quot;</value>
+            <value>&quot;OIC Colored Binder Clips, Assorted Sizes&quot;</value>
+            <value>&quot;Ooma Telo VoIP Home Phone System&quot;</value>
+            <value>&quot;Padded Folding Chairs, Black, 4/Carton&quot;</value>
+            <value>&quot;Park Ridge Embossed Executive Business Envelopes&quot;</value>
+            <value>&quot;Pastel Pink Envelopes&quot;</value>
+            <value>&quot;PayAnywhere Card Reader&quot;</value>
+            <value>&quot;Peel &amp; Stick Add-On Corner Pockets&quot;</value>
+            <value>&quot;Peel-Off China Markers&quot;</value>
+            <value>&quot;Pencil and Crayon Sharpener&quot;</value>
+            <value>&quot;Penpower WorldCard Pro Card Scanner&quot;</value>
+            <value>&quot;Performers Binder/Pad Holder, Black&quot;</value>
+            <value>&quot;Perixx PERIBOARD-512B, Ergonomic Split Keyboard&quot;</value>
+            <value>&quot;Perma STOR-ALL Hanging File Box, 13 1/8\&quot;W x 12 1/4\&quot;D x 10 1/2\&quot;H&quot;</value>
+            <value>&quot;Permanent Self-Adhesive File Folder Labels for Typewriters, 1 1/8 x 3 1/2, White&quot;</value>
+            <value>&quot;Personal Creations Ink Jet Cards and Labels&quot;</value>
+            <value>&quot;Personal File Boxes with Fold-Down Carry Handle&quot;</value>
+            <value>&quot;Personal Filing Tote with Lid, Black/Gray&quot;</value>
+            <value>&quot;Personal Folder Holder, Ebony&quot;</value>
+            <value>&quot;Petty Cash Envelope&quot;</value>
+            <value>&quot;Pizazz Global Quick File&quot;</value>
+            <value>&quot;Plastic Binding Combs&quot;</value>
+            <value>&quot;Plastic Stacking Crates &amp; Casters&quot;</value>
+            <value>&quot;Plymouth Boxed Rubber Bands by Plymouth&quot;</value>
+            <value>&quot;PNY Rapid USB Car Charger - Black&quot;</value>
+            <value>&quot;Portable Personal File Box&quot;</value>
+            <value>&quot;Portfile Personal File Boxes&quot;</value>
+            <value>&quot;Post-it “Important Message” Note Pad, Neon Colors, 50 Sheets/Pad&quot;</value>
+            <value>&quot;PowerGen Dual USB Car Charger&quot;</value>
+            <value>&quot;Premier Automatic Letter Opener&quot;</value>
+            <value>&quot;Premium Transparent Presentation Covers by GBC&quot;</value>
+            <value>&quot;Premium Transparent Presentation Covers, No Pattern/Clear, 8 1/2\&quot; x 11\&quot;&quot;</value>
+            <value>&quot;Premium Writing Pencils, Soft, \#2 by Central Association for the Blind&quot;</value>
+            <value>&quot;Presstex Flexible Ring Binders&quot;</value>
+            <value>&quot;Prestige Round Ring Binders&quot;</value>
+            <value>&quot;Prismacolor Color Pencil Set&quot;</value>
+            <value>&quot;Project Tote Personal File&quot;</value>
+            <value>&quot;PureGear Roll-On Screen Protector&quot;</value>
+            <value>&quot;Quality Park Security Envelopes&quot;</value>
+            <value>&quot;QVS USB Car Charger 2-Port 2.1Amp for iPod/iPhone/iPad/iPad 2/iPad 3&quot;</value>
+            <value>&quot;Recycled Data-Pak for Archival Bound Computer Printouts, 12-1/2 x 12-1/2 x 16&quot;</value>
+            <value>&quot;Recycled Desk Saver Line \&quot;While You Were Out\&quot; Book, 5 1/2\&quot; X 4\&quot;&quot;</value>
+            <value>&quot;Recycled Easel Ring Binders&quot;</value>
+            <value>&quot;Recycled Eldon Regeneration Jumbo File&quot;</value>
+            <value>&quot;Recycled Interoffice Envelopes with Re-Use-A-Seal Closure, 10 x 13&quot;</value>
+            <value>&quot;Recycled Interoffice Envelopes with String and Button Closure, 10 x 13&quot;</value>
+            <value>&quot;Recycled Premium Regency Composition Covers&quot;</value>
+            <value>&quot;Recycled Pressboard Report Cover with Reinforced Top Hinge&quot;</value>
+            <value>&quot;Recycled Steel Personal File for Hanging File Folders&quot;</value>
+            <value>&quot;Recycled Steel Personal File for Standard File Folders&quot;</value>
+            <value>&quot;Redi-Strip \#10 Envelopes, 4 1/8 x 9 1/2&quot;</value>
+            <value>&quot;Regeneration Desk Collection&quot;</value>
+            <value>&quot;Revere Boxed Rubber Bands by Revere&quot;</value>
+            <value>&quot;Ricoh - Ink Collector Unit for GX3000 Series Printers&quot;</value>
+            <value>&quot;Riverleaf Stik-Withit Designer Note Cubes&quot;</value>
+            <value>&quot;Rosewill 107 Normal Keys USB Wired Standard Keyboard&quot;</value>
+            <value>&quot;Round Ring Binders&quot;</value>
+            <value>&quot;Round Specialty Laser Printer Labels&quot;</value>
+            <value>&quot;RSVP Cards &amp; Envelopes, Blank White, 8-1/2\&quot; X 11\&quot;, 24 Cards/25 Envelopes/Set&quot;</value>
+            <value>&quot;Rubber Band Ball&quot;</value>
+            <value>&quot;Rubbermaid ClusterMat Chairmats, Mat Size- 66\&quot; x 60\&quot;, Lip 20\&quot; x 11\&quot; -90 Degree Angle&quot;</value>
+            <value>&quot;Sabrent 4-Port USB 2.0 Hub&quot;</value>
+            <value>&quot;Sanitaire Vibra Groomer IR Commercial Upright Vacuum, Replacement Belts&quot;</value>
+            <value>&quot;Sannysis Cute Owl Design Soft Skin Case Cover for Samsung Galaxy S4&quot;</value>
+            <value>&quot;Satellite Sectional Post Binders&quot;</value>
+            <value>&quot;Security-Tint Envelopes&quot;</value>
+            <value>&quot;Seidio BD2-HK3IPH5-BK DILEX Case and Holster Combo for Apple iPhone 5/5s - Black&quot;</value>
+            <value>&quot;Self-Adhesive Address Labels for Typewriters with Dispenser Box&quot;</value>
+            <value>&quot;Self-Adhesive Removable Labels&quot;</value>
+            <value>&quot;Self-Adhesive Ring Binder Labels&quot;</value>
+            <value>&quot;Sensible Storage WireTech Storage Systems&quot;</value>
+            <value>&quot;Serrated Blade or Curved Handle Hand Letter Openers&quot;</value>
+            <value>&quot;Shocksock Galaxy S4 Armband&quot;</value>
+            <value>&quot;ShoreTel ShorePhone IP 230 VoIP phone&quot;</value>
+            <value>&quot;Sima Universal USB Charger&quot;</value>
+            <value>&quot;SimpliFile Personal File, Black Granite, 15w x 6-15/16d x 11-1/4h&quot;</value>
+            <value>&quot;Situations Contoured Folding Chairs, 4/Set&quot;</value>
+            <value>&quot;SKILCRAFT Telephone Shoulder Rest, 2\&quot; x 6.5\&quot; x 2.5\&quot;, Black&quot;</value>
+            <value>&quot;SlimView Poly Binder, 3/8\&quot;&quot;</value>
+            <value>&quot;SmartStand Mobile Device Holder, Assorted Colors&quot;</value>
+            <value>&quot;Snap-A-Way Black Print Carbonless Ruled Speed Letter, Triplicate&quot;</value>
+            <value>&quot;Snap-A-Way Black Print Carbonless Speed Message, No Reply Area, Duplicate&quot;</value>
+            <value>&quot;Sortfiler Multipurpose Personal File Organizer, Black&quot;</value>
+            <value>&quot;Speck Products Candyshell Flip Case&quot;</value>
+            <value>&quot;Speediset Carbonless Redi-Letter 7\&quot; x 8 1/2\&quot;&quot;</value>
+            <value>&quot;Spigen Samsung Galaxy S5 Case Wallet&quot;</value>
+            <value>&quot;SpineVue Locking Slant-D Ring Binders by Cardinal&quot;</value>
+            <value>&quot;Square Ring Data Binders, Rigid 75 Pt. Covers, 11\&quot; x 14-7/8\&quot;&quot;</value>
+            <value>&quot;Stackable Trays&quot;</value>
+            <value>&quot;Stacking Tray, Side-Loading, Legal, Smoke&quot;</value>
+            <value>&quot;Stacking Trays by OIC&quot;</value>
+            <value>&quot;Staples&quot;</value>
+            <value>&quot;Star Micronics TSP100 TSP143LAN Receipt Printer&quot;</value>
+            <value>&quot;Star Micronics TSP800 TSP847IIU Receipt Printer&quot;</value>
+            <value>&quot;StarTech.com 10/100 VDSL2 Ethernet Extender Kit&quot;</value>
+            <value>&quot;Steel Personal Filing/Posting Tote&quot;</value>
+            <value>&quot;Stiletto Hand Letter Openers&quot;</value>
+            <value>&quot;Stride Job 150 Highlighters, Chisel Tip, Assorted Colors&quot;</value>
+            <value>&quot;Stur-D-Stor Shelving, Vertical 5-Shelf: 72\&quot;H x 36\&quot;W x 18 1/2\&quot;D&quot;</value>
+            <value>&quot;Super Bands, 12/Pack&quot;</value>
+            <value>&quot;Super Decoflex Portable Personal File&quot;</value>
+            <value>&quot;Surelock Post Binders&quot;</value>
+            <value>&quot;Swingline SM12-08 MicroCut Jam Free Shredder&quot;</value>
+            <value>&quot;Telephone Message Books with Fax/Mobile Section, 4 1/4\&quot; x 6\&quot;&quot;</value>
+            <value>&quot;Telephone Message Books with Fax/Mobile Section, 5 1/2\&quot; x 3 3/16\&quot;&quot;</value>
+            <value>&quot;Telescoping Adjustable Floor Lamp&quot;</value>
+            <value>&quot;Tops Green Bar Computer Printout Paper&quot;</value>
+            <value>&quot;Toshiba IPT2010-SD IP Telephone&quot;</value>
+            <value>&quot;Trav-L-File Heavy-Duty Shuttle II, Black&quot;</value>
+            <value>&quot;TRENDnet 56K USB 2.0 Phone, Internet and Fax Modem&quot;</value>
+            <value>&quot;Trimflex Flexible Post Binders&quot;</value>
+            <value>&quot;Tuf-Vin Binders&quot;</value>
+            <value>&quot;Tuff Stuff Recycled Round Ring Binders&quot;</value>
+            <value>&quot;Turquoise Lead Holder with Pocket Clip&quot;</value>
+            <value>&quot;UniKeep View Case Binders&quot;</value>
+            <value>&quot;Unpadded Memo Slips&quot;</value>
+            <value>&quot;V7 USB Numeric Keypad&quot;</value>
+            <value>&quot;VariCap6 Expandable Binder&quot;</value>
+            <value>&quot;Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box&quot;</value>
+            <value>&quot;Vinyl Sectional Post Binders&quot;</value>
+            <value>&quot;Vtech AT&amp;T CL2940 Corded Speakerphone, Black&quot;</value>
+            <value>&quot;Vtech CS6719&quot;</value>
+            <value>&quot;VTech DS6151&quot;</value>
+            <value>&quot;Wausau Papers Astrobrights Colored Envelopes&quot;</value>
+            <value>&quot;Weyerhaeuser First Choice Laser/Copy Paper (20Lb. and 88 Bright)&quot;</value>
+            <value>&quot;While You Were Out Pads, 50 per Pad, 4 x 5 1/4, Green Cycle&quot;</value>
+            <value>&quot;White Business Envelopes with Contemporary Seam, Recycled White Business Envelopes&quot;</value>
+            <value>&quot;White Computer Printout Paper by Universal&quot;</value>
+            <value>&quot;White Dual Perf Computer Printout Paper, 2700 Sheets, 1 Part, Heavyweight, 20 lbs., 14 7/8 x 11&quot;</value>
+            <value>&quot;White Envelopes, White Envelopes with Clear Poly Window&quot;</value>
+            <value>&quot;White GlueTop Scratch Pads&quot;</value>
+            <value>&quot;Wi-Ex zBoost YX540 Cellular Phone Signal Booster&quot;</value>
+            <value>&quot;Wilson Electronics DB Pro Signal Booster&quot;</value>
+            <value>&quot;Wilson SignalBoost 841262 DB PRO Amplifier Kit&quot;</value>
+            <value>&quot;Wireless Extenders zBoost YX545 SOHO Signal Booster&quot;</value>
+            <value>&quot;Woodgrain Magazine Files by Perma&quot;</value>
+            <value>&quot;X-Rack File for Hanging Folders&quot;</value>
+            <value>&quot;Xblue XB-1670-86 X16 Small Office Telephone - Titanium&quot;</value>
+            <value>&quot;Xiaomi Mi3&quot;</value>
+            <value>&quot;Zipper Ring Binder Pockets&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;OtterBox&quot;'>
+            <value>&quot;OtterBox Commuter Series Case - iPhone 5 &amp; 5s&quot;</value>
+            <value>&quot;OtterBox Commuter Series Case - Samsung Galaxy S4&quot;</value>
+            <value>&quot;OtterBox Defender Series Case - iPhone 5c&quot;</value>
+            <value>&quot;OtterBox Defender Series Case - Samsung Galaxy S4&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Panasonic&quot;'>
+            <value>&quot;Panasonic Business Telephones KX-T7736&quot;</value>
+            <value>&quot;Panasonic KP-150 Electric Pencil Sharpener&quot;</value>
+            <value>&quot;Panasonic KP-310 Heavy-Duty Electric Pencil Sharpener&quot;</value>
+            <value>&quot;Panasonic KP-350BK Electric Pencil Sharpener with Auto Stop&quot;</value>
+            <value>&quot;Panasonic KP-380BK Classic Electric Pencil Sharpener&quot;</value>
+            <value>&quot;Panasonic KP-4ABK Battery-Operated Pencil Sharpener&quot;</value>
+            <value>&quot;Panasonic KX - TS880B Telephone&quot;</value>
+            <value>&quot;Panasonic KX MB2000 Monochrome Laser All-in-One Printer&quot;</value>
+            <value>&quot;Panasonic KX MB2030 Monochrome Laser All-in-One Printer&quot;</value>
+            <value>&quot;Panasonic KX MB2061 Multifunction Printer&quot;</value>
+            <value>&quot;Panasonic KX MB3020 Highspeed Multifunction Printer&quot;</value>
+            <value>&quot;Panasonic KX MC6040 Color Laser Multifunction Printer&quot;</value>
+            <value>&quot;Panasonic KX T7731-B Digital phone&quot;</value>
+            <value>&quot;Panasonic KX T7736-B Digital phone&quot;</value>
+            <value>&quot;Panasonic KX TS208W Corded phone&quot;</value>
+            <value>&quot;Panasonic KX TS3282B Corded phone&quot;</value>
+            <value>&quot;Panasonic KX TS3282W Corded phone&quot;</value>
+            <value>&quot;Panasonic KX-TG6512B DECT 6.0 Plus Digital 2-Handset Cordless Phone&quot;</value>
+            <value>&quot;Panasonic KX-TG6844B Expandable Digital Cordless Telephone&quot;</value>
+            <value>&quot;Panasonic KX-TG9471B&quot;</value>
+            <value>&quot;Panasonic KX-TG9541B DECT 6.0 Digital 2-Line Expandable Cordless Phone With Digital Answering System&quot;</value>
+            <value>&quot;Panasonic Kx-TS550&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Peel &amp; Seel&quot;'>
+            <value>&quot;Peel &amp; Seel Envelopes&quot;</value>
+            <value>&quot;Peel &amp; Seel Recycled Catalog Envelopes, Brown&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Plantronics&quot;'>
+            <value>&quot;Plantronics 81402&quot;</value>
+            <value>&quot;Plantronics Audio 478 Stereo USB Headset&quot;</value>
+            <value>&quot;Plantronics Audio 995 Wireless Stereo Headset&quot;</value>
+            <value>&quot;Plantronics Calisto P620-M USB Wireless Speakerphone System&quot;</value>
+            <value>&quot;Plantronics Cordless Phone Headset with In-line Volume - M214C&quot;</value>
+            <value>&quot;Plantronics CS 50-USB - headset - Convertible, Monaural&quot;</value>
+            <value>&quot;Plantronics CS510 - Over-the-Head monaural Wireless Headset System&quot;</value>
+            <value>&quot;Plantronics Encore H101 Dual Earpieces Headset&quot;</value>
+            <value>&quot;Plantronics HL10 Handset Lifter&quot;</value>
+            <value>&quot;Plantronics MX500i Earset&quot;</value>
+            <value>&quot;Plantronics S12 Corded Telephone Headset System&quot;</value>
+            <value>&quot;Plantronics Savi W720 Multi-Device Wireless Headset System&quot;</value>
+            <value>&quot;Plantronics Single Ear Headset&quot;</value>
+            <value>&quot;Plantronics Voyager Pro HD - Bluetooth Headset&quot;</value>
+            <value>&quot;Plantronics Voyager Pro Legend&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Poly&quot;'>
+            <value>&quot;Poly Designer Cover &amp; Back&quot;</value>
+            <value>&quot;Poly String Tie Envelopes&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Polycom&quot;'>
+            <value>&quot;Polycom CX300 Desktop Phone USB VoIP phone&quot;</value>
+            <value>&quot;Polycom CX600 IP Phone VoIP phone&quot;</value>
+            <value>&quot;Polycom SoundPoint IP 450 VoIP phone&quot;</value>
+            <value>&quot;Polycom SoundPoint Pro SE-225 Corded phone&quot;</value>
+            <value>&quot;Polycom SoundStation2 EX Conference phone&quot;</value>
+            <value>&quot;Polycom VoiceStation 500 Conference phone&quot;</value>
+            <value>&quot;Polycom VVX 310 VoIP phone&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Prang&quot;'>
+            <value>&quot;Prang Colored Pencils&quot;</value>
+            <value>&quot;Prang Drawing Pencil Set&quot;</value>
+            <value>&quot;Prang Dustless Chalk Sticks&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Premier&quot;'>
+            <value>&quot;Premier Electric Letter Opener&quot;</value>
+            <value>&quot;Premier Elliptical Ring Binder, Black&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Pressboard&quot;'>
+            <value>&quot;Pressboard Covers with Storage Hooks, 9 1/2\&quot; x 11\&quot;, Light Blue&quot;</value>
+            <value>&quot;Pressboard Data Binder, Crimson, 12\&quot; X 8 1/2\&quot;&quot;</value>
+            <value>&quot;Pressboard Data Binders by Wilson Jones&quot;</value>
+            <value>&quot;Pressboard Hanging Data Binders for Unburst Sheets&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Pyle&quot;'>
+            <value>&quot;Pyle PMP37LED&quot;</value>
+            <value>&quot;Pyle PRT45 Retro Home Telephone&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Quartet&quot;'>
+            <value>&quot;Quartet Alpha White Chalk, 12/Pack&quot;</value>
+            <value>&quot;Quartet Omega Colored Chalk, 12/Pack&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Razer&quot;'>
+            <value>&quot;Razer Kraken 7.1 Surround Sound Over Ear USB Gaming Headset&quot;</value>
+            <value>&quot;Razer Kraken PRO Over Ear PC and Music Headset&quot;</value>
+            <value>&quot;Razer Tiamat Over Ear 7.1 Surround Sound PC Gaming Headset&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;RCA&quot;'>
+            <value>&quot;RCA 25214 2-Line Corded Telephone&quot;</value>
+            <value>&quot;RCA H5401RE1 DECT 6.0 4-Line Cordless Handset With Caller ID/Call Waiting&quot;</value>
+            <value>&quot;RCA ViSYS 25423RE1 Corded phone&quot;</value>
+            <value>&quot;RCA ViSYS 25425RE1 Corded phone&quot;</value>
+            <value>&quot;RCA ViSYS 25825 Wireless digital phone&quot;</value>
+            <value>&quot;RCA Visys Integrated PBX 8-Line Router&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;REDIFORM&quot;'>
+            <value>&quot;REDIFORM Incoming/Outgoing Call Register, 11\&quot; X 8 1/2\&quot;, 100 Messages&quot;</value>
+            <value>&quot;Rediform S.O.S. 1-Up Phone Message Bk, 4-1/4x3-1/16 Bk, 1 Form/Pg, 40 Messages/Bk, 3/Pk&quot;</value>
+            <value>&quot;Rediform S.O.S. Phone Message Books&quot;</value>
+            <value>&quot;Rediform Voice Mail Log Books&quot;</value>
+            <value>&quot;Rediform Wirebound \&quot;Phone Memo\&quot; Message Book, 11 x 5-3/4&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Riverside&quot;'>
+            <value>&quot;Riverside Furniture Oval Coffee Table, Oval End Table, End Table with Drawer&quot;</value>
+            <value>&quot;Riverside Furniture Stanwyck Manor Table Series&quot;</value>
+            <value>&quot;Riverside Palais Royal Lawyers Bookcase, Royale Cherry Finish&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Rogers&quot;'>
+            <value>&quot;Rogers Deluxe File Chest&quot;</value>
+            <value>&quot;Rogers Handheld Barrel Pencil Sharpener&quot;</value>
+            <value>&quot;Rogers Jumbo File, Granite&quot;</value>
+            <value>&quot;Rogers Profile Extra Capacity Storage Tub&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Rush&quot;'>
+            <value>&quot;Rush Hierlooms Collection 1\&quot; Thick Stackable Bookcases&quot;</value>
+            <value>&quot;Rush Hierlooms Collection Rich Wood Bookcases&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;SAFCO&quot;'>
+            <value>&quot;SAFCO Arco Folding Chair&quot;</value>
+            <value>&quot;SAFCO Boltless Steel Shelving&quot;</value>
+            <value>&quot;Safco Chair Connectors, 6/Carton&quot;</value>
+            <value>&quot;Safco Commercial Shelving&quot;</value>
+            <value>&quot;SAFCO Commercial Wire Shelving, 72h&quot;</value>
+            <value>&quot;SAFCO Commercial Wire Shelving, Black&quot;</value>
+            <value>&quot;Safco Contoured Stacking Chairs&quot;</value>
+            <value>&quot;Safco Drafting Table&quot;</value>
+            <value>&quot;SAFCO Folding Chair Trolley&quot;</value>
+            <value>&quot;Safco Industrial Shelving&quot;</value>
+            <value>&quot;Safco Industrial Wire Shelving&quot;</value>
+            <value>&quot;Safco Industrial Wire Shelving System&quot;</value>
+            <value>&quot;SAFCO Mobile Desk Side File, Wire Frame&quot;</value>
+            <value>&quot;SAFCO Optional Arm Kit for Workspace Cribbage Stacking Chair&quot;</value>
+            <value>&quot;SAFCO PlanMaster Boards, 60w x 37-1/2d, White Melamine&quot;</value>
+            <value>&quot;SAFCO PlanMaster Heigh-Adjustable Drafting Table Base, 43w x 30d x 30-37h, Black&quot;</value>
+            <value>&quot;Safco Steel Mobile File Cart&quot;</value>
+            <value>&quot;Safco Value Mate Series Steel Bookcases, Baked Enamel Finish on Steel, Gray&quot;</value>
+            <value>&quot;Safco Value Mate Steel Bookcase, Baked Enamel Finish on Steel, Black&quot;</value>
+            <value>&quot;Safco Wire Cube Shelving System, For Use as 4 or 5 14\&quot; Cubes, Black&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Samsung&quot;'>
+            <value>&quot;Samsung Convoy 3&quot;</value>
+            <value>&quot;Samsung Galaxy Mega 6.3&quot;</value>
+            <value>&quot;Samsung Galaxy Note 2&quot;</value>
+            <value>&quot;Samsung Galaxy Note 3&quot;</value>
+            <value>&quot;Samsung Galaxy S III - 16GB - pebble blue (T-Mobile)&quot;</value>
+            <value>&quot;Samsung Galaxy S4&quot;</value>
+            <value>&quot;Samsung Galaxy S4 Active&quot;</value>
+            <value>&quot;Samsung Galaxy S4 Mini&quot;</value>
+            <value>&quot;Samsung HM1900 Bluetooth Headset&quot;</value>
+            <value>&quot;Samsung Replacement EH64AVFWE Premium Headset&quot;</value>
+            <value>&quot;Samsung Rugby III&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;SanDisk&quot;'>
+            <value>&quot;SanDisk Cruzer 16 GB USB Flash Drive&quot;</value>
+            <value>&quot;SanDisk Cruzer 32 GB USB Flash Drive&quot;</value>
+            <value>&quot;SanDisk Cruzer 4 GB USB Flash Drive&quot;</value>
+            <value>&quot;SanDisk Cruzer 64 GB USB Flash Drive&quot;</value>
+            <value>&quot;SanDisk Cruzer 8 GB USB Flash Drive&quot;</value>
+            <value>&quot;SanDisk Ultra 16 GB MicroSDHC Class 10 Memory Card&quot;</value>
+            <value>&quot;SanDisk Ultra 32 GB MicroSDHC Class 10 Memory Card&quot;</value>
+            <value>&quot;SanDisk Ultra 64 GB MicroSDHC Class 10 Memory Card&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Sanford&quot;'>
+            <value>&quot;Sanford 52201 APSCO Electric Pencil Sharpener&quot;</value>
+            <value>&quot;Sanford Colorific Colored Pencils, 12/Box&quot;</value>
+            <value>&quot;Sanford Colorific Eraseable Coloring Pencils, 12 Count&quot;</value>
+            <value>&quot;Sanford Colorific Scented Colored Pencils, 12/Pack&quot;</value>
+            <value>&quot;Sanford EarthWrite Recycled Pencils, Medium Soft, \#2&quot;</value>
+            <value>&quot;Sanford Liquid Accent Highlighters&quot;</value>
+            <value>&quot;SANFORD Liquid Accent Tank-Style Highlighters&quot;</value>
+            <value>&quot;SANFORD Major Accent Highlighters&quot;</value>
+            <value>&quot;Sanford Pocket Accent Highlighters&quot;</value>
+            <value>&quot;Sanford Prismacolor Professional Thick Lead Art Pencils, 36-Color Set&quot;</value>
+            <value>&quot;Sanford Uni-Blazer View Highlighters, Chisel Tip, Yellow&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Sanyo&quot;'>
+            <value>&quot;Sanyo 2.5 Cubic Foot Mid-Size Office Refrigerators&quot;</value>
+            <value>&quot;Sanyo Counter Height Refrigerator with Crisper, 3.6 Cubic Foot, Stainless Steel/Black&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Sauder&quot;'>
+            <value>&quot;Sauder Barrister Bookcases&quot;</value>
+            <value>&quot;Sauder Camden County Barrister Bookcase, Planked Cherry Finish&quot;</value>
+            <value>&quot;Sauder Camden County Collection Libraries, Planked Cherry Finish&quot;</value>
+            <value>&quot;Sauder Camden County Collection Library&quot;</value>
+            <value>&quot;Sauder Cornerstone Collection Library&quot;</value>
+            <value>&quot;Sauder Facets Collection Library, Sky Alder Finish&quot;</value>
+            <value>&quot;Sauder Facets Collection Locker/File Cabinet, Sky Alder Finish&quot;</value>
+            <value>&quot;Sauder Forest Hills Library with Doors, Woodland Oak Finish&quot;</value>
+            <value>&quot;Sauder Forest Hills Library, Woodland Oak Finish&quot;</value>
+            <value>&quot;Sauder Inglewood Library Bookcases&quot;</value>
+            <value>&quot;Sauder Mission Library with Doors, Fruitwood Finish&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Seth Thomas&quot;'>
+            <value>&quot;Seth Thomas 12\&quot; Clock w/ Goldtone Case&quot;</value>
+            <value>&quot;Seth Thomas 13 1/2\&quot; Wall Clock&quot;</value>
+            <value>&quot;Seth Thomas 14\&quot; Day/Date Wall Clock&quot;</value>
+            <value>&quot;Seth Thomas 14\&quot; Putty-Colored Wall Clock&quot;</value>
+            <value>&quot;Seth Thomas 16\&quot; Steel Case Clock&quot;</value>
+            <value>&quot;Seth Thomas 8 1/2\&quot; Cubicle Clock&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Sharp&quot;'>
+            <value>&quot;Sharp 1540cs Digital Laser Copier&quot;</value>
+            <value>&quot;Sharp AL-1530CS Digital Copier&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Smead&quot;'>
+            <value>&quot;Smead Adjustable Mobile File Trolley with Lockable Top&quot;</value>
+            <value>&quot;Smead Alpha-Z Color-Coded Name Labels First Letter Starter Set&quot;</value>
+            <value>&quot;Smead Alpha-Z Color-Coded Second Alphabetical Labels and Starter Set&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Socket&quot;'>
+            <value>&quot;Socket Bluetooth Cordless Hand Scanner (CHS)&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Sony&quot;'>
+            <value>&quot;Sony 16GB Class 10 Micro SDHC R40 Memory Card&quot;</value>
+            <value>&quot;Sony 32GB Class 10 Micro SDHC R40 Memory Card&quot;</value>
+            <value>&quot;Sony 64GB Class 10 Micro SDHC R40 Memory Card&quot;</value>
+            <value>&quot;Sony 8GB Class 10 Micro SDHC R40 Memory Card&quot;</value>
+            <value>&quot;Sony Micro Vault Click 16 GB USB 2.0 Flash Drive&quot;</value>
+            <value>&quot;Sony Micro Vault Click 4 GB USB 2.0 Flash Drive&quot;</value>
+            <value>&quot;Sony Micro Vault Click 8 GB USB 2.0 Flash Drive&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Southworth&quot;'>
+            <value>&quot;Southworth 100\% Cotton The Best Paper&quot;</value>
+            <value>&quot;Southworth 100\% Résumé Paper, 24lb.&quot;</value>
+            <value>&quot;Southworth 25\% Cotton Antique Laid Paper &amp; Envelopes&quot;</value>
+            <value>&quot;Southworth 25\% Cotton Granite Paper &amp; Envelopes&quot;</value>
+            <value>&quot;Southworth 25\% Cotton Linen-Finish Paper &amp; Envelopes&quot;</value>
+            <value>&quot;Southworth 25\% Cotton Premium Laser Paper and Envelopes&quot;</value>
+            <value>&quot;Southworth Parchment Paper &amp; Envelopes&quot;</value>
+            <value>&quot;Southworth Structures Collection&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Space Solutions&quot;'>
+            <value>&quot;Space Solutions Commercial Steel Shelving&quot;</value>
+            <value>&quot;Space Solutions HD Industrial Steel Shelving.&quot;</value>
+            <value>&quot;Space Solutions Industrial Galvanized Steel Shelving.&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Square&quot;'>
+            <value>&quot;Square Credit Card Reader&quot;</value>
+            <value>&quot;Square Credit Card Reader, 4 1/2\&quot; x 4 1/2\&quot; x 1\&quot;, White&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Standard&quot;'>
+            <value>&quot;Standard Line “While You Were Out” Hardbound Telephone Message Book&quot;</value>
+            <value>&quot;Standard Rollaway File with Lock&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Stanley&quot;'>
+            <value>&quot;Stanley Bostitch Contemporary Electric Pencil Sharpeners&quot;</value>
+            <value>&quot;Stanley Contemporary Battery Pencil Sharpeners&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Sterilite&quot;'>
+            <value>&quot;Sterilite Officeware Hinged File Box&quot;</value>
+            <value>&quot;Sterilite Show Offs Storage Containers&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Stockwell&quot;'>
+            <value>&quot;Stockwell Gold Paper Clips&quot;</value>
+            <value>&quot;Stockwell Push Pins&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Storex&quot;'>
+            <value>&quot;Storex Dura Pro Binders&quot;</value>
+            <value>&quot;Storex DuraTech Recycled Plastic Frosted Binders&quot;</value>
+            <value>&quot;Storex Flexible Poly Binders with Double Pockets&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Strathmore&quot;'>
+            <value>&quot;Strathmore \#10 Envelopes, Ultimate White&quot;</value>
+            <value>&quot;Strathmore Photo Frame Cards&quot;</value>
+            <value>&quot;Strathmore Photo Mount Cards&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Tenex&quot;'>
+            <value>&quot;Tenex \&quot;The Solids\&quot; Textured Chair Mats&quot;</value>
+            <value>&quot;Tenex 46\&quot; x 60\&quot; Computer Anti-Static Chairmat, Rectangular Shaped&quot;</value>
+            <value>&quot;Tenex Antistatic Computer Chair Mats&quot;</value>
+            <value>&quot;Tenex B1-RE Series Chair Mats for Low Pile Carpets&quot;</value>
+            <value>&quot;Tenex Carpeted, Granite-Look or Clear Contemporary Contour Shape Chair Mats&quot;</value>
+            <value>&quot;Tenex Chairmat w/ Average Lip, 45\&quot; x 53\&quot;&quot;</value>
+            <value>&quot;Tenex Chairmats For Use With Carpeted Floors&quot;</value>
+            <value>&quot;Tenex Chairmats For Use with Hard Floors&quot;</value>
+            <value>&quot;Tenex Contemporary Contur Chairmats for Low and Medium Pile Carpet, Computer, 39\&quot; x 49\&quot;&quot;</value>
+            <value>&quot;Tenex File Box, Personal Filing Tote with Lid, Black&quot;</value>
+            <value>&quot;Tenex Personal Filing Tote With Secure Closure Lid, Black/Frost&quot;</value>
+            <value>&quot;Tenex Personal Project File with Scoop Front Design, Black&quot;</value>
+            <value>&quot;Tenex Personal Self-Stacking Standard File Box, Black/Gray&quot;</value>
+            <value>&quot;Tenex Traditional Chairmats for Hard Floors, Average Lip, 36\&quot; x 48\&quot;&quot;</value>
+            <value>&quot;Tenex Traditional Chairmats for Medium Pile Carpet, Standard Lip, 36\&quot; x 48\&quot;&quot;</value>
+            <value>&quot;Tenex V2T-RE Standard Weight Series Chair Mat, 45\&quot; x 53\&quot;, Lip 25\&quot; x 12\&quot;&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Tennsco&quot;'>
+            <value>&quot;Tennsco 16-Compartment Lockers with Coat Rack&quot;</value>
+            <value>&quot;Tennsco 6- and 18-Compartment Lockers&quot;</value>
+            <value>&quot;Tennsco Commercial Shelving&quot;</value>
+            <value>&quot;Tennsco Double-Tier Lockers&quot;</value>
+            <value>&quot;Tennsco Industrial Shelving&quot;</value>
+            <value>&quot;Tennsco Lockers, Gray&quot;</value>
+            <value>&quot;Tennsco Lockers, Sand&quot;</value>
+            <value>&quot;Tennsco Regal Shelving Units&quot;</value>
+            <value>&quot;Tennsco Single-Tier Lockers&quot;</value>
+            <value>&quot;Tennsco Snap-Together Open Shelving Units, Starter Sets and Add-On Units&quot;</value>
+            <value>&quot;Tennsco Stur-D-Stor Boltless Shelving, 5 Shelves, 24\&quot; Deep, Sand&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Tensor&quot;'>
+            <value>&quot;Tensor \&quot;Hersey Kiss\&quot; Styled Floor Lamp&quot;</value>
+            <value>&quot;Tensor Brushed Steel Torchiere Floor Lamp&quot;</value>
+            <value>&quot;Tensor Computer Mounted Lamp&quot;</value>
+            <value>&quot;Tensor Track Tree Floor Lamp&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Texas Instruments&quot;'>
+            <value>&quot;Texas Instrument TI-15 Fraction Calculator&quot;</value>
+            <value>&quot;Texas Instrument TI-30a Scientific Calculator&quot;</value>
+            <value>&quot;Texas Instrument TI-30X Scientific Calculator&quot;</value>
+            <value>&quot;Texas Instrument TI-30X Solar Scientific Calculator&quot;</value>
+            <value>&quot;Texas Instrument TI-36X Solar Scientific Calculator&quot;</value>
+            <value>&quot;Texas Instruments TI-34 Scientific Calculator&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Things To Do&quot;'>
+            <value>&quot;Things To Do Today Pad&quot;</value>
+            <value>&quot;Things To Do Today Spiral Book&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;TOPS&quot;'>
+            <value>&quot;TOPS \&quot;Important Message\&quot; Pads, Canary, 4-1/4 x 5-1/2, 50 Sheets per Pad&quot;</value>
+            <value>&quot;TOPS 4 x 6 Fluorescent Color Memo Sheets, 500 Sheets per Pack&quot;</value>
+            <value>&quot;TOPS Carbonless Receipt Book, Four 2-3/4 x 7-1/4 Money Receipts per Page&quot;</value>
+            <value>&quot;TOPS Money Receipt Book, Consecutively Numbered in Red,&quot;</value>
+            <value>&quot;TOPS Voice Message Log Book, Flash Format&quot;</value>
+            <value>&quot;Tops White Computer Printout Paper&quot;</value>
+            <value>&quot;Tops Wirebound Message Log Books&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Tripp Lite&quot;'>
+            <value>&quot;Tripp Lite Isotel 6 Outlet Surge Protector with Fax/Modem Protection&quot;</value>
+            <value>&quot;Tripp Lite Isotel 8 Ultra 8 Outlet Metal Surge&quot;</value>
+            <value>&quot;Tripp Lite TLP810NET Broadband Surge for Modem/Fax&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Tyvek&quot;'>
+            <value>&quot;Tyvek  Top-Opening Peel &amp; Seel  Envelopes, Gray&quot;</value>
+            <value>&quot;Tyvek  Top-Opening Peel &amp; Seel Envelopes, Plain White&quot;</value>
+            <value>&quot;Tyvek Interoffice Envelopes, 9 1/2\&quot; x 12 1/2\&quot;, 100/Box&quot;</value>
+            <value>&quot;Tyvek Side-Opening Peel &amp; Seel Expanding Envelopes&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Ultra&quot;'>
+            <value>&quot;Ultra Commercial Grade Dual Valve Door Closer&quot;</value>
+            <value>&quot;Ultra Door Kickplate, 8\&quot;H x 34\&quot;W&quot;</value>
+            <value>&quot;Ultra Door Pull Handle&quot;</value>
+            <value>&quot;Ultra Door Push Plate&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Universal&quot;'>
+            <value>&quot;Permanent Self-Adhesive File Folder Labels for Typewriters by Universal&quot;</value>
+            <value>&quot;Self-Adhesive Address Labels for Typewriters by Universal&quot;</value>
+            <value>&quot;Universal Premium White Copier/Laser Paper (20Lb. and 87 Bright)&quot;</value>
+            <value>&quot;Universal Recycled Hanging Pressboard Report Binders, Letter Size&quot;</value>
+            <value>&quot;Universal Ultra Bright White Copier/Laser Paper, 8 1/2\&quot; x 11\&quot;, Ream&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Verbatim&quot;'>
+            <value>&quot;Verbatim 25 GB 6x Blu-ray Single Layer Recordable Disc, 1/Pack&quot;</value>
+            <value>&quot;Verbatim 25 GB 6x Blu-ray Single Layer Recordable Disc, 10/Pack&quot;</value>
+            <value>&quot;Verbatim 25 GB 6x Blu-ray Single Layer Recordable Disc, 25/Pack&quot;</value>
+            <value>&quot;Verbatim 25 GB 6x Blu-ray Single Layer Recordable Disc, 3/Pack&quot;</value>
+            <value>&quot;Verbatim Slim CD and DVD Storage Cases, 50/Pack&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Wasp&quot;'>
+            <value>&quot;Wasp CCD Handheld Bar Code Reader&quot;</value>
+            <value>&quot;Wasp WCS 3905 CCD Barcode Scanner&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;WD My Passport&quot;'>
+            <value>&quot;WD My Passport Ultra 1TB Portable External Hard Drive&quot;</value>
+            <value>&quot;WD My Passport Ultra 2TB Portable External Hard Drive&quot;</value>
+            <value>&quot;WD My Passport Ultra 500GB Portable External Hard Drive&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Westinghouse&quot;'>
+            <value>&quot;Westinghouse Clip-On Gooseneck Lamps&quot;</value>
+            <value>&quot;Westinghouse Floor Lamp with Metal Mesh Shade, Black&quot;</value>
+            <value>&quot;Westinghouse Mesh Shade Clip-On Gooseneck Lamp, Black&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Wilson Jones&quot;'>
+            <value>&quot;Wilson Jones “Snap” Scratch Pad Binder Tool for Ring Binders&quot;</value>
+            <value>&quot;Wilson Jones 1\&quot; Hanging DublLock Ring Binders&quot;</value>
+            <value>&quot;Wilson Jones 14 Line Acrylic Coated Pressboard Data Binders&quot;</value>
+            <value>&quot;Wilson Jones Active Use Binders&quot;</value>
+            <value>&quot;Wilson Jones Century Plastic Molded Ring Binders&quot;</value>
+            <value>&quot;Wilson Jones Clip &amp; Carry Folder Binder Tool for Ring Binders, Clear&quot;</value>
+            <value>&quot;Wilson Jones Custom Binder Spines &amp; Labels&quot;</value>
+            <value>&quot;Wilson Jones data.warehouse D-Ring Binders with DublLock&quot;</value>
+            <value>&quot;Wilson Jones DublLock D-Ring Binders&quot;</value>
+            <value>&quot;Wilson Jones Easy Flow II Sheet Lifters&quot;</value>
+            <value>&quot;Wilson Jones Elliptical Ring 3 1/2\&quot; Capacity Binders, 800 sheets&quot;</value>
+            <value>&quot;Wilson Jones Four-Pocket Poly Binders&quot;</value>
+            <value>&quot;Wilson Jones Hanging Recycled Pressboard Data Binders&quot;</value>
+            <value>&quot;Wilson Jones Hanging View Binder, White, 1\&quot;&quot;</value>
+            <value>&quot;Wilson Jones Heavy-Duty Casebound Ring Binders with Metal Hinges&quot;</value>
+            <value>&quot;Wilson Jones Impact Binders&quot;</value>
+            <value>&quot;Wilson Jones International Size A4 Ring Binders&quot;</value>
+            <value>&quot;Wilson Jones Leather-Like Binders with DublLock Round Rings&quot;</value>
+            <value>&quot;Wilson Jones Ledger-Size, Piano-Hinge Binder, 2\&quot;, Blue&quot;</value>
+            <value>&quot;Wilson Jones Legal Size Ring Binders&quot;</value>
+            <value>&quot;Wilson Jones Standard D-Ring Binders&quot;</value>
+            <value>&quot;Wilson Jones Suede Grain Vinyl Binders&quot;</value>
+            <value>&quot;Wilson Jones Turn Tabs Binder Tool for Ring Binders&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Wirebound&quot;'>
+            <value>&quot;Wirebound Four 2-3/4 x 5 Forms per Page, 400 Sets per Book&quot;</value>
+            <value>&quot;Wirebound Message Book, 4 per Page&quot;</value>
+            <value>&quot;Wirebound Message Books, 2 7/8\&quot; x 5\&quot;, 3 Forms per Page&quot;</value>
+            <value>&quot;Wirebound Message Books, 5-1/2 x 4 Forms, 2 or 4 Forms per Page&quot;</value>
+            <value>&quot;Wirebound Message Books, Four 2 3/4 x 5 Forms per Page, 200 Sets per Book&quot;</value>
+            <value>&quot;Wirebound Message Books, Four 2 3/4 x 5 White Forms per Page&quot;</value>
+            <value>&quot;Wirebound Message Books, Four 2 3/4\&quot; x 5\&quot; Forms per Page, 600 Sets per Book&quot;</value>
+            <value>&quot;Wirebound Message Books, Two 4 1/4\&quot; x 5\&quot; Forms per Page&quot;</value>
+            <value>&quot;Wirebound Message Forms, Four 2 3/4 x 5 Forms per Page, Pink Paper&quot;</value>
+            <value>&quot;Wirebound Service Call Books, 5 1/2\&quot; x 4\&quot;&quot;</value>
+            <value>&quot;Wirebound Voice Message Log Book&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Xerox&quot;'>
+            <value>&quot;Xerox 188&quot;</value>
+            <value>&quot;Xerox 1880&quot;</value>
+            <value>&quot;Xerox 1881&quot;</value>
+            <value>&quot;Xerox 1882&quot;</value>
+            <value>&quot;Xerox 1883&quot;</value>
+            <value>&quot;Xerox 1884&quot;</value>
+            <value>&quot;Xerox 1885&quot;</value>
+            <value>&quot;Xerox 1886&quot;</value>
+            <value>&quot;Xerox 1887&quot;</value>
+            <value>&quot;Xerox 1888&quot;</value>
+            <value>&quot;Xerox 1889&quot;</value>
+            <value>&quot;Xerox 189&quot;</value>
+            <value>&quot;Xerox 1890&quot;</value>
+            <value>&quot;Xerox 1891&quot;</value>
+            <value>&quot;Xerox 1892&quot;</value>
+            <value>&quot;Xerox 1893&quot;</value>
+            <value>&quot;Xerox 1894&quot;</value>
+            <value>&quot;Xerox 1895&quot;</value>
+            <value>&quot;Xerox 1896&quot;</value>
+            <value>&quot;Xerox 1897&quot;</value>
+            <value>&quot;Xerox 1898&quot;</value>
+            <value>&quot;Xerox 1899&quot;</value>
+            <value>&quot;Xerox 19&quot;</value>
+            <value>&quot;Xerox 190&quot;</value>
+            <value>&quot;Xerox 1900&quot;</value>
+            <value>&quot;Xerox 1901&quot;</value>
+            <value>&quot;Xerox 1902&quot;</value>
+            <value>&quot;Xerox 1903&quot;</value>
+            <value>&quot;Xerox 1904&quot;</value>
+            <value>&quot;Xerox 1905&quot;</value>
+            <value>&quot;Xerox 1906&quot;</value>
+            <value>&quot;Xerox 1907&quot;</value>
+            <value>&quot;Xerox 1908&quot;</value>
+            <value>&quot;Xerox 1909&quot;</value>
+            <value>&quot;Xerox 191&quot;</value>
+            <value>&quot;Xerox 1910&quot;</value>
+            <value>&quot;Xerox 1911&quot;</value>
+            <value>&quot;Xerox 1912&quot;</value>
+            <value>&quot;Xerox 1913&quot;</value>
+            <value>&quot;Xerox 1914&quot;</value>
+            <value>&quot;Xerox 1915&quot;</value>
+            <value>&quot;Xerox 1916&quot;</value>
+            <value>&quot;Xerox 1917&quot;</value>
+            <value>&quot;Xerox 1918&quot;</value>
+            <value>&quot;Xerox 1919&quot;</value>
+            <value>&quot;Xerox 192&quot;</value>
+            <value>&quot;Xerox 1920&quot;</value>
+            <value>&quot;Xerox 1921&quot;</value>
+            <value>&quot;Xerox 1922&quot;</value>
+            <value>&quot;Xerox 1923&quot;</value>
+            <value>&quot;Xerox 1924&quot;</value>
+            <value>&quot;Xerox 1925&quot;</value>
+            <value>&quot;Xerox 1926&quot;</value>
+            <value>&quot;Xerox 1927&quot;</value>
+            <value>&quot;Xerox 1928&quot;</value>
+            <value>&quot;Xerox 1929&quot;</value>
+            <value>&quot;Xerox 193&quot;</value>
+            <value>&quot;Xerox 1930&quot;</value>
+            <value>&quot;Xerox 1931&quot;</value>
+            <value>&quot;Xerox 1932&quot;</value>
+            <value>&quot;Xerox 1933&quot;</value>
+            <value>&quot;Xerox 1934&quot;</value>
+            <value>&quot;Xerox 1935&quot;</value>
+            <value>&quot;Xerox 1936&quot;</value>
+            <value>&quot;Xerox 1937&quot;</value>
+            <value>&quot;Xerox 1938&quot;</value>
+            <value>&quot;Xerox 1939&quot;</value>
+            <value>&quot;Xerox 194&quot;</value>
+            <value>&quot;Xerox 1940&quot;</value>
+            <value>&quot;Xerox 1941&quot;</value>
+            <value>&quot;Xerox 1942&quot;</value>
+            <value>&quot;Xerox 1943&quot;</value>
+            <value>&quot;Xerox 1944&quot;</value>
+            <value>&quot;Xerox 1945&quot;</value>
+            <value>&quot;Xerox 1946&quot;</value>
+            <value>&quot;Xerox 1947&quot;</value>
+            <value>&quot;Xerox 1948&quot;</value>
+            <value>&quot;Xerox 1949&quot;</value>
+            <value>&quot;Xerox 195&quot;</value>
+            <value>&quot;Xerox 1950&quot;</value>
+            <value>&quot;Xerox 1951&quot;</value>
+            <value>&quot;Xerox 1952&quot;</value>
+            <value>&quot;Xerox 1953&quot;</value>
+            <value>&quot;Xerox 1954&quot;</value>
+            <value>&quot;Xerox 1955&quot;</value>
+            <value>&quot;Xerox 1956&quot;</value>
+            <value>&quot;Xerox 1957&quot;</value>
+            <value>&quot;Xerox 1958&quot;</value>
+            <value>&quot;Xerox 1959&quot;</value>
+            <value>&quot;Xerox 196&quot;</value>
+            <value>&quot;Xerox 1960&quot;</value>
+            <value>&quot;Xerox 1961&quot;</value>
+            <value>&quot;Xerox 1962&quot;</value>
+            <value>&quot;Xerox 1963&quot;</value>
+            <value>&quot;Xerox 1964&quot;</value>
+            <value>&quot;Xerox 1965&quot;</value>
+            <value>&quot;Xerox 1966&quot;</value>
+            <value>&quot;Xerox 1967&quot;</value>
+            <value>&quot;Xerox 1968&quot;</value>
+            <value>&quot;Xerox 1969&quot;</value>
+            <value>&quot;Xerox 197&quot;</value>
+            <value>&quot;Xerox 1970&quot;</value>
+            <value>&quot;Xerox 1972&quot;</value>
+            <value>&quot;Xerox 1973&quot;</value>
+            <value>&quot;Xerox 1974&quot;</value>
+            <value>&quot;Xerox 1975&quot;</value>
+            <value>&quot;Xerox 1976&quot;</value>
+            <value>&quot;Xerox 1977&quot;</value>
+            <value>&quot;Xerox 1978&quot;</value>
+            <value>&quot;Xerox 1979&quot;</value>
+            <value>&quot;Xerox 198&quot;</value>
+            <value>&quot;Xerox 1980&quot;</value>
+            <value>&quot;Xerox 1981&quot;</value>
+            <value>&quot;Xerox 1982&quot;</value>
+            <value>&quot;Xerox 1983&quot;</value>
+            <value>&quot;Xerox 1984&quot;</value>
+            <value>&quot;Xerox 1985&quot;</value>
+            <value>&quot;Xerox 1986&quot;</value>
+            <value>&quot;Xerox 1987&quot;</value>
+            <value>&quot;Xerox 1988&quot;</value>
+            <value>&quot;Xerox 1989&quot;</value>
+            <value>&quot;Xerox 199&quot;</value>
+            <value>&quot;Xerox 1990&quot;</value>
+            <value>&quot;Xerox 1991&quot;</value>
+            <value>&quot;Xerox 1992&quot;</value>
+            <value>&quot;Xerox 1993&quot;</value>
+            <value>&quot;Xerox 1994&quot;</value>
+            <value>&quot;Xerox 1995&quot;</value>
+            <value>&quot;Xerox 1996&quot;</value>
+            <value>&quot;Xerox 1997&quot;</value>
+            <value>&quot;Xerox 1998&quot;</value>
+            <value>&quot;Xerox 1999&quot;</value>
+            <value>&quot;Xerox 2&quot;</value>
+            <value>&quot;Xerox 20&quot;</value>
+            <value>&quot;Xerox 200&quot;</value>
+            <value>&quot;Xerox 2000&quot;</value>
+            <value>&quot;Xerox 201&quot;</value>
+            <value>&quot;Xerox 202&quot;</value>
+            <value>&quot;Xerox 203&quot;</value>
+            <value>&quot;Xerox 204&quot;</value>
+            <value>&quot;Xerox 205&quot;</value>
+            <value>&quot;Xerox 206&quot;</value>
+            <value>&quot;Xerox 207&quot;</value>
+            <value>&quot;Xerox 208&quot;</value>
+            <value>&quot;Xerox 209&quot;</value>
+            <value>&quot;Xerox 21&quot;</value>
+            <value>&quot;Xerox 210&quot;</value>
+            <value>&quot;Xerox 211&quot;</value>
+            <value>&quot;Xerox 212&quot;</value>
+            <value>&quot;Xerox 213&quot;</value>
+            <value>&quot;Xerox 214&quot;</value>
+            <value>&quot;Xerox 215&quot;</value>
+            <value>&quot;Xerox 216&quot;</value>
+            <value>&quot;Xerox 217&quot;</value>
+            <value>&quot;Xerox 218&quot;</value>
+            <value>&quot;Xerox 219&quot;</value>
+            <value>&quot;Xerox 22&quot;</value>
+            <value>&quot;Xerox 220&quot;</value>
+            <value>&quot;Xerox 221&quot;</value>
+            <value>&quot;Xerox 222&quot;</value>
+            <value>&quot;Xerox 223&quot;</value>
+            <value>&quot;Xerox 224&quot;</value>
+            <value>&quot;Xerox 225&quot;</value>
+            <value>&quot;Xerox 226&quot;</value>
+            <value>&quot;Xerox 227&quot;</value>
+            <value>&quot;Xerox 228&quot;</value>
+            <value>&quot;Xerox 229&quot;</value>
+            <value>&quot;Xerox 23&quot;</value>
+            <value>&quot;Xerox 230&quot;</value>
+            <value>&quot;Xerox 231&quot;</value>
+            <value>&quot;Xerox 232&quot;</value>
+            <value>&quot;Xerox 4200 Series MultiUse Premium Copy Paper (20Lb. and 84 Bright)&quot;</value>
+            <value>&quot;Xerox Blank Computer Paper&quot;</value>
+            <value>&quot;Xerox Color Copier Paper, 11\&quot; x 17\&quot;, Ream&quot;</value>
+            <value>&quot;Xerox WorkCentre 6505DN Laser Multifunction Printer&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;XtraLife&quot;'>
+            <value>&quot;XtraLife ClearVue Slant-D Ring Binder, White, 3\&quot;&quot;</value>
+            <value>&quot;XtraLife ClearVue Slant-D Ring Binders by Cardinal&quot;</value>
+          </bin>
+          <bin default-name='false' value='&quot;Zebra&quot;'>
+            <value>&quot;Zebra GK420t Direct Thermal/Thermal Transfer Printer&quot;</value>
+            <value>&quot;Zebra GX420t Direct Thermal/Thermal Transfer Printer&quot;</value>
+            <value>&quot;Zebra Zazzle Fluorescent Highlighters&quot;</value>
+            <value>&quot;Zebra ZM400 Thermal Label Printer&quot;</value>
+          </bin>
+        </calculation>
+      </column>
+      <column datatype='string' name='[Product Name]' role='dimension' type='nominal' />
+      <column aggregation='None' caption='Profit (bin)' datatype='integer' name='[Profit (bin)]' role='dimension' type='ordinal'>
+        <calculation class='bin' decimals='0' formula='[Profit]' peg='0' size-parameter='[Parameters].[Parameter 2]' />
+      </column>
+      <column datatype='real' name='[Profit]' role='measure' type='quantitative' />
+      <column datatype='string' hidden='true' name='[Region (People)]' role='dimension' type='nominal' />
+      <column aggregate-role-from='[State/Province]' datatype='string' name='[Region]' role='dimension' type='nominal' />
+      <column datatype='integer' hidden='true' name='[Row ID]' role='dimension' type='ordinal' />
+      <column datatype='string' name='[State/Province]' role='dimension' semantic-role='[State].[Name]' type='nominal' />
+      <column caption='Orders' datatype='table' name='[__tableau_internal_object_id__].[Orders_ECFCA1FB690A41FE803BC071773BA862]' role='measure' type='quantitative' />
+      <column caption='People' datatype='table' name='[__tableau_internal_object_id__].[People_D73023733B004CC1B3CB1ACF62F4A965]' role='measure' type='quantitative' />
+      <column caption='Returns' datatype='table' name='[__tableau_internal_object_id__].[Returns_2AA0FE4D737A4F63970131D0E7480A03]' role='measure' type='quantitative' />
+      <group name='[Top Customers by Profit]' name-style='unqualified' user:ui-builder='filter-group'>
+        <groupfilter count='[Parameters].[Parameter 1]' end='top' function='end' units='records' user:ui-marker='end' user:ui-top-by-field='true'>
+          <groupfilter direction='DESC' expression='SUM([Profit])' function='order' user:ui-marker='order'>
+            <groupfilter function='level-members' level='[Customer Name]' user:ui-enumeration='all' user:ui-marker='enumerate' />
+          </groupfilter>
+        </groupfilter>
+      </group>
+      <drill-paths>
+        <drill-path name='Location'>
+          <field>[Country/Region]</field>
+          <field>[Region]</field>
+          <field>[State/Province]</field>
+          <field>[City]</field>
+          <field>[Postal Code]</field>
+        </drill-path>
+        <drill-path name='Product'>
+          <field>[Category]</field>
+          <field>[Sub-Category]</field>
+          <field>[Product Name (group)]</field>
+          <field>[Product Name]</field>
+        </drill-path>
+      </drill-paths>
+      <layout dim-ordering='alphabetic' measure-ordering='alphabetic' show-structure='true' />
+      <semantic-values>
+        <semantic-value key='[Country].[Name]' value='&quot;United States&quot;' />
+      </semantic-values>
+      <datasource-dependencies datasource='Parameters'>
+        <column caption='Top Customers' datatype='integer' name='[Parameter 1]' param-domain-type='range' role='measure' type='quantitative' value='5'>
+          <calculation class='tableau' formula='5' />
+          <range granularity='5' max='20' min='5' />
+        </column>
+        <column caption='Profit Bin Size' datatype='integer' name='[Parameter 2]' param-domain-type='range' role='measure' type='quantitative' value='200'>
+          <calculation class='tableau' formula='200' />
+          <range granularity='50' max='200' min='50' />
+        </column>
+      </datasource-dependencies>
+      <object-graph>
+        <objects>
+          <object caption='Orders' id='Orders_ECFCA1FB690A41FE803BC071773BA862'>
+            <properties context=''>
+              <relation connection='excel-direct.0ozsbj20cdelf51evvdk71kugqg0' name='Orders' table='[Orders$]' type='table'>
+                <columns gridOrigin='A1:U10195:no:A1:U10195:0' header='yes' outcome='2'>
+                  <column datatype='integer' name='Row ID' ordinal='0' />
+                  <column datatype='string' name='Order ID' ordinal='1' />
+                  <column datatype='date' name='Order Date' ordinal='2' />
+                  <column datatype='date' name='Ship Date' ordinal='3' />
+                  <column datatype='string' name='Ship Mode' ordinal='4' />
+                  <column datatype='string' name='Customer ID' ordinal='5' />
+                  <column datatype='string' name='Customer Name' ordinal='6' />
+                  <column datatype='string' name='Segment' ordinal='7' />
+                  <column datatype='string' name='Country/Region' ordinal='8' />
+                  <column datatype='string' name='City' ordinal='9' />
+                  <column datatype='string' name='State/Province' ordinal='10' />
+                  <column datatype='string' name='Postal Code' ordinal='11' />
+                  <column datatype='string' name='Region' ordinal='12' />
+                  <column datatype='string' name='Product ID' ordinal='13' />
+                  <column datatype='string' name='Category' ordinal='14' />
+                  <column datatype='string' name='Sub-Category' ordinal='15' />
+                  <column datatype='string' name='Product Name' ordinal='16' />
+                  <column datatype='real' name='Sales' ordinal='17' />
+                  <column datatype='integer' name='Quantity' ordinal='18' />
+                  <column datatype='real' name='Discount' ordinal='19' />
+                  <column datatype='real' name='Profit' ordinal='20' />
+                </columns>
+              </relation>
+            </properties>
+          </object>
+          <object caption='People' id='People_D73023733B004CC1B3CB1ACF62F4A965'>
+            <properties context=''>
+              <relation connection='excel-direct.0ozsbj20cdelf51evvdk71kugqg0' name='People' table='[People$]' type='table'>
+                <columns gridOrigin='A1:B5:no:A1:B5:0' header='yes' outcome='6'>
+                  <column datatype='string' name='Regional Manager' ordinal='0' />
+                  <column datatype='string' name='Region' ordinal='1' />
+                </columns>
+              </relation>
+            </properties>
+          </object>
+          <object caption='Returns' id='Returns_2AA0FE4D737A4F63970131D0E7480A03'>
+            <properties context=''>
+              <relation connection='excel-direct.0ozsbj20cdelf51evvdk71kugqg0' name='Returns' table='[Returns$]' type='table'>
+                <columns gridOrigin='A1:B297:no:A1:B297:0' header='yes' outcome='6'>
+                  <column datatype='string' name='Order ID' ordinal='0' />
+                  <column datatype='string' name='Returned' ordinal='1' />
+                </columns>
+              </relation>
+            </properties>
+          </object>
+        </objects>
+        <relationships>
+          <relationship>
+            <expression op='='>
+              <expression op='[Region]' />
+              <expression op='[Region (People)]' />
+            </expression>
+            <first-end-point object-id='Orders_ECFCA1FB690A41FE803BC071773BA862' />
+            <second-end-point object-id='People_D73023733B004CC1B3CB1ACF62F4A965' />
+          </relationship>
+          <relationship>
+            <expression op='='>
+              <expression op='[Order ID]' />
+              <expression op='[Order ID (Returns)]' />
+            </expression>
+            <first-end-point object-id='Orders_ECFCA1FB690A41FE803BC071773BA862' />
+            <second-end-point object-id='Returns_2AA0FE4D737A4F63970131D0E7480A03' />
+          </relationship>
+        </relationships>
+      </object-graph>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='1-total'>
+      <table>
+        <view>
+          <datasources>
+            <datasource name='Sample - Superstore' />
+          </datasources>
+          <datasource-dependencies datasource='Sample - Superstore'>
+            <column datatype='date' name='[Order Date]' role='dimension' type='ordinal' />
+            <column datatype='real' name='[Sales]' role='measure' type='quantitative' />
+            <column-instance column='[Sales]' derivation='Sum' name='[cum:sum:Sales:qk]' pivot='key' type='quantitative'>
+              <table-calc aggregation='Sum' ordering-type='Rows' type='CumTotal' />
+            </column-instance>
+            <column-instance column='[Order Date]' derivation='Month-Trunc' name='[tmn:Order Date:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <aggregation value='true' />
+        </view>
+        <style />
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+          </pane>
+        </panes>
+        <rows>[Sample - Superstore].[cum:sum:Sales:qk]</rows>
+        <cols>[Sample - Superstore].[tmn:Order Date:qk]</cols>
+      </table>
+      <simple-id uuid='{613A3F22-4BAC-43B9-8BEA-1647EE7D9503}' />
+    </worksheet>
+    <worksheet name='2-difference'>
+      <table>
+        <view>
+          <datasources>
+            <datasource name='Sample - Superstore' />
+          </datasources>
+          <datasource-dependencies datasource='Sample - Superstore'>
+            <column datatype='date' name='[Order Date]' role='dimension' type='ordinal' />
+            <column datatype='real' name='[Sales]' role='measure' type='quantitative' />
+            <column-instance column='[Sales]' derivation='Sum' name='[diff:sum:Sales:qk]' pivot='key' type='quantitative'>
+              <table-calc diff-options='Relative' ordering-type='Rows' type='Difference'>
+                <address>
+                  <value>-1</value>
+                </address>
+              </table-calc>
+            </column-instance>
+            <column-instance column='[Order Date]' derivation='Month-Trunc' name='[tmn:Order Date:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='table'>
+            <format attr='show-null-value-warning' value='false' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+          </pane>
+        </panes>
+        <rows>[Sample - Superstore].[diff:sum:Sales:qk]</rows>
+        <cols>[Sample - Superstore].[tmn:Order Date:qk]</cols>
+      </table>
+      <simple-id uuid='{2DD9DD1C-CD78-4F85-8463-0559FDA91335}' />
+    </worksheet>
+    <worksheet name='3-percent-from'>
+      <table>
+        <view>
+          <datasources>
+            <datasource name='Sample - Superstore' />
+          </datasources>
+          <datasource-dependencies datasource='Sample - Superstore'>
+            <column datatype='date' name='[Order Date]' role='dimension' type='ordinal' />
+            <column datatype='real' name='[Sales]' role='measure' type='quantitative' />
+            <column-instance column='[Sales]' derivation='Sum' name='[pcva:sum:Sales:qk]' pivot='key' type='quantitative'>
+              <table-calc diff-options='Relative' ordering-type='Rows' type='PctValue'>
+                <address>
+                  <value>-1</value>
+                </address>
+              </table-calc>
+            </column-instance>
+            <column-instance column='[Order Date]' derivation='Month-Trunc' name='[tmn:Order Date:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='table'>
+            <format attr='show-null-value-warning' value='false' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+          </pane>
+        </panes>
+        <rows>[Sample - Superstore].[pcva:sum:Sales:qk]</rows>
+        <cols>[Sample - Superstore].[tmn:Order Date:qk]</cols>
+      </table>
+      <simple-id uuid='{4D67DF1B-9259-4335-9583-79262767CF14}' />
+    </worksheet>
+    <worksheet name='4-percentile'>
+      <table>
+        <view>
+          <datasources>
+            <datasource name='Sample - Superstore' />
+          </datasources>
+          <datasource-dependencies datasource='Sample - Superstore'>
+            <column datatype='date' name='[Order Date]' role='dimension' type='ordinal' />
+            <column datatype='real' name='[Sales]' role='measure' type='quantitative' />
+            <column-instance column='[Sales]' derivation='Sum' name='[pcrk:sum:Sales:qk]' pivot='key' type='quantitative'>
+              <table-calc ordering-type='Rows' rank-options='Competition,Ascending' type='PctRank' />
+            </column-instance>
+            <column-instance column='[Order Date]' derivation='Month-Trunc' name='[tmn:Order Date:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <aggregation value='true' />
+        </view>
+        <style />
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+          </pane>
+        </panes>
+        <rows>[Sample - Superstore].[pcrk:sum:Sales:qk]</rows>
+        <cols>[Sample - Superstore].[tmn:Order Date:qk]</cols>
+      </table>
+      <simple-id uuid='{84416492-0E2A-43F7-B374-A657F29D227D}' />
+    </worksheet>
+  </worksheets>
+  <windows source-height='30'>
+    <window class='worksheet' name='1-total'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+          <strip size='31'>
+            <card type='title' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[Sample - Superstore].[yr:Order Date:ok]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+      <simple-id uuid='{20BD0E07-5AB7-4A1A-8DF8-8E26844CFE5E}' />
+    </window>
+    <window class='worksheet' name='2-difference'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+          <strip size='31'>
+            <card type='title' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[Sample - Superstore].[yr:Order Date:ok]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+      <simple-id uuid='{4D69102C-6099-47E2-A8C1-9C013D2035C6}' />
+    </window>
+    <window class='worksheet' name='3-percent-from'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+          <strip size='31'>
+            <card type='title' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[Sample - Superstore].[yr:Order Date:ok]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+      <simple-id uuid='{97CCE13B-A6E4-4D05-BD08-A658CD9F642A}' />
+    </window>
+    <window class='worksheet' maximized='true' name='4-percentile'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+          <strip size='31'>
+            <card type='title' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[Sample - Superstore].[yr:Order Date:ok]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+      <simple-id uuid='{0319DC87-CCA9-46FC-91CA-B002CDF400B6}' />
+    </window>
+  </windows>
+  <thumbnails>
+    <thumbnail height='192' name='1-total' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7DAAAOwwHHb6hk
+      AAAUI0lEQVR4nO3d6W8k13nv8W9VdfW+L2x2kxySM9JsWmY0kmwrlmXHWeBrXMAJboLcANmB
+      AEHyIkj+gMB/Q4AESIIAWZAgu5M4ie0siiNHu2eTRpqNw53s5tbdZK9VXVUnL8Ye2CKlkBou
+      06zn82YEsNV9SPSv65zTz3lKU0ophPApfb+fUPIkBsm+B8DzvP1+SiEOzL4HQIhBEtjNg5Ry
+      uHdnilxpjEZtjUI6QaXeJh0xsJRJKh6h33fIZjMHPV4h9tWuAgAG2WyGztYG640WphEgEtDo
+      Oh6a6nH7nZucvPACnufheZ6sA8TA2F0APIvZuWXyQzlwungqwVbHJh3RsZTJ5JnzdJt1svEi
+      SikMwzjgYQuxP7T93gZ1XVcCIAaGLIKFr0kAhK9JAISvSQCEr0kAhK9JAISvSQCEr0kAhK9J
+      AISvSQCEr+2yGlTheR66ruO6Hoah43kKTbv/c+07//Hdf4UYFLusBnWZm7qLa4SwtjYwknl6
+      nQ7JsI6tAkQDCj2aYXQ4D8ipMDE4dhkAUEaIUiFDLRoDu0swFkE3NEKeolFfp5gqPrhSCDEo
+      dhcApdA1Rbtn4/TaDJdKtNo94iGdPiajo6O4rouu61IOLQaKlEMLX5NdIOFrEgDhaxIA4WsS
+      AOFrEgDhaxIA4WsSAOFrEgDhaxIA4WsSAOFre2qOm0ilWa9tMVLKslpvP2iNmIpH6fcdcrns
+      QY9XiH21q1ogpRQbayusbmzxWCnKOxWP4biGp4GmFCvzM5y88ALpaADXdeVcgBgYuwuA2+Pa
+      tVsMFXNs1LcYKmTY2Ox85woQJB0PY/U9SsNDUgwnBopUgwpfk0Ww8DUJgPA1CYDwNQmA8DUJ
+      gPA1CYDwNQmA8DUJgPA1CYDwNQmA8LVdN8d1HIdAwMCy+oSCAWzHI6CDh46ha9IRTgykXfYG
+      Vdy5O8VwJsbs4gqxTB6r953WiMogSJ9gssBIMYdSSprjioGxywBoRCMhbMfDNMByFNFQED2g
+      YXrQaXaIZAIP3vzSIFcMil0GwCMUMImm0gwFoxSyKTbbFtGgRh+T8ImxB/cPkKmQGCRSDi18
+      TXaBhK9JAISvSQCEr0kAhK9JAISvSQCEr0kAhK9JAISvSQCEr0kAhK/tshzaY3p6jvGRAndn
+      qwwPJVmtd0iHdXqYpGMR+o5LPp876PEKsa92XQtUqVbweh22ejZGMEbUlOa4YvDtuj36WqVK
+      vliErkUkaLDVsR60Rz917kms9iZ6vCDVoGKgSDWo8DVZBAtfkwAIX5MACF+TAAhfkwAIX5MA
+      CF+TAAhfkwAIX5MACF/bMQBzMzN846v/hH3YoxHikO1YC6R7XWL58oN0KKWwbZtQKIRlWZgB
+      g57tYBoaHjoB435HuEBgl43mhHhE7PiOXV9f5NblGs++cOk7D1BMT89w5vQkb759hZNjwzTa
+      NtGghqN0NKdHNFuiPJSV3qBioGwLgN1pEYwUGDsTIfi9DzR0luYXcL0+bcshYOiga+hKo+84
+      gCZdocXA2RYAzTDYaqwxe28N50fgfl2nIp1KEU2meHF0HENTNLt9wqaGi0EwYHxfc1xdl7W1
+      GAzbAmCGIpRPTLK20uO7x1o0zaBQLH7f41KJ4Af/VyEGzraP6mZ1Ac0IQiIpe6Ti2Nv2Htd0
+      eOfmDOcmSshSVhx326ZAjmswMT5KsVTc7d0zhBhY264AiVyGtfkpvvXa23IFEMfetgAYwQjx
+      WAysHs5RjEiIQ7TjofheZ4vqRouJsfKen1AOxYtBsuNGz73bt5ifnad/2KMR4pDtGICeZRON
+      RJD2VuK42zEAiViESmVFFsHi2NsxAOXxUxSSUQmAOPa2bfVvVeap9z1WO86DHyrlcfPmbU6N
+      jzJ19y6hdJ5Wq006YmApk1TExNGDjJaGDnn4QjycbQHQAzrvvjvD+ZPlB1cATdPJZNPohk5y
+      qIxybLKJKErTCCuP5YVZxs5ewvM8PM+TqlAxMHbcBm1vNdhobJEfGiYaDqKUw52bd4jE4nSt
+      HsPFIRqtHqmwjo1JPBLGcfokk0nZBhUDZccAvP3qKyxXNsicGOelT1za0xNKAMQg2XERPFTI
+      0CPAsxeeOOzxCHGodgzARn2T8dEywVDosMcjxKHaFgClLIJmHLsv3wOL42/7eQAtRCikETTN
+      oxiPEIdqxymQUgpXOjsIH9gxAJ1uF0MOtgsf2PFdHg2bVKuryNdZ4rjbMQDp3BA4Nu5hj0aI
+      Q7YtAK7d4dadaUojI9IVQhx7297ji++9hxvyuHZjFvk+Vxx320ohHNuivrkFmk4un0PnfjVo
+      pbpCMZ9hZqHKSDHDSr1DOqxjESQRDeE4jtQCiYGzqxtlK6VYWFwkoEEipLizrihENZQGKMVG
+      ZYET558lGw/hui6aJmfJxGDYZesfl7VqhWwux9p6i1w2Q73ZeVANWj4xQbe5hZ4sopSSK4AY
+      GLu6AuyFTIHEIJGNHuFrEgDhaxIA4WsSAOFbPcuRBtDCn9YaHX77b9+UAAj/eefeCn/x8g1+
+      6YvPyDao8A/PU3zlWze5s1Dj1378eZKxkARA+EOra/N7/3iZsaEk/++z5x6cd5EpkDj2ppfr
+      /OE/X+HHPnOW586Uv69URwIgji2lFP91fY5vXp3l13/iUwxlYtseI1MgcSzVm13+8uX30DSN
+      n//CBcLBnT/r93QFqK8sMbdUJZ7J02x1SEd0LGWSDBt4RoTRsjTHFUenttXl27eXuXy7gmFo
+      vPT0OJ88P/KR1cl7CoCnFIam6PTV/ea4OkQ8RXV5kdHTF6U5rjh0jVaPt24uc/VuBTMQ4NLp
+      Er/8fy+SjoeB+zOSj7KnKZBjdZhbWqFczLO+eb8c2iJIPBLCcfokEgmZAolDYfdd/vqb73Nv
+      ucannxzj0ukS6Xh4z2dRZA0gBs7thQ3+5OvX+dzFcT7/7ORDtfCRAIiB0bMd/uo/32N5vckv
+      fvEZijvs6uyVBEAMhFvz6/zx16/zQ5cm+cFLE/vWuE0CIB5p9WaXr752h8pGk1/64jMU0g//
+      qf+9JADikWP3Xa5NVXnl+hxdy+FHnj/J82fLB9KuUwIgHglKKeZXNvmPKzPMVBqcH8/zuWcm
+      KGbj6AfYZUQCII6MUorFtSZv31riyp0KxUyMly6Mc36igBk4nPeQBEAcKrvvMrVU4833F5la
+      qjOcjfPM6WEunCoSjwQPvaeUBEAcKKUUq/U2t+bXuXq3ylqjw+mxHM+dKXFqJPuhNTqHRQIg
+      9pVSivXNDu/PrnFjZo2VWotMIszZ8TxPnypSzMQJGI/OUXQJgHhojusxtVjjtRsLzFQbpOMh
+      zozdf8OXcvFDm89/HHsKgOdY3JtZojScZa3eJhUx7leDxsI4jkMqlZIA+ETPdnh3epXLt5ep
+      1lpMDKf51PlRJstpQubgHDPZUwCWZ+9R7zmEwxGCOngaaEqxtjTPxJPPk4kFpTnuMWb1Xd6d
+      XuXNm8us1ls8PprlhfOjTJRSA3tLrT0FoN3YYHZxETOcomdbD5rjJqNB+p7BaLkoV4BjxnE9
+      bs+v86135llY3eLceJ6XLowzkk9gPEJz+Y9L1gBiG6UUdxdrvPruPLPVTSZLaV586gQTpfQj
+      tYDdDxIA8YDjerzx/iIvX5khl4zy4lNjh/ql1FGQAAhaXZuXr8zw7VvLnJso8IVPnPpYh0sG
+      kQTAhzxP0erabGx1ePP9JW7MrPLi0yd46elxomHzqId3qCQAx5TreWxsdVlY2WR5o8Vqvc3G
+      ZoeO1cd1PaKRINlEhGdPl7j4+PCxm9vvlgTgGLD7LpVai/lqg3vLdeZXN7H7LrlklBPFFKVc
+      nKFMjHwqSiQYwAwY6Prxn97shgRgwN1e2OBPv3Gdcj7BxHCaUyNZRvMJwqHAwO7NH6bB+cpO
+      fB/X8/iX1+/yzvQKv/GTnyKXih71kAaSXAEGUKtr8/tfvcxQOsZPff6JY71NedDkCjBgZip1
+      /vCfr/KlT5/hubNlX2xVHiQJwIBQSvHylRleuT7Pr/7485RziaMe0rEgU6ABYPdd/uCfrhAO
+      GvzMj14gZMrfd7/s6QqglMurr73FqRMlKvXvaY4b0vHMGGPSHHffrTXa/O7fv81LF8b53MUJ
+      mfLssz0FYHVxlq5ts9l1ySajoGlElMfqSpWRx5+S5rj77ObcOn/+7zf4hf9zkVPl9P/a6FXs
+      3Z6nQJ1OB1NXrDY6JMM6NkFiYRPHdYnHYjIF2gdKKb7x1j2+fXuZX/2x58kmI0c9pGNL1gCP
+      GLvv8kdfv4auafzcFy4QlC3OAyW7QI+Q2laX3/nKW7zwxBg/9OykzPcPgQTgiHWtPtemVnj9
+      xgLtns1P/uATnD2RP+ph+YZMgY5Az3a4PlXl9fcW2WxbXDhV5IUnRymkYwfaBlBsJwE4RI7r
+      8ZVXbnL1bpWnTxX57MVxipm4VGYeIQnAIela/Qc3av7Si2d9W3//qJE1wCFY3+zwO3/3Fj/8
+      3Cl+4MlRWdw+QiQAB2x6uc4ffPUyv/DFZzgzljvq4YgPkAAcoDfeW+Rrb07xmz/1wr7f2UTs
+      D1kDHABPKf7xv28zvVznV770nO8Omg8SCcA+qm11uXKnwlu3lhgrJPnpH35KFruPuD0FwO62
+      mJlfpljMs7HZIR3WsTBJxiI4jkM6nfZVAFzX495ynWtTVa5PVUlEQ1x4bJhnz5QopKKy2B0A
+      e+sO7blUF+ZoK5PI9zTHXVmcZfLpT5KJmse+Oa7nKW4vbPD6e0vMr25SzsV5/myZc+P5I7/Z
+      g9i7PQWgsbLI3HqLXDJGvdV90Bw3FQthOxojx7Q5rlKKhdUtvnltlhszq5wfL/CZp+/3ypTO
+      C4NN1gAfYX2zwyvX57h8u0I5n+AHnhzlyckhOYR+jEgAPmCz1ePNm0u8fXMJ0zT45LlRnjtb
+      IhYOHvXQxAGQAHC/OO3qnQqv3lig2bH5xLkyLz51gmQsdKzXM8LHAWg0e1y/t8KVOxVWG22e
+      P1vm00+NMZSOyZveR3wTALvvcnepxtU7FW7NrxOPBHlissClx0uUcgmpyPSpYxuA796u8+rd
+      KtenVmi0epwZy3HhsSJnx/MEA4Z80ovjFQDH9bizsMG3by8ztVgjGjZ57kyZi48Pk01G5LCJ
+      2OZYBKDT6/Nn//Yu05U6Z8ZyXHx8+P6tfQxdPuXFRxroACileOP9Rf7hv2/zE589z6XTJZnL
+      iz15qAB0mg1sTKIhE8/zCIfDhxaA2laXP/raNaJhk5/90aeJRWSfXuzdQxSvKFY36nieYq6+
+      QWnyDOFweP9G9iFcz+PlyzP81/U5/v/nn+SJyYJMc8TH9lDVW67dw8YknU7R7XaB5EMPSCnF
+      zbl1as0uPcuhZzt0rD5W36Vn9Zlb2eT8RIHf+vnPEpQmseIhPdQUSCkPhcZ3P381TXvoKZDn
+      Kf798jSO6xEJBggHA4RDJuGgQThokkmESck3tGKf7Osi+IONcT3PQ/+Qakml1Ie+iT/Ozw7z
+      teT1js/r7WsB+wd/AU3TPvSX2m+H+Vryesfn9fZ9G1SIQTIwR5jmp28RiBW4d/cW5x6fxIxl
+      cLptdENR29jCiEYYLw+zMDtNq2dhdSyyQ0NsrlfJl8ewLMXkieE9v26lWiGTzgAOy0sbjI6N
+      gAZrlQUazS6u0yOZLtBsbJAZGsbq2ZyaPLGr516Zm6Ktm+iEMTWHTC5HQNdobtUJRpNs1jbQ
+      jACO3SUUTRE2PPRglL7dIxGPcu/WLbxgFNu2KBULVFZqDMVDhIfL5GIfcddIp8Ub1+fIm13M
+      oRMEFGSTEay+S7vbYXO9xvjjZ3A6DabnK0TDBp4RJqq7WJ6Oslskio9Rzsf3/vdcmieTL7K+
+      XCVWKBAzDXTNY+rOTfpaHNvuMVrOU1mpU8hE2ep6nDt9alfP/cYbrzNcGiEdD6ObYUKRKE63
+      TbPnYGLT63skYjr3Fro8cabMeq2J8eUvf/nLe/4tjkCn16e1voQeSeP2mlSqa2imTrfdIxI0
+      0D2FmUpitdoUcikMM4ptWSTzRcpDWXpdi0Rib61JlFLU63W2mls0GnUMDJaXFkgXivS7bfK5
+      HJoZpG/ZxFNZRktFrF6XRGJ39++yuhaW1aRWaxAKmqys12l12yzOzGJZNlpARzkelmvgWW1m
+      F+ZwLYt+IEw6GsImQCSgE42GUHqAQqFAMhLBDRhEzI/oROFZ1BptPNel73pUFhdxlMK1emSH
+      Cjh9hW11CZoBEpkcnuth6BAImJRKw1iewUgxu+eNCM9zaFTnqPdcVtZahAIOa437Jwy7rkks
+      qBENhyEQIF8YwnNshoZHdt0i3u02Wa51AJdOu8na4iKVWoNOt4cZCOC4Lk5vk2AkybUr17E9
+      NThTIMuy6Pf7BAIGzUadQCRBLBqmvVnD1cMkY2GMoMnCzDSRZBbP6pJIxFiqrpFOxdlq9jj5
+      2CR72Z+yOk02ex4Bt4sXCBM1A1TXNjg5eYLFuRm0UJKAsognEiwuVcmkUzS2WkyePIlp/O9v
+      jr5lga7oWS6Neo1SaZhur0+vVUcPJYhFg2gKet02XUcjiI2nh0imkmhOj5m5RYrlEdrtDiHd
+      pdHuEw54uEaEE+Xih7+w59Dt2bieQnl9Gs0ehXyGgKaorjco5LKAotNssLHVZSiTwAuEqK9U
+      CMcSNJubDI9MkIyF9vDXhPWVCvFsgfXKIolUHuW2sLwouUSA6bkFhksjNFttQrrLVtfF1Pro
+      oQQjw4VdPb9lWXS7XVS/hx5JoXl9wqZOZaPJcCF7/0HKYWl5jdGRIkvVjcEJgBAHQU50C1+T
+      AAhfG5hdICEexr/+zZ8wfukzfOu1q3zhxQskswUWFpdkDSD84fVXX6O6tER2dBjd9fBq86jM
+      hARA+MPm5iaO4xAIBGjW1kjkCqAO4ECMEIPkfwCG3tRh1PsVQwAAAABJRU5ErkJggg==
+    </thumbnail>
+    <thumbnail height='192' name='2-difference' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7DAAAOwwHHb6hk
+      AAAgAElEQVR4nO2dSZAk13nf/7kvlbV0VfU6M5iFIAcYEAQEUBIYlChqd0gMmrZkhaVwWAc5
+      Qg47dLAP8tG8+GDdZevkUITCobAt27SlEEO0REk0IVMUQGyDwQwwMz1b79W15r49H7Kzp7oq
+      qyqzOqs6azp/p5nu6syXWfnle+9b/h9FCCHIyTmn0GkcJLehnEUlFQPwfT+Nw+TkzJ1UDCAn
+      Z1HJDSDnXJMbQM65JjeAnHNNbgA555rcAHLONbkBpEweE1kscgNImT/6q1swbfesh5ETk8wb
+      ACFkod6qf/vRFgzLOeth5MQk8wagGjb+619+eNbDiIXn++hoFmzHO+uh5MQk8wbQ1S3c3Dw4
+      62HEwrI96KYD280NYFGIbQCEuLh752Pouo6tnX1YlgVd12c5NgCAqttQDXvm50kDy3FhWA5M
+      K98DLAps3A966gEaJg3uYB+UR3D/QQOCWMaVSyJ835/ZOr2tGtBNG66b/Yeqq5nwfALdWozx
+      5iQwAJ8tokRvo91T4Lk2VlfrMHUDFE2DJgQMw8xkgJrpQjUcMAwDiqJmco60UE0XAsfAcnyw
+      bOxbm3OGxP6WeEnBjZdfn+VYIunpFlzPh+P64LnZGFladFQTK0sFWE7+9l8UMr8J7uk2JIGF
+      YWfftdjRLKzXFOhmbgCLQuYNQDMd1MvyQmwsWz0Dy+V8BlgkMm8AuumgWpJgLEB0tadbWKsp
+      UwXCXM+H6+WVdfMm8wagmTaWywXoZvaXQKoRzFbGFLPVd99/hD9/6/4MRpUzjky7KgghMCwX
+      9bIEzcx+LMC0HSwVRVhTRIJVw0ZXt2YwqpxxZHoG8AkBTVNQJB6ake0ZgBACy/ZQLUpTLYEM
+      20Wza8xgZOebvZaKg7Y28veZNgDPI2BoCgWJz/wM4Hg+aJoCzzFwpljLa4aNjpbPAGnz9p0d
+      vHnz8cjfZ9sAfB80RUEWuMzvAWzHA88xYBka3hQGYNouOqo5g5Gdb3q6jcPO6Jk10wZgWC4K
+      EgdF4jOfD2TaLkSeBUPTU80AhuWgq1vw/cVJ/V4EDMtBszs6Zy3TBqCaNmSBgyxy0DI+A2iG
+      DUXkwTL0VA+x6xEURC6PIaRMz7Bx2DVG5qpl2gB6moVyQVyIGaDZM1BWBLAMDXeKdGjX81CQ
+      +Kk8SDmj0Qx77PI5vgEQgof37qPbaeL23U10uz0cHh6mMcaR9HQbisyDY2k4braDRD3dRlkR
+      QdNBwl7SWcD1fFQUMfOGvmhopgNZ5OCPmAFixwFMrYO9gxZcjkVVYPFk+yFEaQlLS/7M0qHb
+      qgFF5ABC4Pl+plOMWz0D9bIE13XBMDRM2wbPxk/ec1wf1aKIVlfH2pI8w5GeL3w/eLE0uzqW
+      FHHo97ENgFA0JJEBSwH7qoGN1Q2YpjnTdGjdclEry+A4Fj4hmU4x7mgWrj9XB8uy4FkGhFCx
+      x+v7BD4hWK4U0DOcTF/nwkFRWK4U0FYtLFeUoV/HvtNSoYSXX3011bFNoqfbKMkCGJrKvHek
+      o5ooFQQAAMvQsF0fhZh/63o+OJbBUlHKg2FpQ4B6efR9zfQmWDdtyCIPiqLAMjScDNfamrYH
+      iQ/eJxzLJIoFOK4HjqFRKgh5OkSKeJ4PhqZQLck4XEQD0EwHisQBAESezXRGaBgHAACeoxMV
+      xjueD46lUc1ngFQxbBeiwKJelnDQjo4FZNoAdMuBJAQGIAlsZmsCfJ/Adr1jAxA4FlYCY3Vc
+      DyzDBIU/Gb3GRUQ1bCgSj2pJQqu3YDMAIeTEW1XkucxWhYVLmLBmWRI46AkS4izHg8AzEHk2
+      V5VLEd10UBA51Eoymr3oYFhmDcDzCVj66fBkMbv5QLbrnahXFngmUUDLtFxIPAuRZ2E5buY3
+      /ItCOAME+VkLFgn2/GADE1LIcDqEYbmQhKcONSnhfkXr2+zzLJPPAimhmw7koyU0wYIZgOv5
+      YJi+GUDgoGU0StrRTBRl4fj/ssDBSGCshv3UgIR8GZQaPSPIJACAghidTpNZA9CPQtghisxn
+      dgZo9UxUi9Lx/5Ou5Q3r6ZuqKPOJ9g85o9FMGwUxMIB6WYp0hWbWAFTDQVF6+lYtiHxmZ4C2
+      ah6/aQCAT2gAuvl0BigXxNwVmhKqbqMohwYQHQvIrAH0dAulwtOHKst7gJ5un8gzkRIagOW4
+      EI68XUtFEe28MCYV+meAaknCYWc4FpBAHNeHaZogxIdtO/B9f6YNsruadXJdLSZzLc6Tjmai
+      3GcASZdAmukcf1EVRUQ3L41MBc0I3KAAUCvJaEQYQHxxXNvEx7c+ACXXQGwLlaUiXNfH1SuX
+      AaTfGqinW1Ak/vi4ishB1e1MNsvoahaKfWMVeQaG7cYeq246kHgWhBCUZAF3nzQzeZ2Lhmra
+      kEUOhBBUi2JkYUz8bFDQkGQBPdtFWRJgWQYoRgJB8PCnPRv0dAsrS4Xj47IMfeQjz15dgGm7
+      4Fn6eGwcQ8O244/VsGyIPAPf91EtiWipRiavc9GwbQ8cQx3dVwnNrj50X2MbAM3QkEuruLZS
+      Q6uro1wswPc9UBQFiqJST4dWDQcVRTw+LscReP7sVKhPg2W7KEjC8dh4jk00Vtcj4DkWDMNA
+      FnmYtpfJ61w4KByrissMA9vxQdP0CZXx2HsAhuVxYWMdDMujXq2A4zgIgohZCZb35wEBAEPT
+      yOKqwPN8eD45EQlmGTqRzKHr+WDZ4KuQhPnEAWzXw92t5szPc5YMPi8LlQqhHYWxQ2iagpfB
+      ZcFgGgQAMAwNN8FYbdcDexT0EzgWjuvNPB1ip9HD73/z3ZmeI03+8C9uJkoxj3rYBW44yp5J
+      AyCEnIiOAgBNUWBoKnMCsqbtHj+8IUlnAM8j4PqOMY+kuL2Wht1DNdM1FiGG5eB/fuejRPXS
+      tuNB4E42VamVZbR6J13MGTWAp1VS/Yg8l7kWpIblnpipABxLo8Tx5JCjemd23gbQVKEadmZd
+      y/189LAB2/ESKedppoPCwPdSLw+7QjNpAD4hJxLhQua1Pk5CSzWxVIwoto45CziuD2ZgYzYP
+      KcjdlobnL1YjfeNZ4+bmPl64XEcvQbVcEATjTvysVpIWwwA8z4/sBybybObeWB3VRLkwbAAc
+      y8SScnG84dZPS4o4NFWnTaOt43PXVrF10JvpedLg3lYLP/zCBnoJlkCa6QwZQOAKPZkOkUkD
+      sF0PAjfsoZVFLnNVYV3NQlkRhn7OMvH2K67nDe0h5pEOYdourm5UsNXItgF0dQs8x6BeltFR
+      488Aqm4PLYFqZRmH3QWYAbSBTNCQLOYDdTQLJTnKABg43uQNpuv6JzbAQJAQN0uhXNvxQEBw
+      aaWMvaY6s/Okwe2HDVx/roaKIqKjxb8n2lEUuJ9aSRoSys2kAai6jZLMD/18VE73WTKYBxQS
+      qFhMngHCcsh+looiWjM0gPbRsq1alNDqmZlOu3j37i4+e3UFRVlIuAdwUByYAYqyAM10Tlxv
+      Jg2gZ5xMhAspSNmbAfoTrvoROCaWi9GwnKHlXlmZ7RKoeaRix3MMKAqJFCzmCSEEm9stXNtY
+      QlHm0dXjv/x6uj3knQuP2U8mDaCrPc3j7kcWsucG1UwbIj9sAHEL43XLHTIgiWcTVZQlZbep
+      Yq0aqKTJIpfZ7jvNroFKUQTH0InrQQwrehnNDHjnYhuAa+m4ffsWdnf38NEn99HpdNFoNGIP
+      KAld3TpWWetHkXj0ErwFZg0hBJbjnQjYhcSVODEGUj6Cv+VgzlAler+lHRvARq2I3YzuA249
+      bODla6tBLo/IwbDiZ9j2jOgZoFaSTnjYYifDMbyIclFBTzNREzls7TyCIC2hWk1fHLenm7i0
+      XBwSwxU4GqpuZUYkN3iTEID4cAfW+zxLQzftiWPVDBsCx5z4HE0BtuPCtp1jtek02T3s4Ysv
+      XYTrulirFvB4r43PXFxK/Tyn5f27u/jFL3z6+N5QFOC6bqSLfBBVtyAO3FcgcDHvt1RUi0cy
+      lnEHY3Ub2G/pWF4q4qCnY2P1AizLmok4rma6KCvikEhsWZGgW25mxGNNx4YkcJHjKYg8bMef
+      OFbL8QLpjoHPySIP1wdkPv1r7RkOKiUJLMvi0koZ37v1JDP3NIQQgscHXVxaKR+LI9A0BYpm
+      htzGURiWi5IigqFPfnZ5qYCWah1fb+yrFssreKW8AgDYiH0Z09EvZ9GPwLGZ6qBi2i7EiHgF
+      EKg7xNExMm0X1ZI09HOBY2A6buQ69jT4A4Jjy5XCSNnAs2TroIflinxCGYRjGLiuH8sAfEIi
+      Z4paScJO35Ivk5tgzRwOYgAAw1DwMiQaNZix2o8kxNMGigrZA0E6hDqD/Y5uOse9zACgXBDQ
+      0azMuUJvbu7jc59aO/GzUkFAR4/nHSMEkan6tbJ8IhaQOQMghARKaREbS5rKlkx6Z0QUGIif
+      0BaIag0bwNKMXKGtnoFKX9yCYWhwLJ25HKubm/t45VOrJ36mSDx6WryXwighrEEB4gwaQGAE
+      g2s3ICiKyVJNQFuNDoIBwXItngFEL/dmlQ7RaOuol092oKkUsqVE4fk+upo1NM6yEk8+3vVG
+      L5OWikFEOZzxMmcAnu+DHjF4mqZAU9RUfXhnQVePToMAcOS2m7wHsF0fHDfsQKgo0kwS4nZb
+      GtZrJzulrNeL2DnMjiv0yX4XG/XikAesKAmx3OCB1ioXuQegKOpEv7AMGgAZOygx5tp6HrR7
+      JsoR8Qog/hIoeFsNf1EVRUiU+xKXvaaKlaWTvWsu1IvYOuimfq5pee/eHm5cWR76edx7opo2
+      CtJo5wGFp+WSmTMA03YhjfF8JBWdmiU93YpMhQYAlh6tSNxPIK0+PAPMKh2i0dGHDGC9pmC3
+      paV+rml57260AcS9J3pEKnQ//dpLmTMAbYQLNCRLVWGjslaBwGMVpy7Ycb3jgvh+ZtUsQzcd
+      FITBLEkZ+xkxANvxYFjOCa3VkLj9otUx3jkguN4wLTpzBtAbkQYRIonZ6aJiWO5IY41TEUYI
+      gTNiwybxXOoznRuhYAEE7kXDcjKxt9rcaeH5i9XICHjcVBjNeCqJGEWt/LQyLJMGEJUJGlIQ
+      Z18uGAffDwJKg6nMIXEMwPV8cAwDOmKzxnMMXNdLVQQguLd85OZQFrhM7K1ubh7glQH/f0hR
+      ChLiJsUs+mXRowhkEgNXaAYNIDoTNKSQkexFx/XAc/TIvBSGoSe+Ud2j5nijEAUWdopJcYcd
+      I7J+GQCWIuplz4Lbj4ICmCgYhh7Z8b0ffYRrOWSqGYAQAsuyQXwPumHC87yZJKX1xrgWgbAq
+      7OxngFFlmyE0NdllO2r5ExI3lhCXvZaK1aXhZtFA4AnaOePySMNyYNrD6eH9DLoxo1D1yTNA
+      86hpXnxtUNfC5qNtlEQara6BgiLB9ylcvfJcqtqgPd3G8xe4kccriBwanWGNx3kTphSMGwfL
+      0LAdFwIVfZsdxzuSUIk+hiLx6GomKiOizUnZbaq4tFyKPN96TcHD3c6Z3tdbDw7w/IUlEDJa
+      UoamjkQTxhxHNWzIwuhnaKkootUN9FfjL4FoFjTxgsANw8DzXMwiK0E1onNjQoICjrOfAbq6
+      NVRyNwjHju8XbDkueHZ0Fm2Qp5OeK3Q3IgYQsl5VsHN4tjNAVPrDIHG+f1W3UIhIpQlh6Kce
+      uvgzgO+hVCqiXKnAsh0oshRY2JE4Lh2RujANhuVAkYSRx1MkAbrlpna+aenpNsqKOHYcLEOD
+      kNH3xnZ8SAI78ve1soyWaqV2rR3VQq0sRx6vVpbR7JnHYsdnwf3tFv7xT3927PWWCyJ6hoOl
+      kjzyM5rlolgY/92ABMup+AUxnIC1tWB3LonRG6k00EwH8pgoXlrKEN/6u3tgGRo/9drVqf6+
+      rZqojNhQhnAsM3YG0CwH8hh3XbkgplatNdh3eRDpaMkQpcg3Dz64t4dyQRw7IwJBD7VJxfGu
+      6008TiA+5kQvgR5ubuLP/vhPMO+FRvglSWOKQCSBg3nKQJhuOvjLdx7g/7x1f+oNdUc1x27W
+      gcCVOc4AgnLI0deaZjpEqGE67uE+iy48hBB8+web+MZ37+A3vvJDE2efQB1i/HdGgOhc6D7q
+      5SArNNIAaN9Aob4xdx9pWMQw7iYEKtGn23x8+web+PKrl/Ezr1/FN793d6pjtFQzMlrZj8Sz
+      Y4W8xr2RgSBk304pIa6jWRNnrOVKAXvN+UWEPd/Hf/n2h/hw8wD/5te+ODKtpJ+wfmEsI2oB
+      +gl1QiOf8UbjCW6/fQfz9rZ7frQmaD/MKWXSDcvB3956gi//0BV86ZXL+OD+/lQ5Nz19fMIV
+      MLnn76SclTQT/xqd4TToQS6tlOemFGc7Hv7DN94CRQH/8h/88FB0ehQVZbxoGCEE/ohagH6q
+      R3GPIQOwdRWcVMel6xcw3seRPp7nR0ZF+2FoGqfx1L35wWP8yIsXIHAsOJbBV77wafyP73yU
+      +DimPblcUeRZmGNKOINI8pjlHs/FKquMw87hUymUUaxVC3PxBHU1C7/zh2/ixuVl/MpPvpSo
+      8L8oj68JCMtUJy2lwqZ5QwZAMQzUTgMP7j3GvAPjhjX5oaJpCqAw1SxgOS7++r2H+KnXn258
+      X7u+jif7XewmzIc3LAdShB5QP5M6xvd3h4yC5xgQkFTSIQ7aGlYq0S7QkNUlBXszTorbOuji
+      d/7wTfz9H7uOn379amKPU7AJHr0H0E1nbCJcSK00Yg/ACRLWL13Deq04s/ZHo+jv6zqOafXz
+      3/zgMV59fu3EORiaxi9/+Qb++3duxT6O5/nwI5LKBplUFzxpEwwExfFppEPsHo6OAYRUSxLa
+      veFOimnxYKeN3/vfb+M3v/o6Xr423t8/iknymKrpTFyaAsEeINIAuruPQDEsoJTmvgnuatbI
+      ApN+Jm0uo3BcD3/x9iZ+9vPXhn734uU6DMvFvZg9s2zXi+Uq5FgG1lgDiK597kfgWBj26ZdB
+      6oQEMSCIW1AUlWr+UQghBH/wrffxm199HZdWylMfRxaDLNlRRqqb9ljXcgjPMbAcb/gZp2ka
+      73/0EC9eXce8g+KTEuFCBD755vBvbj7By9dWIlOtKYrCL/3Ei/hvf3Ur1tsvqi9YFJMU3izH
+      HZtPBAAlWTi1OoTvEziuN1LCpZ9Ja+xp+eD+PpYrMi7Ui6c+FkUNN8ALGaXVGgUhEdWHyspF
+      vP7CJRy21bkvgSalQocUYtbbhjiuh2/93T38whufHvmZK2sVKBKPWw8OJh5vkvcmJChqGT3O
+      ccXbIaU4br8JqIYNWeJjbTY3agp2U3aFEkLwv757B//wSy+mEmWmKWrkiyruMpqiKAg8G73K
+      2dnePt0Ip2RSHneInDAa/Nadbdy4sjy20IaiKPyjL9/AH/31RxOlVzpqvKWaOCGb03aGm2MM
+      Ui1JQ00dktLqGRNjFiEb9VLq9cE/+HgHG/Uilivj3bBx4VgazgjHQM+It4oAgo3w0N0nxALP
+      K7Cd6Aes2zrArTv30G53sH8w+W2ZhGAJFGcG4GPXBLiejz/7/vi3f8hqVcHl1TK+f3tr7Ofa
+      mjnWmEImlTW6nj8xZF8uiGgn6IwSxX5Li/3wbdSVVGMBnu/jj//mY3ztx19ILceoVBjdLEPV
+      xydT9lMvy8O5QBQl4PpL12E4JDJRqKuZqMs8tncfQ5CWUPcDcVzLssAwDLyjrihx/k3TT1OB
+      aZpGp6eBgQfTNE/8fPDfPAN0VB26rh9Hjn3fj/z32x/v4NKyAolDrM//3OvP4Xf/1zv47OUq
+      aAqRnzlsqRA56nico47pujZsxz0+LxAsB8J/m5YD17XhuSd/TggBTdMghEDiKRw0ezAM48TP
+      k/z70V4TtZIM0zQnfr4oMmi0Vei6PtW5Br+rv7uziytrJUgsOT5m1Heb5NmROBqNVg9FgR76
+      jKpbYKngXJOOU5K56GS4m+/+X7z1/UP8k9/6VQxOnCVZwJODHjbWLp4Qx5Xl009vlgvUKkWI
+      E5LtKiUZWwe9ief0fYJvv/MY/+Jrn594zJANUcSP3riIb35/E7/0Ezci182q5eH6am3iMV3C
+      wPej743r+eA5FrI0fmmyWvNhOI8hTfjcOFqqg1c/U411D0RJQs9wIIrSqZWpXc/Hn721id/+
+      1S9CltNLoKyWC7BcRN5X3XZRWyrGeh5Xq8XoPcDy2vN47QsvImoiKVVXcOP6p1CpVLC6upra
+      RpkQMlIlbRBF4mN1DHzv3i4uLhdRm5ACMMgvvPFp6JaDP/jW+5GR2I5mnpAXHAXLjF6rup4f
+      qQYxiMgzp65/aHR01CMEeKOgKQo8O9xRfRq+895D/NDza7HuVRJKhdHtkiYpQvSzVIzYAwAA
+      cXRsPt6ZfoRTQMhRmWEMOfBAHWD8upgQgj/93l388pdvJB4Ly9D49b/3Kt64cQH/7g++g/vb
+      rRO/j+uuZcfUBdsxUnYBQBF56JYz0usxCUJIoLYdwzMSslZTsNc6XRp2V7Pw52/dx9d+/IVT
+      HSeKWknC4UC70xDdHG44Mu440V6g3QYurq/ESClKD5+Q2FOuIk3eBNuuB8f1Ym2qR3H9uTp+
+      65d+FL//zXfx1u2nnjEzRhoEMN5bEVfmm2FoMDQVq+FeFKbtgmOZscX3g2zUitg+5Ub4T/7f
+      x/iFL3x6JrUFpYJwLGwVRdxVSbEgRBtAUWHx6ME+5tk6zfMnJ8KFCBwLe0KfgI46Xl8oLmtV
+      Bb/9a1/Et3+wiW9+75NADsXxxqYxh1BjCuODovp4D4fIc2OT6sYxTsF6FBv14khPkOv5uLfV
+      RGtMykSrZ+DO40O8ceNi4vHGYVKwLq6zicKIkkhZKcH32/HLxVLAdsarLPTDxKgJ2Nxp49p6
+      Om1/FInHv/qVN/D733wX/+lP3wFNIfZsFc4CzMDb3rTG1wL0IwlB6sekApwoDtraxDToQdaq
+      Ct784NHx/wkh2G9p+Mt3HuCjhw0sVwJVBZam8dLVFbz2mTVcqJeO78k3vnsHX3nj07FmuGko
+      iNzIfKCkK8XIb0BXbbz+hVfnGgkOZAbjPRBximIe7LZx/VK0vsw0cCyD3/jF1/DHf3MnUQ9f
+      mo4WyNJGdDGMonwkXz4pmS2K3eawGvQkwkZyqmHjnU928NfvPoTAs/ixly/haz/+wrHhtlUT
+      79/bwze+ewf7LQ1X1yu4cXkZj/c7+PWffyXxWOOiSDz0o36//bEFy3aPWr/Ge3LH1ASbePf7
+      H+DS1YuYV3Vo0Bw73hsuTp+AJwdd/ORrV1IY2VNomsJXv3g9UUUaz9JDDfSA6O6Qo1gqTS+U
+      u99S8crz0UproxB4Fqpp49//5+/ih1+4gH/+1c+jVpaGHqyKIuJLr1zGl165DMt2cXeriXfv
+      7uHXfublmTT3C6EoKugjgZPrfcOenFw4yNCnPdcFJ8rw5rwE6mjx8oCAoz4BNDUyl8b3Cdqq
+      ifoY5YBpoSgqUs58FBzLwPGGd1OTyiH7KReEsVVQ49hraVidYub4t7/+ExAFNrJRSRQCz+Kl
+      qyt46epK4nNNA00f5QP1GWUSF+jxcQZ/0Nvfwptv3cbGxfpcvUBaghwOYHxNgGbakHh2pm+h
+      uHAsHenBiZtQBwT+6mmbZQRFRslr+woSH/vhPwtYmhqSn9cMG0rCax26Qt/1IBUUlEvzLYgZ
+      1Rx7FONqArYbvYnlf/NilLzhpHLIfmolCY0pEuJClY243qZFQpEF9IyTnqBJkjpRDBnA0qUL
+      WBYFPH68Pdd6ADWh9Yr8aDXjB7ttfOpCNho/SyNUlyeVQ/ajSNPVBFhH2aaz8sacJUWZH4oF
+      qIY91PtgEhEzgA9OFlDfWDuRCkEICRKyPBfdngbXdeGMyBidhjgVS/0EfQKiz/9gt43nVqev
+      OkqTUTUBccohQ6YVA5tmTbwolAvD+kCa6SR6hoCITfDWhzeBch2te/ehvvYywvod4lp4vL2H
+      Agf0NAu8yAIUh6uXL6Uijmva7lhB00FkgYNqWJGf32tqWC7LZy6gCxw1vLacobHopgORY2KN
+      kWUoEBDYjpvobR6Id/GZuA9po0g82qpx4tpU3cJqJdn3PmQAGzc+B6nTBS6sI/QdWFoXHd2G
+      Y+qwKeF4953mjf2nP/+5yObYoxjVJ8B2PPiEpN5hfVpG1QTYTry8p+PjHG36k7zRm10DtZhJ
+      cItGlECWZjqJniEgwgBYXsDy8skGZUKhhLrggGVoFAoKHNeFJAqpiuOWYqiC9aNIQZLY4Hmb
+      PQ3lScKoc0TkuUB9YGA8nh9ocMYdZ6Bl6Sa6T4ddA/VKITP3Ik2WihIe7nVPXJt2JImS5Hpj
+      f5JmOVSrVQgCD6Ugg2EYcBw397rhEOVI3HSQx/sdXF2vnMGIohm1Cbbd8d1hBqkWJbR60RmQ
+      o0hSCrloKPKwPIqWRhxgUQjKIoc9I5s7bVzdyIYHCAjy+aPcoKPao46iNkULo4OOjlr52TSA
+      oGl2hBs04dJ3YQ1gVGH8o/0O1jMSAwCCgN2gNhAhZGJ/sEHqlULi4nhVf3a9QFEtU32fJA7e
+      LawBFKRhA/B9gp5uJ85+nCWyMKzvGYoAJykSrxZFHHaSLYEm9TFbZELp+f6UbBJHFnqAhTUA
+      MaKPbtAbKhspECFBLtBJb5kbkR49ibIiJtIHcj0fhJBEs8yiwRwlxR2T/PlfXANg6OFCk61G
+      F2vV0yuPpUnQL/hkMpzjTtYDGkQWOegJmnlohg1J4M6s3dE8oPoEsjzfBzXFi2+xDWAgLfnR
+      XiczKRAhTETSVtggOwkSz8J2/diq2N0J7WafBfr7J4QFRkkNfoENYLi96OZOG8+dQnh1FkR1
+      jHdcHzyX7NZTFBVEle14hapt1UT1GQ2ChZT7aoNVc7oN/8IaAH20iQyXQYQQ7DZVrFaT577P
+      Eoah4Qz0CTMsZ6rNqSTEXwY1OsYz6wINUST+uDY4SXp5PwtrAMBRC6KjYvGwGV3cKqt5wTI0
+      CHCiu7luje+GPopqSYpdGdbs6qjOoCAoS5Tkp7EA1bATp0EAC24A/TUBh53sRqENQmwAAA5r
+      SURBVD1Z5mRZpGk7EKcw1LCrSRwOO0ZsMaxFpdTnGdOmnAFiz8OupePu5iYUZQkdVcfGah22
+      bWF1dbpOH2nQ3yfg4V4Hl9eykwLRD8cyR1KIwcbXsMa3gh1FEA2OZwAt1UQ5ZUW2rFEpCHi4
+      1wEwXRoEENMALK2LruWhWCjCcFwsFwTs7D2BIC5h+Ugcd1ZtdcYh8QxU3YLrutjcbuLFy3W4
+      7rw7m02GoSmYtg2eDTwUqm5B4pnEY60oAu5uNWP9nWk5YGlk8n6kRUHk0O4ZcF0XPd3C6lIh
+      8fXGMgChUELRbeCTno7lahmHXQMX1i/BsuxjcVwmoVsvDRRZgOl4YFkWTw56+LkfeR4sm73I
+      J8cyIKCOx2a7PqolKfFY6+UCOqo18e98n8DxfMiikKmgYNpUihJU0wHLsseZsknvaexPi+U6
+      Xi7XAQBryVQ2ZkbYJ8DzffR0K7O57zxLw3Ge7gE008HFlVLi48giBzWGFyisNnuWH37gSCDr
+      qCrMSKCz1M9Cb4ILR9HRMAswq1FPYaBfcFwV7EEK4lNBqHH0plBHWETCmhBCghywcxUHAJ5m
+      hD7e6+DCcvI36ryQhJM9zcwpBJyAIPYRdJ4cHwzrqCYqxWd7Aww8TYUgiN8bbJCFNoAwJfbx
+      fhdXMuoBAgCRO/nQGglEsYaOFaNH8mHXeOZjACFhhxrL8SDwyfehC20A4QzwYLeNyxlRgYhC
+      GHhovRjdIUdRUYSR/bFCDhM0xFh0wlwrQgioKeoTF9oAgj4BNnYOVawlFICdJwWRg963BHJi
+      NtqOolaS0ZgQDGv2TFQzVBMxS4p9AlnTbAEX2gAkgUVHs0BRyHThB8cysPo2wUnrgfuplSUc
+      TiiNbHb1zHrE0iYUyJo2DLXQBsDQNPZbyfXv540kcCeyOKdJhw6pluSJ6RCaGV90a9EpFwQ0
+      2jqEBLLo/Sy0AdA0BcN2MpcCPUiQsxQsgTzPB4X4DTYGqZdH98cC8HRDmOEZMU2KsoCdpjq1
+      wS+0ATA0BVngcHUjux4g4GThhusnL4fsJ6oYvB/7GdYDjaJcELDbVKcu/l/ou8TQNMqKmOkY
+      AHDSdem4PrhTPJyywEEbEw1Wjfid0p8FKoqIrYPuVDEAIIEB+J6D3b19eJ6DZrsLx3Fg26fr
+      X5sG//pX3sBSxrMe+6VRHNeL1R94FBzLgKao4/qHQXqGnUpzwEVBkXnstbSppTBjL5x8z0dr
+      7xH2m11INEGTBWhGxNXLF0EIOW5DP2+qRTHz4q8UCBzXh+d5sB33yHc9/f0SOAa6YYOJUEJu
+      tDVUi+KZfR/zpiBwOGjrKIjcVNccOx260dEAioLnuLBoAkWS4fa59rKah5MFeJaF6/ugKAqW
+      46Eg8qe6X6EsZNSb/rBroFaSz833USoI8AmBIk13T2OnQ29IBVTKZUiSANt2wfPcsUp0GuK4
+      zzIcy8DzCGiahmkHPYZPc7+qJRmtnhm592l2Ddy4unJuvg+epiHxLBQ5mShuSOwlEEUzKBQC
+      f7soPnstd2YJw1DHyhDTdDIcZLkij5RJPOwaWM54XCRtSgVh9pvgnOlhmaCtKyEkUXvUUdRK
+      0kiZRDVhs8FngYoiopCwN1hIbgBzgKIoMEcNsw1zulqAfqolCQcdLfJ3lu2emyBYyLX1JZQT
+      9pcIOV936gwJBbIM20X5lG7KUkGAGtEdx/N8eP6zrQcaxT/7ymtTJcIB+QwwN1g2MICgeu10
+      S5SCyEcGw1Qz0MY5Lx6gEDqh0vaJv015LDkj4I5mANNyppJE6UfkWbiuPyQOHJQFnp8ocBrk
+      BjAnWCboGG/YLsQUMjUFjhlqvdTumago5yMNOi1yA5gTPMfAcb2pC+IHkUX+WBUv5LCrY7ly
+      vlygpyU3gDkh8Rx0y4V7inLIfqolEc2BpnmNDMtDZpXcAOaEKLAwbSdIV07BS1MryThon3SF
+      NrvGMy+Jnja5AcwJkWNgWC4czwc/ZT1wP9UIody2amApnwESEd8ACMHtmzfRaOzh5kefoNls
+      YXd3d4ZDe7YIyiJduG46S6BaWR6qDAvyjPI0lSTEzgbd2t7B450DeKKMFUXE7v4WBHEJ/hmK
+      4y4SAkdD1a2gTwDxT8ilT0NJ4tA6EoYFAEIAy3HBPOOCuGkTOxv08lUZilICK7DYb6q4uPEc
+      bPtsxXEXCVnkcdg1wTF0KgK+xYII7UgYFgg6pIg8C57L4wBJiP1NMCyLlfV1AEC1ujyzAT2r
+      iDyLnm6dqh64H1nkYFgufJ+ApqkgCe4ZbYo9S/JN8JwQeBaq4aSyAQYA+qhpXqg31FZNFM9R
+      KWRa5AYwJ2SBQ1e3Uk1UC2cBIKgDyLo+UhbJDWBOSAKLVs8An2KqctA9PtAJPezouQFMQW4A
+      c4Kh6UCx7ZSJcP3U+wpjDrt6HgSbgtwA5gTD0OhqFqQUNXuqJek4HaLZM/M0iCnIDWBOhGJY
+      ac4AtbKMxpFQ7rQtgs47uQHMCYahwDJ0qo28q6WnStGGNX3TjfNMbgBzgmMYcCwNWUzvIVXE
+      QB/IOhLbOi96oGmS37E5Efb3SnMGCBtvaIYztTjseSc3gDkiC1yqewCGocHQNBod/dxJoaRF
+      bAMgxMOjBw9gmhb2G03YtgPTHN+rKuckIs+mUg3Wj8Ax2Gp08zToKYn9OvLUfWy3HRBqB57j
+      od3aB8sruHJpI/PitFlB4BjwHJ2qcG1B5LC53cJzq+VzI4ibJrHToQ97BEW6g2ZHAU08LNVK
+      sC37WBf0vGhRnoYvfPYSlopSqvdquVLAzc19vH59I/8OpiB2OvS6XER9eflI6NUHwzDH4rhA
+      rg4dh5/9/LXUj1mvyLjz+BD18vlRhE6T+OK4FHWcax7WtOY3/OypFSUQQqDkm+CpyOfMBada
+      lqBIfB4Em5LcABacoiSgVpJTqzM4b1AkhWJez/PyksgzwvN93HrQwMvXVs56KAtJbgA555p8
+      CZRzrskNIOdckxtAzrkmN4Ccc01uADnnmtwAcs418dOhfQef3LmDTruNj+8/hKqqaLVasxxb
+      Ts7MiRUHsHQVTx5sogsOMi+gwrM41DsQpSquXFqD53l5XlDOQhLLAAjx4eg9fPJwCwInQLdd
+      bKzWYZoGLly8CD8PhOUsKHkkOOdck2+Cc841qcwAhJDjskjf90dWJhFCRu4Vpv3dLM53FucM
+      v4ao34/73WnPOe9rHHfPz+LZSSWJnKKo4wqxsERyXsz7fGdxzkkGMAvOw32lKCqdGSAnZ1FJ
+      rYxo85PbUHUbz33qKizLA+OZ4EQZmmFDZDzolguxwGL7YRfXX3wOB4dtVEsSXPDQWntodA0Q
+      R4NSrsNQO/DAwbMtvPjqqzAbT7CjAusVAQ4lgIMDwyUwDQ0XV+q4/fHHACvDsWysr1ex1+ii
+      JrqQL7yMakK1ELW5iwcNE88/twYA0HptUJyMgiTAtU20VQPNgz08/8INHG4/Qke34NoGykur
+      6LYPUF+5ANOycO3KpQln8vDe2+9CrNRQKwqQS1W0Gg3IEg+Gl9HtNEFRDFzHAi8VoQgUPIqD
+      5zoolYrYvHsbts/Bsm2sr61gb7eB9aoMqrKG1XIh1rXubd2HThSUeA+sXIJrmiAUBVXrYbVa
+      wUcf34eiyDBtH/WKjLZmQaIJCF/Etcsbie7rwc5jdG0aF1ZrAIBOqwFBKkOWOJiWCd2wsLuz
+      h5c+9xKe3L8Lw7BgeS6q9Q0c7O7g4sVV7O638crnbmD8PGjj7b99D0tr65A5oLq8gr39JiSO
+      QCqU0Wg2wTEMXEuDWKyB+frXv/71RFcyAtN2UOSAjx/twLFMeD5Bu7GDw54JnmPgum5wUk7G
+      hx/ehGF60F0L66sr0HUNy8vLIBQF33EgFMqQBQZFmQdbWMKTh/fQ7mkQBAFarw1NcwDiAKBQ
+      KsqwIUDkgILAgfAcVlZWURIZOGwRUkIZnvv376PT7YEQH53WAWyPQudgD6ZlY6/RgOUSlEtF
+      VJcq0DQN9VoVDCfAtmwUl+rYWFuGbepQisUJZyIgYOHaPTx6tIVep4XyykXcv3MTjmUBFAuX
+      uDAsD4xr4v7jJ/AsDQYloV4SodtASWIhyTI8AiyvrqCqSLDAohBTe+j+vbtQdROCIKDb2YOh
+      0/B9EwAFRRbBiUXQ8CFwDFiOxcraOmzTxoWLG2DoZMux+/fuoqsZIJ6LdnMLLhGxd/8BXMpB
+      o2vCdX2UFBmVchmqqqJWKkIqF6BpHlZXl8HTBEv1ZYgCP8EAPFC0BNts4MGDPTQOm7h89Qpu
+      vf8OfF2FBx4OAHAcTLWX3hKofbgPw2NQkVkc9iyItAtWkNHuaVhfqQMACHGxu93AhYureLJ9
+      gPX1FYgCj+3HD+ExMkTahVws4cmTbaxvrKOn6thYX4FlWqAJ8GT7ESr1dRREAYR4IKDAEAeb
+      j3awsbEOVTfB+BY0lwLrWaClEi6s1hNdh2maYCiCbk+FCwZPPvkQlQvPg4eDUkmBanqQGAKp
+      vISDrUfgChVQrgmlqGBrex+VShHdnoar1z6F8c1gCB4/2MTS6kXo7X0ISgXddhuyyILQApSC
+      DFAEtqFBtQgKHIHlUShXlsDCxf3NB1he3YCmaZB4oNm1IPMUHHC4fHE9xpUSmKYFEODxo/tY
+      vXgFAsuBEBcEFIhj4PH2IS5cWIFu+XC0FggrwtJ6KNfXUF8qJb6vFAh6nTYoQcLtd9/Gleuv
+      wLU0lMoKbI8G5Ziori7j0d37KNZXYesqSoqI7b0WymUJukVw9bmLGL8V8rF59x7WL19Dc/cx
+      StVlNFsdiIwPTixCEkWABkytC5tw+R4g53yTxwFyzjW5AeSca3IxmZxnnv/4e7+LL73+GbTI
+      ZdTKNNbrJTS6Ju599E5uADnPPqsFDocOjQc334bw8jr+5DbB1SoPuVzPN8E5zz6ddgOuC7As
+      j63dPVxYDzSUHKObG0DO+eb/A8WbNc4K5qfhAAAAAElFTkSuQmCC
+    </thumbnail>
+    <thumbnail height='192' name='3-percent-from' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7DAAAOwwHHb6hk
+      AAAgAElEQVR4nO2dZ4xk2Xmen5srV3V1de7pMHlnZ2Z3ZncpbuJKDKJMyFSGSVGGBQG2bAMC
+      /Ee0YQGGf9iCIf+QbFiGDAiioGBJFG2ZEkVl5iWXm2bT7Ozknu7pnCpX3Xj8o7pnu6dTVVf1
+      dNXOeYAFtuvWvffUnfPek77zfooQQiCRPKSoB3FRqSlJp3AgAgiC4CAuK5G0nAMRgETSKej1
+      fEl4NhMzS/SmIkzOLtOXiZMreViKgxqKkVvJMTDYRyIeP+jySiQtpS4BKLpFyFCJRCKUS5MU
+      oiF0xSdQTLzSKuVShanJSQaGR0nGwgRBIMcBko6gLgEEToWZmRmCwCekaygElKo+llJBC6cY
+      G+2mWMziuC6aFgNA07QDLbhE0gqUg5gG9X1fCkDSEchBsOShRgpA8lDTcQK4PbsqB9iSltFR
+      AhBC8Ftffg3PlwttktbQUQIIhMB2PRzXP+yiSD4gdJQAhADb8bE9KQBJa+goAQRBrQVwpQAk
+      LaKzBCAEFUd2gSSto6MEIITAdX1sKQBJi6gvGE4ErK7mSMbDTM0uM5BJkC17WDio4QSlfI6u
+      rhShUOhAC+sHAtcPsB3vQO8jeXioSwD4Htl8kUjYQnGqTC16aIFPVdXxsze5O1NmoD/L4Mgx
+      QoZ6YMFw5YoNQKli43lSBJLmqa8FCHwWZqfx7QLFqiAZtyhUPCylhBZOcvZMD/MLiywtrzA6
+      1AccTDCcv6Yp1xfoen3alUh2o65apJphPvz0h3f9TjrT15IC7UbV8YhYhhwDSFpGRw2Cq45H
+      Kh6iXHUPuyiSDwgdJQDH9UlELNkCSFpGRwnAdn2SMYuKLVsASWvoKAFUHY9ExMKRK8GSFtFR
+      AnA9n2QsRNWWU6CS1tBRAqg4HsmoRUUuhElaREcJwHF9UrEQVSkASYvoKAFUHY+QqcsdYZKW
+      0VECsF2fSMggCKQAJK2howTguj4hUyeQLYCkRdRtjXj19jRjgxnmlgtYqsdqycVSXFTTZHm5
+      zOjoAD2ZzIEW1vUDTF2TLYCkZdRtjZiMhQlFE4TyJVxPJRY2UNQwInCIWgrzc7N4gUpvd/LA
+      okFtx8XQFTw/kNGgkpZQtzXi8vIyiqKwvLJCX18vJdvHxEaLdZNO91At5dHDoXtRoAcRDer6
+      gohlomkqiqqiqR3Vg5O0IXVHg549exaA/v5+AO7v7MRisZYWbDtcz8fQNSxDw3F9wpYUgKQ5
+      OqoGuZ6PaWgYuorrSW8gSfN0jACEEPiBQNdUTF3HduUYQNI8HSQAUFAAMHRVOkNIWkLHCCAQ
+      AmWttCFTlxGhkpbQOQIIBKpSawFMQ5PxQJKW0DECEOJ9AYRMHduRLYCkeTpGAIEQKGsCCFuG
+      DImWtISOEYAfCDS1JoDaOoAUgKR5OkYAjltbA4BaF0g6Q0haQd3BcLenF+nvijIxu0J/Ospq
+      2SOEgxKKklvJMzjYSzKZPLCC2q6Pqb8vgJV85cDuJXl4qDsYLmxqrORLDEZNZiseMdVHKBZ+
+      NY9TLXP37l08oZKKRw4kGK5ctTENDc/zMDSFiu3KgDhJ09QdDDc3O0dPb4apfJnerii5ssCk
+      hBZJMTqWoVjIbkqP2upgONcXhC0DXdeJrXkDSXtESbPUHQx34eIFAIbXPrvfCDHV1dXCYm3F
+      dX2stTGAZehU5SBY0gI6ZhBc3SQATa4DSFpC5wjA8bDMWoMVDhnSHU7SEjpGAOuh0AC6qspU
+      qZKW0DECqDoe4bUWQFUVuTFe0hI6RgAbF8JURZHeQJKW0DECqDoeIWNDCyB7QJIW0DECsN33
+      B8GqohBIBUhaQMcIwNkQClEbAyD9gSRN0zkC8AIM/f3iGrqcCZI0T0OxBCLwa/PxhobrC1QC
+      FE3H9zx0Q0dTW+8FtM7GaVCorQbb7ubPJJJGaUgAdydvs7iUJ55O4tgehuKDGjAzU+TY8SEG
+      B4fuzdC0epbG8Xx0Tb13XUNXqTousbDR0vtIHi4aEkBPTy8zM0sIRcUwNHRFA1Xn2FiE7MoK
+      PgYjg70IIVo+SLUdD117f/Br6iqu58vBsKQpGhKAphucOPMoiYhOyQ7Q8VDNCLoKmUwV1Yqg
+      qrW3dKujQf1AEDKNe9e1TAPXCw7EglHy8NCQAAwrTNqq/X/SvO+YcXBdESEErhdg6O9XdtPQ
+      pDWKpGk6YhZICO45QqwTNnUqMlmepEk6QgA1R4jNn1nSG0jSAjpCAGKDJco6IcuQ/qCSpukI
+      AQRCoKr3CcDUqcpNMZIm6QwBBDuNAeSmGElzdIYAdmgBbDkGkDRJRwjA9XxMfXNRLVPDlhbp
+      kibpCAHYjodlbF6yCJlyX7CkeTpDANsEvVmGbAEkzdPQSvDi7BQz81lS3TGKJQ9LcVEMg6XF
+      EuNHh+jt6TmQQlYdj5C5uaiRkEFZtgCSJmlIAH4QEPgeTqATCytreYJdUnGD+blZ3EChP9PV
+      cmvEctXB0NRNVoiqInBcX9ojSpqiIQEkkykKlYC+ZIR8xcfEQQv3kMkotTzBkeiBWCN6viAS
+      MjZZIRp+TWDSHlHSDA3VnnAsyYnjNQfoRGrzsWg02rJC3c/G/cDrqKqCL7dESpqkIwbBG/cD
+      r6Mq0htI0jwdIYDqdi2AouDLPcGSJukIAdjO+8a466iqgnz/S5qlMwTgbhWAoig1j1BPtgKS
+      /dMhAvAwja3j9dpimJwGleyfzhDABmPcjei6iivHAZIm6AgBuH6Arm8tas0bSLYAkv3TGQLw
+      tk6Dwpo1iitbAMn+2VYAE7du89d//hc4D7o0O7CTA5xlylxhkubYdiVYExViPUNb1JFfXWJ6
+      bpnBwV6KlVownBqKU8xlyWS6iUQiB1JI9z5f0HUMXcOREaGSJthWAEtLd7ny6jJPPH1x0xcS
+      Xd3kihWyuQIIH1/R8UtTzM2VqZSLDI4cJWLpLQ+Gcz0fBbEl8C1kqJSrjgyIk+ybLQIoZRdZ
+      yrqYKWPLQeHZaGYEtZpjtexhKWW0cJJTJ3tYWVkml88T76+FRLcqGE4IgecHhC1zizNEJCTz
+      BUuaY0vNiaZ6OHlshEp1fsuXFT3EYF8I6GbovmPpzMHsBRACFNhS+aG2DiC7QJJm2NKxFkKA
+      HsavFNoi1GC3gLewpVOSm2IkTbClBVi6eYXVsotrhGiHCUYhBKq2/WytZei4sgWQNMGWmpUa
+      HKJiw/NPP4a53RkPmECILZ5A64QsnYq0RpE0wRYBFJaWmVuYYXE52yYtAKjb138ilkG5KrtA
+      kv2zRQBdR8Y5NZRhem6RHerdA8XzA1R1+y5QzR5RtgCS/bOlZimKguf5KI5NO1QtZ5tQ6HUs
+      U5fWKJKm2HYC/ezjF0jOLrfFGMD1/E2JMTYSMjRpjyhpii0CqORXee/yO7w3U2DgyOChi6Dq
+      eISt7Re6avmC22GyVtKpbOkCOcUcN+cLPH7uRFuEila3sUVcp5YxXgpAsn+21Kx4Tz9PXNAZ
+      Gx3eMggWIiCXKxCPhqi4Ah0fxbBw7SqhUOhAQhIcb+cxgGwBJM2ypcaqRojx0eFtvzw3NUHW
+      0chlfSqOh66AwGF6usj4eD+DQyNoKi1Nk1q1PUxd3f56QhAErU/JKnl4aKyXo0BlZY6CC7U4
+      CYGqxzh1fIBCPs/03ELLC1h1tlqirKNqKr6s/JImaKjP0j88RiTZQyxsUfUCNHxUPYSqCNKZ
+      XlTdupcneKe5+0Zx/QDL1He8nqqqBAL0HcIlJJLdaEgAiqKSTMQBiN6XFvigQpKrjkcyau14
+      fD0iVApAsh/avtbY7s7rAACmLhNmS/ZP+wtgm9wAGzHkngBJE7S/AFx/x0EwrHWBZAsg2Sdt
+      LwDH9bD26gLJFkCyT9pfAN72pljr1ALiZDyQZH+0vwC2yQ2wkVrCbCkAyf5oewG4/vamWOtY
+      ck+ApAnaXwA7mGKtE5IJsyVN0PYCcFwfYxePobBMmC1pgoaWb1dmppgre8QNQbbsElI8FENn
+      Yb7EsePD9PX2trRw66ZYe3WB7GyppfeVPDw0JADVsrBnljB6uolHFFQlQhB49KQDFuZmcXyF
+      wd50y6wRhRAosKv1oakpVGxX2iNK9kVjaVLDYZKZDH3pGLnyep7gbiwd7HIBPZJoaZ7g2oZ4
+      Zdc4o0jYXJsqlfaIksZpqNZYkThHx9aC4eKbjx2EM7QQAmUnT5Q1Qqb0BpLsn7YeBO9mirVO
+      yNTlxnjJvmlrAQgBe9T/tVkgKQDJ/mhrAQSBQNtjY01tX7DcFSbZH20tAMfzMXdZBIM1AUhn
+      CMk+aWsB2M72+YE3oioKvhSAZJ+0twB2sUVcR1WVlqZjkjxctLUAqnvsBoNaC+D5UgCS/dHW
+      AnC83SNBodYCqApyHCDZF20tgKq9sy3iRgy5LVKyTxqLHxCCmdlZEhFrLUukgxqKk8/m6OvN
+      EI1GW1o42927CwS1bZGu59f1XYlkIw3VmFJuhbnFFfx0kkD4VBWdIDvH0kIZu1pi8Mg4sbDZ
+      smC4qu2ia7sHwwEYmkql6hA2W5OaVfLw0JAAqo6DUyngeRHKjo9FGS2c4vjxDNnsCsVSmWQs
+      DLQmGM7xBbGQuWegm2Xq+OLgzLkkH1waqjHdvQN09w5seyzdnWlJgTZiOx7peGjP75mG3BUm
+      2R9tPQi23fr69ZbMFCPZJ20tAMetbxbIMmSuMMn+aGsBVB1vz3UAqGWMl84Qkv3Q1gLYaz/w
+      OpYhBSDZH20tAMcLMOqwPQ/JFkCyT9pcAHuHQoBMmC3ZP+0tALdOARhyW2QzfOGv3mDxIbWW
+      aWsBeN7upljrhC3pD7pfhBC8cmWaK3eWDrsoh0LbCkAIgePvbou4jmXqVKVD9L4olB08P+Da
+      1PJhF+VQaGgl2LUrrOTLpBMRSraPgYdqRamWi8RiMQzD2PsidSJETZ3KXrviWVsIk+sA+2Ju
+      pciFEwPMLBVqNjR1PO8PEg0JIPBdpiYmKfakCDwfTVEIgrvcnS4xOpJh8MgYhqa0JG/v+jZH
+      39+7YluGRrnq1PVdyWZuzaxweiTNwmqRYtkmEmrdS6wTaKwFcD0U4eH5AZ7rYyg+qhXnzKku
+      FpeXmZ1fZHSoD0VRmk6T6gc+qqrWdR3T0PD81qVmfZiYXMjz0YvjDPdmmV4qcGqk9TFd7Uxj
+      1oixBGfOn8cyNLxAoCBQVB1VgXSmB0UzUBTl3n/NIKh5AtVzHU1VCYL2ar6FEFy/u8LJI92H
+      XZRdmV8pMdgd55HRHq5Pr3B6tOewi/RAaeiVqWk64ZCFqumYhoFhmOha7S2tGybaHjaGjSBE
+      bbtjPaiKQtBmG+OzxSq/+gffplhxDrsoO+J6Pq7vE7J0xgdS3JrJHnaRHjht22cQddgirtOO
+      3kBX7ixRsT3uLuQPuyg7spyr0J2IoCoKfV0xlnJlPP/hMhlrWwHYdS6Cwbo7XHsJ4PLEIj/+
+      3Cmu3W3f6cWphRxHehNA7RkmIhaFsn3IpXqwtK0A9kqOtxFVqXkDtYs/kB8ETM7nePbcCLdn
+      27dbMTGfY6Qvee/vo4NdvDf5cC2Ita0A6vEEWkdRFHRNbZvme265SCJqMdAdYzFbwm/BtPBB
+      cGcuy3h/6t7fp0a6uTm9eoglevC0rQDqDYRbp50SZr97Z5EnTw1g6BqJqEW2UG3o/L9++QbZ
+      YmPnNIoQgnzJJhG17n022pdkcj53oPc9LK5OLbOcK2/5vG0FYDfQAkDNG6hdVoPfubXII2vT
+      iWP9KSbm6u8GuZ7Pl77xLt98Y+KASlejXHWxTB1jQzczHrGwXf8DGVj4xa+9w19899qWz9tW
+      AFXXr2s75DqmruG2QRfIdj2W82V6UrWMOSePdHNjeqXu82eXixwd7OK1a7MHOqaZWS4wmIlv
+      +bw/HWN2pXhg9z0MXM/H9QLeub2wpTvatgKwHW9PY9yNWIaG0wYBcVMLeUb6kvfyGtS6FfVP
+      hb5ze4Hnz48QC5nMLh9cRbw9m2V0wwB4nVMj3dy4W79gO4HLE4scG+risWN9vHVzftOxthWA
+      4/qbmue9MI32GAO8cX2Ox4/33/s7GQ2xWqjUbd347sQip0cyPH32CN99Z+qgilkTau9WARwd
+      7OLdO4sHdt/D4I3rczx1eoiPXhznH167vallbUgApcIql9++wszsFFdv3Gbi5jUmpyZ5880r
+      LK+09q1hux4hq/4uUDvsChNCcOXO0qbwB1VVGMzEWcpuHYDdT9XxyJdsuhMRnjg5wOWJxQNb
+      4JtZKjDQHdvy+XBPgpV8pe0WFpvhvcklTgynGepJsJyvbNo70liWSCtMPJXA8wURS0VRogSB
+      jYbL3OwMnlDJpOItsUas2C6JiFl3/l9DUylVnEPNF1wLexDEQvqmcoz2Jbh+d4neVHjX829N
+      LzPcEycIfExdIR0PMTmfZbhna1+9GfxA4Lgepq5u+7x0TSVfqhALmy2972GwnK+QjodQEHie
+      x0fOj/Cdt+7w0YtjQIMCyK6uUKlU6ErFKFbAUmzMcIqRVIZKMYeu6S3LE+x6AWFrb1vEdSIh
+      E9cXh2qPeGd+mZNHMlvKcGqkh2+9eYcXHh/f9fx3J5d58vTQvfOfOXuEl96d5jMfO9vSci6v
+      FOlORjB2mGQYG0gxuVDg/LG+lt73MHj71iKPHR+490yfPT/Cf/2j7/KJp47V1o8auVimb5DM
+      2jPpve9YIpFoRXnvUa8n0Drt0AV65b1pnn50eMvng5k400t7D4SvTi7zw08eu/f3o+O9/MV3
+      r+H5AXod7hj1MrWYZ6hn53+v0yMZrk4tf0AEMM/nPnH+3t+JiEUsbLKYLdPbFW3fQXC9tojr
+      1Myx3AMs0e4EgWByPsexwfSWY9GQASiUqzuXL1+ycT2feOT9bkfI1OlORrg509rV2TtzWcYH
+      UjseHx9IcXu2/VaEPT/gG5cmcOucUPD8gNnl4r0p6XVeeHyUb6yts7StALw69wOvc9gtwGqh
+      QjIW2nbgrigKwz1x5naZX78xvcLpkcyWPQ3Pnx/hey2eDbozl9t2CnSddDxMtlCtu6I9CMpV
+      l1//4kv8zcs3eOnd6brOuT27yunRrc/04okBXr06A7SxAByvsWlQy9CoOof3D/b2rQVO7bL5
+      ZXygi5szO8+UvXN7gceOb+1yPDKa4frdlZZWxtVidVMIxP0oikJ/OsZyrtKyezbDwmqJ//R7
+      3+KFx0f5t597jq+9fruuSZZXrsxw/ujWZ2oaGieHu7k+tdzGAqgjQ+RGDrsFePPmPOeO3j8y
+      ep8Tw2nendg+0lIIwe3ZLGP9W7slllHbrNKqblCp4hA29T1X2Y8O7i7YB8XVySV+/U9f4l98
+      +gmeOj1IKhYiEbW4VUcX7b3JpR3HMR95bJS/ffVWewugoRbA1LEPaSXY9XxWCxWGe3ceWPZ2
+      RVktVLZ9cy3nKxi6StjafkP68+dHePHtyZaUdWa5QG/X3qmsTh3pPnSvoG+9eYc//tplfvkz
+      zzDWn7rXlfnUDxzn7165teu5+ZK9Fuu0fRU/MZxmeinfvgLw/Pp8QdeJWAYV+3AGwbWBVvRe
+      +MN2WEbtrZsvbd1wcmVikUfHdt6Le2wozeR8viUr3ZP37QHYieHeBNNrVikPmkAI/uRr73Dp
+      +hyf/+wzpBOb109OHulmeqmw63bTt2/Nc3a8d8d94oqicOHEQHsKQAiB7foYjYRD7zMatOp4
+      /O5fvcH//H+vbFs56+H1a7O7dn/WOdKbYHJha7jx5YlFLpzYPvMO1Bamjg11tWR32cRcjqMD
+      XXt+L2wZCCEoP8CXSrnq8tbNeX79iy8hgF/6yQ9t2yoqisJHHhvh66/f3vFar16d5cKJ/h2P
+      Q60b1KYCqDlC1LsnGNZ2hTW4fD8xm+U///63GetP8aHTQ/yXP/wO33lrsuG33rWpZc6O7y2A
+      E8Nprk5ursR+EDC/Wto2LGEjz5w9wjcuTTRUru24u5inL11fNs8jvckD3dO8Wqjw8pVpvvDV
+      S/zHL3yDX/ujF3n71jyffvYk/+SHHt3VFOH586O8+M7UtiEbgRDMrxR37ZIC9KYiDaZJfUA0
+      siF+HVVV8OusuEEg+NtXbvLq1Rl+8dNPMLy2KHRmrIc/+fplXnxnil/41IUt88fbUbFdyrZL
+      Vx25zI4Ppfnmm3c2fTa3XCQWNvcc74z3p5hZKlCx3R3HCnvhBwGeHxAN1RficHqkm2t3V1rq
+      FSSE4OuXJvj2W5OEDI3jw2k+/OgRPvOxs4RMvW5rm5Cpc/JIN5dvL3DuvoHunbksQz3xPetQ
+      wyvBdrnIatEmogfv5wm2YuSyOfr7e4nHdn+L1UuwD4u+ep0hssUqv/OXl+hLx/j8Z5/dtNoc
+      CRn8/I88xnuTS/zGn36PH7owzkcvju/6JroxvcL4QKqu8qbiIUpVFz8I7o0X3rq1wGN1rLhq
+      msqj4z28c2uBpx4Z2vP727GUq5BJRuq2mzk2mOb1b1ze1722Y26lyG9/5XXGB1J8/rPPNFTh
+      t+OTTx3jf//925w9urmv/8b1OS6eHKzrGg0JwAxFELkCOdtHET6uqhMUl8hnK7hOhYEj4yQi
+      VtPBcJ4XoLB3fuCNiEDUHOt2OeftWwt86ZtX+JkffGStyyK2/f6JoS5+5eee48svXuVX/+Db
+      fPqZE5wY7t52RuHNG3OcP9pbd1njYZOlbInutYHdlYkFPvuxs3Wd/+FHhvjKS9e5cGJ/IQqT
+      c6v0piJ1lzUdt5heKmA7blOeT34g+PvXbvO9y3f53MfPcmK4tlrerJVlX1eEiu0xv1Ikk3x/
+      oPzWrXk+enGsrt/ZkADKxRwzMzP0ZDKUbK+WJziS4uh4hnx+lWq1Sle81m1oJhjODzxUVWko
+      sE1bE9x253h+wB//wzssZEv8u889Rzyy8yLQOrqu85mPnWNqIc/XL03wZ9++ii8Ex4fSnBnr
+      4dSRbmJhk4m5HD/xkUfqLuuxwS5uz+boS8dxXJ982aEvHa/rrXx0KE22aFN1g31Fak4tFjg+
+      nG7ouXYnwpRtf0sXz/MDqmublnbrvt1dyPPbf/k654728h9+/oW6nT7q5Ud+4DhfvzTBZz9+
+      Dqh1SV0vIBEN1dW6NCSAaKKLJ554YttjXd2tswDcTxdIURRURcH3A7QN06elisNv/tkrPDKW
+      4Wc/ca6hsYWiKIz0JflnP/IYQgiqjseN6VXem1zib1+5SaHkEI+adfepAU4Md/P69Vk+/Ogw
+      U4t5+tKxurskiqLwo0+f5Le+/Cr/5mc+3HCA3MRclufPjzR0zumRDL/6+98iEjIRCIRYG6Op
+      CiGzlp3T8wM0VSEZDdHbFaU3FSWTDHNjepWrk0v88x+9yGAmfiDWlRdPDvB/vnmFn/7BMxi6
+      xuWJRR471lf3vdpyENyoI8Q66zbpkbWKMbNU4H/835f5yY88whOnBpr6B1AUhbBlcO5oL+eO
+      9iKE2JcNy0hfkj9/8SoAl67PbrtUvxsXT/YztZDji1+/zM+uvfXqZbVQJVFH67eRTz19go8/
+      eRRdU9c8X2szbuvPsubHVGsR8iWbhWyJxWyJ23NZelIRfvqF5ze9kFqNrqk8eWqA7787zXPn
+      R3jt6gw/dGH3sPONtOU0aM0Uq/Gi6bp2r1K+eXOe3/yzl/mXP/YkT54ebPnbR1EUDH335n87
+      4hET1w9wXJ/rUyucGWtshkVRFD797CkWs2W++cadvU9Yo1RxCBlawy8WTa2tUBu6hq6paKq6
+      6VnWnMAVTEMjk4pwZqyHFx4f46dfOMNHL44faOVf54efOsbfv3YLIQS3ZrIcH9oakbsTbSkA
+      22ksFHqdWkCcx9+9cpOvfPcan//ss3Wtej5IFEWhKx7ixvQKnh+Qiu09fXo/qqrwi59+gq+9
+      fovrdSyOeX7AV753jZNHutvKQbtVJGMhktEQL707TX93jEZ+YlsKwPEaWwVeR9dUfuerl5hc
+      yPHLn3mG5D4q14PgzFgPf/PyTUb7k/uukCFT55d+6gf43b96g5X8zlGbC9kSv/ZHL2IZOj/x
+      kUf2W+S255MfOsb/+vNXuXCiv6Fn2pYCqDoe4X20AMeH0jx+vJ9f+NSFfY0hHhTHBrv4ztuT
+      dc3/70YmGeHn/9Hj/LcvfX9LJKwQgu+/e5ff+NOX+KkXzvBjz51q6a6yduOR0QzHh9Kca3BM
+      1ZaDYNv1GjLFWueTHzrWEU38QDpOX1eU48P191V34sRwNx9/Ypzf/srr/OsffwpVVe7FN/mB
+      4N//3PMfiM3te6EoCr/yT59v/DxxAOF+vu83tQ7w0uW7LGZL/ONnT7WwVO1FtljdV/9/O4QQ
+      /N7fvEUsbHLx5ABf+OolPvHUMZ47d6QjXgiHSVMCyK8uoYbilIt5kskEllmbYmtWAFXHW9sf
+      29iU3cOMHwT89y+9zEqhwr/6sSe3tT2UbGX/AhABE3cm8d0iU9MlhodTDI0cI2zqTQtAsj+E
+      EAgai6J92GliVKRQLRcItDjnzozi2A7zCw9XcoV2Y301XFI/TXWBgiB4v4+5FsSvKIpsASQd
+      Q0sHwUKITUmygyDYMXfvblnJ93vsIO632/H1R9fq3/Ggf+Nex2D737jf57bXsQf5G1s6Daoo
+      yqY3fysSZjd6/wd5v70EcBDI39jiex3ENKhE0im05ULYbmQX7jJXhP6Uha9a6MKl4gmqlRJD
+      vRmuXruGokdwbYf+gTQLS3nSlkd0+Bxdu5szb2Hy1lX0eA/peBQQLC8ukEh1Y5oalVIR27GZ
+      Wyrx6Okxbl17D1fo2J5Df08fcwtLDHTF0VJpepO7702duXOLlUKJgeERnKpDLKTiolMpV0hE
+      TfLFClbEZG5ykWOnj7OytEQ6ncJxA7xqgcn5VcKqi2bFUYIqGDFc2+aR0yfq+6HC59VXLnH2
+      sUdZXFylJ9NFMZclV64wODTG8uxtCqUKVccj1dVNYXmRroEBFucWOP/YYzQSt+iVs7xxY46z
+      J8dQALtSxBY68UgY4dssZUsUs4sMjZ2kkltkMVcCu0wkmcatZNEjPeQW5jnz5BgibrsAAALi
+      SURBVOOEdm0lHF77/pt09Q8QMSDd08v8wgphQxCOJllaWcXQ1M4TwMz8IvmqIGr0YNuriEDH
+      tFRAQVEEye5B8KsoYRNfURkdG8Xycuztzn8fImBpOYtStLELCUq5JaKJDDev3SCZjuD4Kpah
+      kk53oQKheJqkEuBpCo4rGBsbJaarFOrIEKmbYYb7w7z33nuYoQiRWJiE6nJnpUpPVxeGBpQd
+      EskE777xClXfYjmX4/TJUxSdEuOjI+RWlggCD82MMzg0xOLC/J73XSe/NEvFrnJrcoaoqnLt
+      1h1GMgnKa16rmmZwZCDBSjXALhToHhgmHtIIjY6hNdgzujszR7WwytRdC1X4oKkowqW0GqKY
+      X8IzIqSTaWIRi2pBY3RkmJXFFXyvihXrpacrSjQSwqqjSzZ4ZIxyaY5rt3OE7s7z6PlzvPnK
+      i/Qkk4hQF46pd1oXSFCt2qgC7s5MksoMEA1ZCOEjUNCEy+3JWQYHByiWbbSgQtlT0XwbLZxg
+      sK/+0GMR+DWbFeGTXVnGCoe59Oolzl28SKVUJhoxUMwoTrFAd08XE7fukBkYpFwsETZgpWAT
+      sRRcYTA6vLPlCUA5v8pSwWYgk2BmfpVUzMRTDAq5HH39/dT2ywgWZufpGehnbnaWnr5+ouEQ
+      S3PT5G1BV8xEt6LMz04TT6TIZVcZHBmvKwzCrlYxLJOl2WkKjsrQQAZDVai4HuFQmOk7NzGi
+      XeBVScRj3J2ZI5lMUihVODY+VveGHoBqtYqpKeSLJYpVj/z8HYJID+mIRjQeI1eo0BWzEEaM
+      0uocrmIR1gMisQTT09MkEklyuQLjx49j7qq+gNs3bjI4epTluSmS6R6WV3OEtAAjFCccCoEq
+      xwCSh5wPbnigRFIHUgCSh5qOGwRLJPshO/E6X71SRb9zmec/91NUszZWUJECkDw8qIqLZsZ5
+      7dJlYsJHVzQ5CJY8HHjVAtlCFRQT0/RZztmkExEpAMnDzf8HSWvRUNy+/yQAAAAASUVORK5C
+      YII=
+    </thumbnail>
+    <thumbnail height='192' name='4-percentile' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7DAAAOwwHHb6hk
+      AAAgAElEQVR4nO2dV4wj+Z3fv5WrWCymzmk6zMzuhA2zu7PaoHC7eyvZ55Mg3cMFGQYMw4ez
+      Ab8c4APsRz34wcDZZ59t3IPtBwOGcLbuZCX7fJYEWaeVVlrvzkobpMmppwM7MVaOfqhmTzdZ
+      JKvIboZmfZ56uofkn0V+6x9+39/vR3ie5yEmZkQhj/PJYi3FDBvHKgDXdY/z6WJiTpxjFUBM
+      zLARCyBmpIkFEDPSxAKIGWliAcSMNLEAYkYaOsx/8lwLD1a3MD+dwa37m5iZSKGs2qAdFWJ6
+      AmIqDY4mTnqsMTHHDhE2Epzf3ITjOJhIAh/mXUyJgKlVUdVcjE9OY3ZqDI7jgCBiIcQMD+Fm
+      ANvAxsYGpqencGO1hKlcCormYGluATvFCizLBEmS8DwPFEWd9JhjYo6N0DNAGBzHiQUQM1TE
+      m+CYkSYWQMxIEwsgZqSJBRAz0sQCiBlpYgHEjDSxAGJGmlgAMSNNLICYkSYWQMxIEwsgZqSJ
+      BRAz0oRyg9ZQqyWsbu5hIpdEWbEO8gGS6UycDxAzlEQSgGkYcJVt3HcZTImAZVh4tLaGcdPC
+      7NQ4XNeNi2PFDBWRBJAQRXhsBrMSgapmY3FuAWypCsu243yAEKzvVrCxK+PFC7P9HkrMPnE+
+      QA95++NHuLm6h3/wd670eygx+8Sb4B5SUQyUFb3fw4g5RCyAHqIaFqqq2e9hxBwiFkAPqagG
+      ZC0WwCARC6CHKJqFimr0exgxh4gF0EN00wZFErCdaGXkPc+Lj5dPiFgAPcS0HCQFFoZpR3rc
+      rUd7+Isf/uqERjXaxALoIabtQBJYGJYT6XFrOxV888c3sFdWT2hko0ssgB7heR4s20E6yUOP
+      OANUFAO/9uwivvHWjRMa3egSC6BHWLYLiiSRFjlUlGgb4bJi4LUrS1jfrWKnpJzQCEeH6w93
+      cP3hDlzPi2aFiOkcy3bAMRREgYWsRzsKLSs60kkeX3j1CXzrxzfx+59//oRGORp8/7370E0L
+      X/+b67EAeoVpO2AZCpkkj1I1WjRYN2wILI0r56bxVz+7jZ2SgomMeEIjPf1UVAN/+NsvQdGs
+      eAnUK3TTBsfSEHk2cjDMtB1wLA2SJPD5V5/A1//menws2gWqbiHBMZjMitEEoFVLuH79Bra2
+      8rj7cA0P793C7l4Bhh1/GO1QdAsiz0BKRBOA53kwLAcs7ZsMn1mZwnZJQb4gn9RQR4pISyBd
+      VWBqCgpqEknahWXaWFtbx5hhY246zgdoRVnWIPIMRJ5GWdFh2+FOgkzLAUUScF0HtTbMn3/5
+      PL7xo+v4gy/Ee4FO8DwPjuMfRUcSAMkwYHkWHOFCNV0szs6DK1dhOXE+QDs004GU4JBMcNBN
+      BzQd7tIrug2RZ4/8/yvnZ/BX79zBTlnDzJh0UkM+ldiOC4oiQVEUCIKIJoB0bhLp3OSR382J
+      qWMd4GlFVk0kBRYcQ8OwwscBVMMGzx79mEiSwBc/9SS++dZN/OMvvhB35YlARTGQSrAH1yze
+      BPcIWTMhCixYmoIZIRIsawaSCbbh95eXJ7FXUeO9QETKioGUyB38OxZAj5A1E5LAgmUoOI4L
+      1w23VyorBjJJvuH3JPF4Foj3XeGpKAYySeHg37EAekRVNSAKDACAYajQy6CyrB+5Yx3m8SwQ
+      R4fDUlX9JVCNWAA9wrTdg7U8x9Chl0H+mjVYACRB4OVL87j+cOfYxnnaqcRLoP5gWjY4uiYA
+      KrQjtNkSqIaUYOM0ywiUFR1p8fH1jAXQIwzLt0IAQFJgoYT0A5WV5ksgABAjPFcMUNXMg6Uo
+      EAugJ7iuB8f1wND+5U4lOJRDOkL1gGPQw0hCdGvFaeF//+w2torRTsFK1XgG6Dm244ImiYOz
+      52SCRTVkbrBpOy0FwLF05PyC08K1W5t4tF2J9BhFN+M9QK8xLBsM/ThCnhK5UOv2eh9QEBxD
+      jawA8gUZhYoW6TG244EiHwcOYwH0AMt2D9b/gL8ECjMDmJYDmiJBks0jvSxDwbKjJdmfBmzH
+      xU5JRVnurtBYLIAeoJs2BO7xMkYSwp3c6KaNBMe0/D88Q0dOsj8NFCoaJjNi6L0UgMCAYSyA
+      HqDoJkT+cfAlmQi3BAryAdVDUSRcz4PjjtYssFVUcGFxLJIANMO/ER32TkUywymVIu7fX0V6
+      fMKfnh0VifQEUpls3B+gBdV9I1wNliZDRYKb+YDqYWkKtu2CYkfnfpbfq+KJhXG89cFDeJ4X
+      yhBYrGoNR8qRBCBKGaSyVcBzwVIebMvB+vo6dNPC3PREnA/QhIqiI8HRBzkANEXAtOy2OQHF
+      ioZUgm37/0iSgG5aoEbn+4+N3SquPjkDx3VhOw7C3H4rig5JOHo9IwnAg4OEKMEzFRRVD2dm
+      58FVZJiOG+cDtEA1bEgif+DpJ0l/41rzpDejqpnISELb3AGOoeB5ROgcg9NAvqhgbjINkiRB
+      kiQosr36Zc1Ctu56RrpiBEFjfCwLIIuJ/d/NxvkAbVF060jiCkkSoCiy4XSonopiYG6i/fXl
+      WQaaaSNzLKMdDqqqASnBgiIJOI4XavYrq0bDEmiEJs3+4SfDHD3NCZMY084HVEMUmJGyQ7iu
+      v+YnCQJpkUcpZM+FsmwgHQug9yj60U0w4C9b2jlC2/mAaog8C0WzuhrjMFGS9YOsrozEh44F
+      VFWj4XOIBdADDNMGxxxdbSZ4Bore+kvbzgdUw680MTpl1/MFGZPZJAAgLXKh6yyVZB0p8eiM
+      GgugBxx2gtZICu39QO18QDUEjoHaRkynia2igpkxXwA5SUAp5AwgayZSYjwD9JwgP09K5Fq6
+      OMP4gGqIPAN5hASQL8gHAsgk+dAC0IzGyHosgBPGt0K7B1boGkmBRbWFAML4gGqIAgt1hDbB
+      m3tVTOf2l0BJHiW58+VfLIATxrL9L3L9eX+7TK4wPqCD5xqxnIBSVUd2P7E9LXKoqJ0b4k6F
+      AN751RoebJb6PYxAmq3j0yLfsmWqbobbAAMAx1LQzWhNN4YVz/OTi0jKv6GkRQ5l2WjrQDBt
+      BzRFNNyIToUAbj3aw73NYr+HEYhlNy5/gP2TmxYzQFUzQ/mAgHAxhdNCVfNjKuT+F7lmBmxH
+      RTGQFBqPlE+FAKqaGTkxoleohgUhYCnDt8nkKsl6qCAYEC6mcFrYLigH6/8aBEGgnQaqqtkQ
+      BANOiQAUzRpYAdRboWuwbSpD1JfvaAXH+GIaBSNivihjMnu0NwJFErDs1jeAyn6TkXpOhwB0
+      E4XqYApAVv2KcPW0W7a0qgdUD7mfb+yErDY3zGzsVhtmgEySR7lNTKWqmpAClpSRBOC5Nu7f
+      ewC5WsLG1i7yG4+gqmrf+wMYpj2wpyCyZkEMEABNkYCHpj2DoyyBAIChycj9h4eRrYLSUBE7
+      nWxvhygrjT4gIKIbdOvRQyiGC3evAopwoVf2kN+pYGZ+DhPZVF/yATwPqL1i2Jr7vaSi6Mgk
+      ucCx0TQJTTePpEvWKMs6kjwd+j1RJAHDsBCw3z5V7JYVZOuuZ0bksFtSsDydbvq4QkXF/ESy
+      4XpGTIiRsFteg+J5IAng3Mo5PNrcRqlUwtRYpi/5AH7zOf9teCCOVF8YBFTDwsJUOtCrL7A0
+      HA+BfzNsBwmBC+3xZ+nmz3WasGwXHMscCRBmJQGyZrV874puIZ1szK2IdLWk3CSequsPcP5c
+      c9X1Asf1y1wIHIOqaiKXEto/qIcomhW4BwBa1/QxIsQBAEDgTn99IM2wwHM06nOIMhKPW4/2
+      Wj62ohjIht0E7+3u4ufX3scwHKzVvOFpMVypkV4j62bgHgDYj+AGxAJqPqCg+EEzRqFE4nZJ
+      xVRWbAhmhfEDKU0+h8ArvL12F/cfbGIY7ieG5Wf6pyOYonqJafn9gYOQEhwqAaI19+0TYdL8
+      aiR55tTnBOT3qgc26MOEqbNUXxCrRuAV1o0yCpsVDMOZQq37Yk7isTeAsYAgK3SNZl3j9QDX
+      YjuSidbmutPA5p6MufHGnmhpkUOxqnd0ANMgAFOVwQjjWHhyDuEC8f1F0fxAUy6dQDFiA+pe
+      YJh2U0uz1OTOpZt2y1zhIBIcA8043TPAVlHBVLaxQTjVJiHYdT00KxvR8EiCokB4LjRFHYo9
+      gKJbEHgGmSSPojxYM4DjunA9r+nJVLO7dlULDtq0Ihmy2tww4y+BGgUAAK7nNbVDKLqJBEsH
+      VuBoEADDCfDgoLi5jWGIKyr7vbdyEo9CebAE0K7qg5QIXgKVZB1ZKdppVoI//TOA2eJ68gzd
+      1A5RUYym17NBAJX8KlK5KWQW5jBYJ+rBKLoFUWDamsv6gWk5YFrERRIcDc1oHHNFMTqbAU7x
+      HsDcPxUjm9RRSu3vA4KQ9eBoPBAgAJIk8eH1h3jq3PxQbILlfbMZQ1OwBswKYNrNT4AAPw4Q
+      5AeK4gOqwbOnu0juTllBLiU0LSSWlZovgSuKHmiDAAIEYDskFhfnMDU7Gy1K1icUzT8FoikS
+      BNDWFdhLdMMOtDnUaNYrrJMlUDt36bCzHeABOkwmKaDcJDWyvjfwYRoEII1lsbd6B2+9/e5Q
+      zACKbiLB+0eGUoIbqLNwP6ml+Z2cpSlYttNwfFdRoy+BTntSzGZBxkyuMQZQI5fiUWwSBwoq
+      iFWjQQAUK0AURcDQhyIQZlqPUw6lBBsYWOoXsmYiyTc/zycIAizdeOf2y3hHiwOw+0kxpzUn
+      4HAifBDZpIBSE0t8RdEhNWs1G/TLp688i8vPX0F4M27/0A4Vj4pSIqMX+OXNW6/l/Q4vRwVg
+      WtF8QIDfM5giT29OwOaejOmx5gKQEmzTXgGtSkwGCuDe7Q/x87c/Rv1XyTUVXL95B+VyEev5
+      HeTXV6EoSl/zAQ4nj2clfqCCYapuI9FiDwA0pkZGqQdUD001ium0YFhOy/1UVhKa5gTU92c4
+      TMMz2qYOguJhkmXUT8JKYQ82xWCvWAEJF1W5gPyejNm5WYz3IR/A8zxYjgMCHmzbRibJYW27
+      MjB5ASVZC/SgH0ZgaZRlHdmkP1OYtgOKJOC6DqI2faEpAoZpgaFOV7MS2/G/V57rwm5yURIc
+      hYpqBF5r3bTA0ERwTkb9LzzPxMajXZBwYQNHYgF0Mg2msA5WSEMzHSwtn0dJVqHpOkiy9/kA
+      lu3fKWse7+mchA/ubA+MJ17RLGQCPOiHyaYEyPpjL3tVs5CMkAdwGI6lYbunLycgX6xgZkxq
+      +74IggBJUQGxAgJ0k14MDc9Is0ksnj2LswGrIyGZxoVLR/3/033sD1DLBaiRkfiByg2WD51Q
+      NUOq6xfm72k6u4kkBRaKZmI8nejo8YPKVkEO9ADV41eH8HA4YcBvn9T8MQF7ABf3bvwKv7y3
+      OvCRYNtxjxih/KPAwVkD27bbdi0v1TXNrgQ0cQhLgmOgnkI7RLsNcA2BoxuKBGuGX5m7WQCt
+      0QxH0Mjk0hjLpAbeC6QZNgT28R2WoUg4AxQNbmWFrlFviS7LOjLJzrLaxFNaInGrKLc8Aq2R
+      DagTWlENpJPNbyiBp0BSksajB9sD7wZV6pYY1H4x2UEICPmnOe1tzcm6L61vg+jMiC4eU1LM
+      t398c6CMdVsFpWUQrEZGElCqs0NUVRPJgLpMNQIFICQl2K498FaImg3iMFKiddnxXmE7LqgQ
+      zdvqTWytwvbtqBdTp3z3vbv4ycePun6e40I1rFBxkUyAIa7ayQxQqdg4vziJwbkHBBPUeiiV
+      YFFV+i8AywmuCVoPV9fpvaxE9wHV8POCu/vUXNcDS1P40QcPB6L5tu24IAkiVJn4jCQ0BMN8
+      W0nkJZCA3MLCwEeClQCba0YSBiIxxrdCtxcAy1AwDwWvKi2CNu0QOabrPgGqYWEsJWB2TMLt
+      tUJXz3Uc7JVVjKUToRphZ5N8gx2ilQ8IaCIACjZu374/8F4gPx3y6BIoNyDRYNNywIfw87AM
+      BcN87OGJUha9Hr9bZHczgKpbSCZYfPbFs/jeu3f77i3aKipNs8DqCWqWUZJ1pMXmt/JAAewW
+      83j4y4eDLwC9cQ+QSQoDUShXaVLxrR6SIMDQfs9gYL+KRIdxgCBjXVSqqgFJ4LAyk0Ghqvf9
+      ZpJv4wI9jH+i1rgHaLWnahCAXt7B5o6Kq2++isEqMdVIUK2XXIofCAHImtly7XmYWmKM63kH
+      0e1O4FgaZpcnYGXFgCRyIAgCbzy3hP/78wddPV+3bO5VQ8UAAD8tVDWOVslul13XIIDdtQ3Q
+      SQG3P7ox8JtgLSDhJCcJAxENljUr9Fqeo30rc62CRJj1buDzMBT0LmeAYlVHbn8T/olLc/j5
+      7c0je5Res7EbXAqlGQSBI/ErzbACy9PXaJij5y8/i3k8G2mQ/UI3LfB1/XcHJTNK1oymJRHr
+      qfUMJvdLPHYKQ1NwHBeu64U6NQmiJOtY2i8yyzE0Li5O4Oe3NvHSpfmOx9UpnuehrOht7SSH
+      IQgCnusB+4ZAD4hqhRgeNMMGXzcDsDQ1EGXCg2IUzajVB/I3wN0ZUGiquzLp5bpGEm9eXcEP
+      3n/Ql83wXlnDZEaMVCFPrGtA3m7YkY4bPM/DjZs3MZGVUFRs0K6KhDSOzNg4OLq3Ftyab/6w
+      FQJ4HA22bKevlaKj9PiqdYykKLLjIFiNmgCiFtaqUazqR4rITmVFMDSJ9d0q5id6a3y8ny9i
+      eSYT6TFpkTsIJtY6dLYikgBK22vI75bA8QnwDAHHJLCZz0O3HCzMTvY0H8AvhOQF+uZFjkap
+      qiEr9S+SIasGeJYKlZsgCQxKsgbPc5EWg3sJhIWmSOimCbbDG5JmNHrn33huCf/nnTv4+3/7
+      mY7H1Qm3VvdweXki0vXIJHnslmTM5BIoywZEnobjNF8SR+sPkB7H0rwNgSUhGx7mp2chKBoM
+      ywNJkj3NB6gVkA3yiGeSAlTDxkS2f2YO3XRC+/pTooAH+RIokkRK5Lvy83MsDdvpPCfAz7Fm
+      QR+aPa+cn8HX37oB0/Ei1yzthjvrBXzpMxcivZesJKC63ytAMeS21zPSVWJ5ActLy0d+x/cp
+      H8B1vaZFkmqVohe7eH7HdeF5aDuFNiOMEa6GlGAha36v26hTfj1Jntkvkx4ueHQY1/VgO27D
+      eyZJAq9cmsfbHz/Cmy+sdDW+sDiuC9NxG5a47UgneeyWVQD7/dnaHEUP7SY46IOqcRyVon9w
+      7T7++M/f7rjanHmoc007anuAbnxANUSBbfDEh0U3bSR4JvAE6TPPLuKtHvqD8nsyxtOJyKdZ
+      OelxHKiimkiJrfdhQysAvUXpkFyq+0rRN1b3cG4ui3//9f8XWQSe58GKkNheS4zvxgdUo/4U
+      JAqqYTU9ckyJHGZ66A+6u1HExTPjkR+XEvmD/IqKoiOVaL0PHFoB+J1Xgj+sTJLryhDneh52
+      ywq+9OkLePWpBfy7v3wnkj/edlyQJBn67lUratWND6hGN5ZouY0Ae+kPurtewNm5bOTHpUXu
+      oDROSdaRaXMQMrQCqPUFCCKXErqqFF1VDAgcA4am8MmnF/Dac0v40wgiMO32mWCH4fYNcd34
+      gGqIvJ8X3AklpXVrVt8fpPXEH7S6VcbCZPT+cwmeOWgaXlHMtslFwyuA/arQQfAsDb0LT8yD
+      fOnImfcnLs7hjeeXQ4vAspvvT4Ko5TVrhtWxD6hGN47QdtZhgiDw2pWT9wcZlg3H9VoWFm6H
+      B6CitnaCAsMugCYzAENTB+7KTri9VsD5+bEjv4sigk4iurVFRac+oBoi33mZ9JKstd2Ev3Rp
+      Hu/f2jzRaPv6ThWz41LH14IgAM/1UFUb7fL1DK8AAnIBatAUCYLovFL06nYZZ2cb1581EfzJ
+      137WUgRqC3E2g2fp0O7RVnTTLrVYbV5GvAbP0nhiYQy/erDT0WuE4c56ASsB1z8sSYGFrJuw
+      HRdMm1lkaAUga603bJLQWaVox3H9Sm2p4KnzExfn8OKFWXz33btNn6OqGpFPcySBjVwROgiO
+      oWF2KICyYiAT4hj2jeeX8P337p3YZvjOWgGXFic6fnxa5FCo6L4Rrs3/HVoBBCXDHKbTStFl
+      xf/ytjJgffqZM3j3xkbTGUbRrchfZinBtb37hqFZz4EwKHr7JQMALEymIevmidnOt4oKpnLR
+      A3k1xtIJlGSt7ZcfGGIB6G0qBWSSfNNiqa24t1HEcpvpV+AYPLkwhl/c2Qr8e7vjxCDSItdx
+      PaDDtOo+3w4zQnPu159bwg9PYDNsWDYIovMIPOB/9hu7MvgmjfEOM7QC0MzWNfSzHZZJvPlo
+      F+dmc23/32dfPIsfvH8/8G+1tk1RWJzJHPjwu4GmyH2TYLTlied5cFyvZU+zw7x0cR7v38of
+      ezXqextFLE1nujoMyEoCVrfLoWbUoRWAbjbmAhwml0p0lBr5cKuMxRBfxKmsCALAxm614W9y
+      BCt0jReemMGz56YjPaYZNE3BauGADKJWxSJs8I5lKDy5MIaP7293MsSm3FnrLAB2mLTIYX2n
+      gqRwzAIwNRm3bt9FubiHRxtb2Hj0ANWq3PP+AJ7nwTDthmyww+QkHoWIARvT8oNRrYJBNQiC
+      wJtXVwI3w+026CcNRRKwIx4DdzLmXz+BZJk76wWcDTEDtyKT5LG6VW7rAwIiukFploVZLWGT
+      ZiFQLjS5hO2CjKnZWUyNZXqWD+C6zXMBakgJBoWKGslLvltWkRa5lv7xw1xaHMM3fnQdsqof
+      2Y/ohgWGDK5H3wsYioRhWuCY8Pe3suynHkYZ81RGgKqb2CnKyKWOp4TCXkXDWIrv6tpJAnMQ
+      A2j3PJEEoCkKCIqAZ1uQTRdnF5exsV2ALMuYmcj1LB/AtB1Qh/oCBJFM8NBNO5KX/P5mCefn
+      x0I/hqaBFy7M4t2bm3j9ucc2cdN2kRDYvtXp51galuNFen3FsJHuIBfhjeeX8cMPVvE7r1+O
+      OswGqqoBUWDBtqjmHAaa9uMhWal1bwYg4hJITGVx+dnncfH8Ci4/eQ68mMbK8jLOL5/peLCd
+      4Loe6DZrVZaiYDvRZqPbawWcm482/b52ZQk//MXDI5vOTlscHRdSInqJxEJF6ygd88ULc/jF
+      7ePZDD/YLGFxKt11NBzwD0HCLGWHchNc3xcgCIrymyWEDdl7nofVrXKkEhyAv96czoq4u+7b
+      hN3912wXgTxJOjHE+TaI6CmkLEPh0tIEPmhyJByFm4/28ESdBaVTMkkhVGR9KAWgGVbb1DyC
+      IJBMsJDVcF8E3bRh2U5HdoQ3r67ge+/dA1Ar5oqm2Wq9oJOcgKpqhrpjBvHrLyzjB+/f73r/
+      d7tLC8RhXn9uCWPp9vuSoRRA2JIjksChqoWLBm8XFcx3YL8FgJXZLLZLCgpVDablgA2ZCXZS
+      +FWio80AZaV1GfFWzIxJcD0P20Wlo8cD+zWA5PZepLC8eXUlVEbecAogoCRiEOkkh7IcTgB3
+      N4pY6TAflyJJvHZlCW99sOqXY+kiinkciDwDOaIPqqzoSHVhxnv9ueWubNK7ZQ2TWbHt0va4
+      GUoBVFs4QQ8zlgpfJvHOevQN8GFeujSHazc3IGvhiuKeJJ3MALbjdlVH6bnz0/jo3lbHZRQf
+      5ItYnjme5U8UhlIAWki7cSYZrlCu63nY3JMxMxZtA3wYgWNwdi6Htz9eQyKiDeK4kTpIi7Ts
+      cA09msEyFJ5amcK1mxsdPf72WgHnjmn9H4WhFIDcIhvsMLmQM4CqW/A8r+t83M+9uILvvXe3
+      4x5fxwXHHu060w7T8ptzRylBGMSbLyx3HBm+u17ESpcWiE4YSgG0ygc+TC4VrlfA+m4Vc8dQ
+      9m86l8TSdCbU/uQk4Rkauhl+KSKH3FO1YyIjgmcprAf4o1rhOC50045cA+g4GEoByAG9wYIQ
+      WAaa0f5O6CdgRC/BUQ9BEPh7n3sGz56b6vq5uqG+7VI7VM1CMkIF5lZ89upZ/PU7dyI9ZrMg
+      YyITvQbQcTCUAjBClg/xO6+0/yI8yBexON1dRbYaS9MZzI33p1peDY6lIuUEVFQDyWNIxwSA
+      p1cmcX+zFGkTfm+jiCc7qAF0HAylADQjnABoioQHtKxm5noetopKqEbMwwJFkiCA0E3Di1UN
+      uWMqJEwQBD71zBn85MPwbVbvrhdwbq47B2inDKUAdLOxM0wQBEH4Z+ItosFVxYDAMl1lIA0i
+      UfoE+AWkjq8h1qeeXsBbH62GKqNo2Q7ubhRxZrI/s2a0fABdwa1bt1Es7GJ1PY/11fuoVKo9
+      zQeo9QUIW3czJXIty4Q8yJew0KeLf5JQJAErpAAqqtlVEKweKcFhYSKFm6t7bf/v//zpbTz/
+      xEzH/Qy6JVo+AMMhyVHYLmsQKBeqXMFOUcHUzAymxrM9yQcIkwtwGElgUayomM4mAv9+e20P
+      S9Ppvnn3Twqa9nMC+BA5AXtlBRmRPdZr8OYLS/jWT27hifnmR5uPtiv48G4e//zvvho6B+O4
+      iSSAym4e21UDaZGArDlYWVzC5k4RiqqCJMd6kg/Qqi9AEGPpBNZ2ZTx9NjjdcHW7gteeW+6b
+      d/+kSHAsTDtcToCsWciE8M5HYWVuDGXFQEW1ApNlLNvBf/3uR/iHv/k8OLZ/x8aR3nFmah5X
+      6k74lsXuE7mj4DrN+wIE8cmnF/Afv/0+Pr63hS9++sIRu+1BDaA+dpI5KfwSieFOYswQrYQ6
+      4bNXV/D9a/cCk2W+8/YtPHd+OrL9/LgZup2f5TiRvPZpkccf/d4r+K3PXMS33rqBf/nVH+PW
+      mr82rexnIHUbAR1E/JyAcIY4w7RPpJ/aixfn8MGdrYaj6PubRXx8bxu/8fL5Y0l+6Yahm/f9
+      iGG0YRMEgXNzOfzR772KuxtFfPOtG7AdF+fnc4ElEE8Dta4z7TBtBxRFgjqBIBRLU3hqZRLv
+      3dzAK5cX/NezHPyXv/4A/+gLLwzEyVv/RxCRKO1H66kJ4Z/+7iv43Tcu49F25dhKkQwaAhcu
+      KabWSPqk7sSffWEFP7j2OFnmm2/dwCcuzGEmZPf3k2boZoCq1n3UkiAILM9k8XzVG1kAAAiu
+      SURBVIe//fIxjWrwEHkGG7vty8KobUpMdst4JgGOpbG+W4VpObizUcA/+/In+770qTF0AmhX
+      EzTGx88JaD8DlGXjWKpSt+JzL57Fd35yE5t7Mv7Jb73Y86SXVgzOSEKi6e3zgWNqOQHt9wAl
+      5eRPwZ5emcSttQI++fQZTA2Y5WToZoCqZmIiExzUinmMb4hrH1zyu8KcrAAIgsC/+P3XW9Zy
+      7RdDNwMomgkpRM3HUafWeK8dJVnrOBk+CiLP9rVSRjOGTwAtWnnGPIZjKJgh+gSUZKPr3sTD
+      zNAJIGwuwKhTS4ts580qK8dXimQYGToBqHosgDCQBAGCJOC06RNgmP0t49hvhk4AuhkvgcIS
+      JifAdqL1ND5tRLqVWoaKnZKCJEugqFigHQ3JzDh4UQJHn/wGx/O8yE2oRxmKbC0A23HhASdi
+      gxgWIuYD8IBbQll2QHguVFXGTknF5PQ0pidyJ54P4OcCAK7j4OS61J4eGJqEbphNcwJkzQTP
+      0H3z4g8CkQRgajI21jeQy+Wg2x5Wziwiv1uCpmkgSfLE8wFMK1ouwKiT4JiWOQGaqUESuZG+
+      npHeOSemcPXq1SO/W+phPoDreSM9XUdFbFMhrqqakPpcw6jfDNUm2Nq37saEI8kzUFv4gUqy
+      3lFTjNPEUH2bdNOOfUARSCbYlgUBilX9xG0Qg85QCaDaQQPqUSbBtU6LrCgGcqlYAEND2L4A
+      MT6z4xJ+9WCnaX0ePwocC2BokEP2BYjxOTeXw4Uz4/gP/+PdQGNcRTFG2gYBDJkAdCPeA0SB
+      IAj8xkvncOHMGP7tX7zTUDJdNSzwfW7m0W8GSgCu6+HDu827DVY1E8k+194fNgiCwOdePIuX
+      Ls7hT//ynSNFc7vtCnMaGCgBEATw0b0tfPV7Hx3pu1tD0Uwk+9x9ZRghCAK/dmURn3l2Ef/6
+      v/8UsmbCdT04rtf3fmb9ZqDePUEQ+PKbTwMA/vP/er9BBLIWrjNMTCMEQeDly/P43NUV/PGf
+      /wRbRRk8211H9tPAQAkA8G28X37zKaRFHv/pO9eOiMC07dBFcWOCefHiHL706Yv4V//t7dhV
+      iwEUAOCL4Hdev4S5iRT+7JvvHjgaVT1cWfSY1jx3fhp/8IUX8Mrl+X4Ppe8MpAAAf8r+zVfO
+      49xcDv/maz+FaTnQTWsgE6uHkSfPjOPlS7EAOrqdlgs7KKo2aFtFMjMBIXky+QAEQeBvfeIs
+      aJrEn3ztp5A1C1ycCxBzjHQkgIpqgPRc6LqK3YcPMTE9g5mJHGzbhm3bB/5yiqLa/kySJNz9
+      SGWznz91eRak5+DbP70LwzDgui4IggBBEEPxM+An80T9uWYxH7af232ezX4O83057p8Jr4MM
+      lvzaQxRVG8tz49jaK8PxSKwszsNxnBPLB/A8/9huEAqqxpweOhJAM05SADExJ0F8O40ZaWIB
+      xIw0sQBiRppYADEjTSyAmJEmFkDMSHOsxhqCIA4CDa7rgmzSffFwwOc4/tbL1+r29QAE/r2b
+      x3X6nCfx/obt9Y5VAIffBEEQTd/UcdPL1+rH67X6kp8Ep/16Hn69Yw2ExcQMG0PhLV69dwO0
+      OIG7t2/g4vllMGIWtqaApDwU9iqgEgIWZ6fx6ME9yLoBQzWQm5xEeTeP8dkFGIaH5TPR26Gq
+      xU1UySzSHLCVz2N6Zg6AC7VaxL31XUisB49OgCEsuKQA09Bx6eKToZ7brFbw0YNHGEtJEDka
+      fDINjmVhaFUYLg1bq8DxCDA0UJY9LMykUdEc8KQDVkxh69F9yLoJ2zCQm57D3tYmpmfnoOkm
+      lhdbuzyvvfsOFhcXsL5TRlZKYnJyApquQ5Vl6KqC9MQMUjyJm9dvgU4mYegmpsYz2CkpyAgk
+      dI/FEyuLka/nZn4T2UwWgIZHqyqWlybg0TQ2HtyBqurQbQfZ3BQKW3lMn5nBVn4Pzz7zFMIU
+      A3xw+5fgRBGGlwbl6ZgYz4IgCJQLuxDTWRQKBVAUDVOrQsxMgrBVCGIa1Fe+8pWvRH4nPUbV
+      Lci76yCFDBy9is38LgiagKboSLAUSNcDk07BUBRMjKVBMQmYho7U+DRmJ3PQNQOSJEZ6Tc/z
+      oJQL2CjIUKslUCSFUmETLpUARbjI5Mbh2A5IwgPD8JibX4Dn2pAkKdTzO6YJ29ZQKlfgEAwq
+      hW1s7xSxvZ2HYVtgSMA2bVRUAzxF4vqd27AcD6ahYXJiHLKsIpdNgecFaJaDTHYM01PjMDQV
+      yTZjsPQqtksWEoSBna0tlBQdAkvCY5OA68BzbCQSPDyGB0369YUImsHk5DQsU8fM3HxkT5bn
+      eSgWi6hUKyiV9kA6JB5u5jE9NQlNljGeSYFJSdBkA+PTExBoAuncOASeQ5iFn2460Ks72MhX
+      kU242CibsK0y7t68D1VRAdZPpaVpBkq1itUHd+Gq8nDMALlcDpIkgaYpVEtFjM9KEBM81HIB
+      NsEjleRBAbBME5qdBE1ayE6OYT2/g21YkBUdDiYQxaXkuQ5Ul8X52QR2KzomsilsrlsYH0uh
+      tJNHqVLEeFoEGAF7Wxso7u2iWqlATOeQCtF2lBYEzC8sISurMLQqpPknYRsaKDgoaw7GMknA
+      A2zbwm6hgqvPPIW9qoGJXBoEPFimAVtMwYONmVwSa5s7oAgbVVXHhAu0+n5Oz69gzLJAER74
+      ZBG58XEkEjzW19YxOT3t33EdE3KlhNm5OSiqAcJSUCgVQZgmSuUKpsezEa4moFZLkDJjsJQS
+      2LEx0K4HqsyBJj3/cxMzIHQZc9NprG/ugkiLkCtFZFMSwiggm8shl5EwsUBhb6+AS/NjUCwC
+      zHkSvJSDwLMgAGhyGZyYQkrkwPBSvAeIGW3iOEDMSBMLIGakGYo9QExMV+h5/NlX38bTkxVk
+      nvkCOEfGWJJBRTNjAcSMBjxJwaMYXLt2DWczHO4zFBIkGW+CY0YA10RhrwyXIMCyHDZ39g5O
+      sWIBxIw0/x9ndMliRPQkGQAAAABJRU5ErkJggg==
+    </thumbnail>
+  </thumbnails>
+</workbook>

--- a/skills/tableau-build/references/snippets/worksheets/table-calculations-attestation.twb
+++ b/skills/tableau-build/references/snippets/worksheets/table-calculations-attestation.twb
@@ -31,7 +31,7 @@
       <connection class='federated'>
         <named-connections>
           <named-connection caption='Sample - Superstore' name='excel-direct.0ozsbj20cdelf51evvdk71kugqg0'>
-            <connection class='excel-direct' cleaning='no' compat='no' dataRefreshTime='' filename='C:/Users/lavid/Documents/My Tableau Repository/Datasources/2025.1/en_US-US/Sample - Superstore.xls' interpretationMode='0' password='' server='' validate='no' />
+            <connection class='excel-direct' cleaning='no' compat='no' dataRefreshTime='' filename='C:/Users/%USERNAME%/Documents/My Tableau Repository/Datasources/2025.1/en_US-US/Sample - Superstore.xls' interpretationMode='0' password='' server='' validate='no' />
           </named-connection>
         </named-connections>
         <relation type='collection'>

--- a/skills/tableau-build/references/snippets/worksheets/table-calculations-attestation.twb
+++ b/skills/tableau-build/references/snippets/worksheets/table-calculations-attestation.twb
@@ -545,6 +545,11 @@
       <column caption='Profit Ratio' datatype='real' name='[Calculation_1368249927221915648]' role='measure' type='quantitative'>
         <calculation class='tableau' formula='SUM([Profit])/SUM([Sales])' />
       </column>
+      <column caption='Total Sales' datatype='real' name='[Calculation_1660139451271188481]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='TOTAL(sum([Sales]))'>
+          <table-calc ordering-type='Rows' />
+        </calculation>
+      </column>
       <column datatype='string' name='[City]' role='dimension' semantic-role='[City].[Name]' type='nominal' />
       <column datatype='string' name='[Country/Region]' role='dimension' semantic-role='[Country].[ISO3166_2]' type='nominal' />
       <column datatype='string' hidden='true' name='[Customer ID]' role='dimension' type='nominal' />
@@ -2895,7 +2900,42 @@
     </datasource>
   </datasources>
   <worksheets>
-    <worksheet name='1-total'>
+    <worksheet name='1a-total'>
+      <table>
+        <view>
+          <datasources>
+            <datasource name='Sample - Superstore' />
+          </datasources>
+          <datasource-dependencies datasource='Sample - Superstore'>
+            <column caption='Total Sales' datatype='real' name='[Calculation_1660139451271188481]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='TOTAL(sum([Sales]))'>
+                <table-calc ordering-type='Rows' />
+              </calculation>
+            </column>
+            <column datatype='date' name='[Order Date]' role='dimension' type='ordinal' />
+            <column datatype='real' name='[Sales]' role='measure' type='quantitative' />
+            <column-instance column='[Order Date]' derivation='Month-Trunc' name='[tmn:Order Date:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Calculation_1660139451271188481]' derivation='User' name='[usr:Calculation_1660139451271188481:qk]' pivot='key' type='quantitative'>
+              <table-calc ordering-type='Rows' />
+            </column-instance>
+          </datasource-dependencies>
+          <aggregation value='true' />
+        </view>
+        <style />
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+          </pane>
+        </panes>
+        <rows>[Sample - Superstore].[usr:Calculation_1660139451271188481:qk]</rows>
+        <cols>[Sample - Superstore].[tmn:Order Date:qk]</cols>
+      </table>
+      <simple-id uuid='{613A3F22-4BAC-43B9-8BEA-1647EE7D9503}' />
+    </worksheet>
+    <worksheet name='1b-running-total'>
       <table>
         <view>
           <datasources>
@@ -2923,7 +2963,7 @@
         <rows>[Sample - Superstore].[cum:sum:Sales:qk]</rows>
         <cols>[Sample - Superstore].[tmn:Order Date:qk]</cols>
       </table>
-      <simple-id uuid='{613A3F22-4BAC-43B9-8BEA-1647EE7D9503}' />
+      <simple-id uuid='{41FBC066-0FA3-4051-863D-A57E67A502D2}' />
     </worksheet>
     <worksheet name='2-difference'>
       <table>
@@ -3033,7 +3073,7 @@
     </worksheet>
   </worksheets>
   <windows source-height='30'>
-    <window class='worksheet' name='1-total'>
+    <window class='worksheet' maximized='true' name='1a-total'>
       <cards>
         <edge name='left'>
           <strip size='160'>
@@ -3062,6 +3102,36 @@
         </highlight>
       </viewpoint>
       <simple-id uuid='{20BD0E07-5AB7-4A1A-8DF8-8E26844CFE5E}' />
+    </window>
+    <window class='worksheet' name='1b-running-total'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+          <strip size='31'>
+            <card type='title' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[Sample - Superstore].[yr:Order Date:ok]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+      <simple-id uuid='{2A8FB989-4304-462E-A661-1E369AA193BE}' />
     </window>
     <window class='worksheet' name='2-difference'>
       <cards>
@@ -3123,7 +3193,7 @@
       </viewpoint>
       <simple-id uuid='{97CCE13B-A6E4-4D05-BD08-A658CD9F642A}' />
     </window>
-    <window class='worksheet' maximized='true' name='4-percentile'>
+    <window class='worksheet' name='4-percentile'>
       <cards>
         <edge name='left'>
           <strip size='160'>
@@ -3155,7 +3225,73 @@
     </window>
   </windows>
   <thumbnails>
-    <thumbnail height='192' name='1-total' width='192'>
+    <thumbnail height='192' name='1a-total' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7DAAAOwwHHb6hk
+      AAANMUlEQVR4nO3dSXMbZ37H8W9vWImVxMJFkiXZ1liZjFOTSqWmKjknOeUt+bXknNscUklO
+      qdR4nG3imUOssSVKFEmBO0Bi6wa6nycHeZSJJVfAiKQMPb/PxS6JRjdV+hroxh9/etZai4ij
+      /Kt+QPUky+TKAzDGXPVDilybKw9AZJmEi3yRtSlPvn7M6votBmfHtOoVev0x9WJAYiNqK0Xm
+      85Rms3Hd5ytypRYKAAKazQaTi1NOBiOiIKQYekxTg2djfvubr7j36c8wxmCM0XWALI3FAjAJ
+      z3ZesNZehXSKsRUuJjPqRZ/ERtx98JDpsE9zpYO1liAIrvm0Ra6Gd9W3QbMsUwCyNHQRLE5T
+      AOK0BS+Cb44xln/8922myfxdn4o44AcXgOfBVqvCJFYAcv10ESxO0zWAOE0BiNMUgDhNAYjT
+      FIA4bcFpUIsxBt/3yTJDEPgYY/G8l7/vffsvv/unyLJY8H2AjJ3H35AFeZKLU4LqGvFkQrXg
+      M7MhpdDilxpsddcAfSpMlsfCb4TZIM96q8FZqQyzKblyET/wyBvLoH9Cp9Z59UwhsiwWC8Ba
+      fM8yjmek8Zju+jqjccxK3mdOxNbWFlmW4fu+xqFlqeidYHGa7gKJ0xSAOE0BiNMUgDhNAYjT
+      FIA4TQGI0xSAOE0BiNMUgDjtUstxK7U6J2cXbK43OeqPX61GrK2UmM9TVleb132+IldqoVkg
+      ay2nx4ccnV7w4XqJ3/QM3RUP44FnLYfPn3Lv059RL4VkWabPBcjSWCyALObLLx/R7qxy2r+g
+      3Wpwej759hkgR32lQDI3rHfbGoaTpaJpUHGaLoLFaQpAnKYAxGkKQJymAMRpCkCcpgDEaQpA
+      nKYAxGkKQJy28HLcNE0Jw4AkmZPPhcxSQ+iDwSfwPW2Ek6W04G5Qy9ffPKbbKPNs75ByY40k
+      /nY1og3IMSdXbbHZWcVaq+W4sjQWDMCjVMwzSw1RAElqKeVz+KFHZGAynFBshK/+8mtBriyL
+      BQMw5MOIUq1OO1ei1axxPk4o5TzmRBRu33r18wP0UkiWicahxWm6CyROUwDiNAUgTlMA4jQF
+      IE5TAOI0BSBOUwDiNAUgTlMA4rQFx6EN29s73Nls8c2zA7rtKkf9CfWCT0xEvVxknmasra1e
+      9/mKXKmFZ4F6Bz1MPOEinhHkypQiLceV5bfwevTj3gFrnQ5ME4q5gItJ8mo9+v1PfkwyPsdf
+      aWkaVJaKpkHFaboIFqcpAHGaAhCnKQBxmgIQpykAcZoCEKcpAHGaAhCnKQBx2sLLcWezGfl8
+      niRJiMKAeJYSBR4GnzB4uREuDBdcNCfyA7Hwctzt7ac8+Pgu//Jvv+LerS6D8YxSziO1Pl4a
+      U2qus9FuajeoLJWF/5cdBj77z3fJzJxxkhIGPvgevvWYpyngaSu0LJ2FpkGtzTg5OqFUrZEL
+      AwLPMpzOKUQeGQG5MMAYQy6X0zSoLBWNQ4vTdBdInPbGAJIk5ujoCL2il/fdGwP4ry//g7/7
+      +d8T3/TZiNywNwawulbl7v2Hi98iEllSrwVgTMZkOuHJ9tN3cT4iN+q1AJLROaf9hE63oWsA
+      ee+9FkCx2qSYS9n+6il6P1fed6+9zJ8Nz9j44CFruyNy7+KMRG7QawEMT474py8f89GdWyRA
+      8R2clMhNee2d4HQWc9o/x1qPdrd96XfK9E6wLJM33uk8O9rj6+0T/uqv/4IcL5fjfvXVb7l/
+      Z4vH33xDvr7GaDSmXgxIbEStGJH6ObbW2zd8+iJv57UAwlyBzGb0e//zTrDn+TSadfzAp9re
+      wKYzmpUS1vMoWMOL3Wfc+tFPMcZgjNFUqCyN1wKwNqW3d8rte1uvArA25eKszzyZM01iup02
+      g1FMreAzI+JHP+mQpnN839dyXFkqb3gJ5NNu1TkcGfLf/ornhTx4+PB/fVWt9t3/TpfLsnxe
+      u8b1PB/P8zGTCbN3cUYiN+i1Z4AXjx5RWt/ikzZE7+KMRG7QG+5yWtI0BaxGIeS9p0+EidP0
+      iTBxmgIQpykAcZoCEKcpAHGaAhCnLbgc19A7OKSz1uDp7gGbnQaH/Qn1gk9CjkopT5qmVKvV
+      6z5fkSu14GpEy+7eHqEHlbzl6xNLq+RhPcBaTnu73H74xzRX8mRZhud5N3DqIm9vwc0nGccH
+      PZqrqxyfjFhtNugPJ6+mQTduf8B0eIFf7WgaVJaK3gkWp+kiWJymAMRpCkCcpgDEaQpAnKYA
+      xGkKQJymAMRpCkCcpgDEaQpAnHapHwPWP9xnZ/+AlcYaw9GEetEnsRHVQoAJimxtaDmuLJdL
+      BWCsJfAsk7l9uRzXh6KxHLzYY+vjP9JyXFk6lwqg1mgymMzZ6Kxycv5yHDohR7vT1XJcWUoa
+      hxan6SJYnKYAxGkKQJymAMRpCkCcpgDEaQpAnKYAxGkKQJymAMRplxuGSxOePN1nvdvkuD+m
+      VgxeToOWC6RpSu31Hx4s8oN2qVmgF8+e0I9TCoUiOR+MB561HO8/54Mf/wmNck7LcWWpXCqA
+      8eCUZ3t7RIUa8Sx5tRy3WsoxNwFbGx0Nw8lS0TSoOE0XweI0BSBOUwDiNAUgTlMA4jQFIE5T
+      AOI0BSBOUwDiNAUgTlMA4rRLjUNbm/GLz/+V+7fX6fV/bzlu3sdEZW5pOa4smUsFcLT3jOls
+      xvk0o1ktgedRtIajwwM2P/pDLceVpXPpadDJZELkW44GE6oFnxk5yoWINMtYKZc1DSpLRePQ
+      4jRdBIvTFIA4TQGI0xSAOE0BiNMUgDhNAYjTFIA4TQGI0xSAOO1Sw3Cz6Yinz1/Q6axxej6h
+      XvBJiKiWi6RpSr1ev67zFLkWl5oFMibjYHeHsY0o/t5y3MO9Z9z9yZ/SKEVajitL5VIBDA73
+      2DkZsVot0x9NXy3HrZXzzFKPTS3HlSWjaVBxmi6CxWkKQJymAMRpCkCcpgDEaQpAnKYAxGkK
+      QJx2qVmg75oMB8yIKOUjjDEUCoWrOi+RG/EWAViOTvsYY9npn7J+94ECkKXzVi+BsllMkhrq
+      9RrT6fSqzknkxrzVLJC1BovH72Y/Pc/TLJAslSsdhvvuYlxjDL7/5icZa+33jk3/f37vJo+l
+      470/x3uri+Dv+u434Hne935TV+0mj6XjvT/Hu/JxaJFlcqXPANfp+fYjwnKLJ9884pOP7hKV
+      G6TTMX5gOTu9ICgVubPRZffZNqM4IZkkNNttzk8OWNu4RZJY7t7uXvq4vYMejXoDSHmxf8rW
+      rU3w4Li3y2A4JUtjqvUWw8EpjXaXJJ5x/+7thR77cOcxYz/Cp0DkpTRWVwl9j+FFn1ypyvnZ
+      KV4Qks6m5Es1CoHBz5WYz2IqKyWePHqEyZWYzRLWOy16h2e0V/IUuhuslkvff+B0xBe/3mEt
+      mhK1bxNaaFaLJPOM8XTC+ckZdz56QDoZsP28R6kQYIICJT8jMT52NqLS+ZCNtZXL/3nuP6ex
+      1uHkxQHlVotyFOB7hsdff8XcW2E2i9naWKN32KfVKHExNXzy8f2FHvuLL35Jd32T+koBPyqQ
+      L5ZIp2OGcUrEjHhuqJR9nuxO+YMHG5ycDQk+++yzzy79XbwDk3jO6GQfv1gni4f0Do7xIp/p
+      OKaYC/CNJapVSUZjWqs1gqjELEmornXYaDeJpwmVSvlSx7TW0u/3uRheMBj0CQh4sb9LvdVh
+      Ph2ztrqKF+WYJzNWak221jsk8ZRKpbLQ4yfThCQZcnY2IJ+LODzpM5qO2Xv6jCSZ4YU+NjUk
+      WYBJxjzb3SFLEuZhgXopz4yQYuhTKuWxfkir1aJaLJKFAcUo+v4Dm4SzwRiTZcwzQ29vj9Ra
+      siSm2W6Rzi2zZEouCqk0VjGZIfAhDCPW17skJmCz07z0R1+NSRkc7NCPMw6PR+TDlOPBy08Y
+      TrOIcs6jVChAGLLWamPSGe3uJrlwsZsq2XTIi7MJkDEZDzne26N3NmAyjYnCkDTLSONzcsUq
+      X/7q18yMXZ6XQEmSMJ/PCcOA4aBPWKxQLhUYn5+R+QWq5QJBLmL36TbFahOTTKlUyuwfHFOv
+      rXAxjLn34V0uc38qmQw5jw1hNsWEBUpRyMHxKffu3mZv5ylevkpoE1YqFfb2D2jUawwuRty9
+      d48o+L//csyTBHxLnGQM+mesr3eZxnPiUR8/X6FcyuFZiKdjpqlHjhnGz1OtVfHSmKc7e3Q2
+      NhmPJ+T9jMF4TiE0ZEGR2xud7z+wSZnGMzJjsWbOYBjTWmsQepaDkwGt1SZgmQwHnF5MaTcq
+      mDBP/7BHoVxhODynu/kB1XL+En+acHLYY6XZ4qS3R6W2hs1GJKbEaiVke2eX7vomw9GYvJ9x
+      Mc2IvDl+vsJmt7XQ4ydJwnQ6xc5j/GINz8wpRD690yHdVvPlF9mU/RfHbG122D84XZ4ARK6D
+      ZoHEaQpAnLY0d4FE3sY//O3fcOenf84/f/6f/OWffUq12WJ3b1/XAOKGX/7icw7292ludfEz
+      gzl7jm18oADEDefn56RpShiGDM+Oqay2wF7DYiyRZfLf50AhMm60paQAAAAASUVORK5CYII=
+    </thumbnail>
+    <thumbnail height='192' name='1b-running-total' width='192'>
       iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7DAAAOwwHHb6hk
       AAAUI0lEQVR4nO3d6W8k13nv8W9VdfW+L2x2kxySM9JsWmY0kmwrlmXHWeBrXMAJboLcANmB
       AEHyIkj+gMB/Q4AESIIAWZAgu5M4ie0siiNHu2eTRpqNw53s5tbdZK9VXVUnL8Ye2CKlkBou

--- a/skills/tableau-build/references/snippets/worksheets/table-calculations-attestation.twb
+++ b/skills/tableau-build/references/snippets/worksheets/table-calculations-attestation.twb
@@ -3071,9 +3071,39 @@
       </table>
       <simple-id uuid='{84416492-0E2A-43F7-B374-A657F29D227D}' />
     </worksheet>
+    <worksheet name='5-moving-average'>
+      <table>
+        <view>
+          <datasources>
+            <datasource name='Sample - Superstore' />
+          </datasources>
+          <datasource-dependencies datasource='Sample - Superstore'>
+            <column datatype='date' name='[Order Date]' role='dimension' type='ordinal' />
+            <column datatype='real' name='[Sales]' role='measure' type='quantitative' />
+            <column-instance column='[Order Date]' derivation='Month-Trunc' name='[tmn:Order Date:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Sales]' derivation='Sum' name='[win:sum:Sales:qk]' pivot='key' type='quantitative'>
+              <table-calc aggregation='Avg' from='-2' ordering-type='Rows' to='0' type='WindowTotal' window-options='IncludeCurrent' />
+            </column-instance>
+          </datasource-dependencies>
+          <aggregation value='true' />
+        </view>
+        <style />
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+          </pane>
+        </panes>
+        <rows>[Sample - Superstore].[win:sum:Sales:qk]</rows>
+        <cols>[Sample - Superstore].[tmn:Order Date:qk]</cols>
+      </table>
+      <simple-id uuid='{BA243906-9A2F-4A81-9D1A-45C2BC4D564E}' />
+    </worksheet>
   </worksheets>
   <windows source-height='30'>
-    <window class='worksheet' maximized='true' name='1a-total'>
+    <window class='worksheet' name='1a-total'>
       <cards>
         <edge name='left'>
           <strip size='160'>
@@ -3222,6 +3252,36 @@
         </highlight>
       </viewpoint>
       <simple-id uuid='{0319DC87-CCA9-46FC-91CA-B002CDF400B6}' />
+    </window>
+    <window class='worksheet' maximized='true' name='5-moving-average'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+          <strip size='31'>
+            <card type='title' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[Sample - Superstore].[yr:Order Date:ok]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+      <simple-id uuid='{74A8D00C-79DC-489A-B64C-420BD37B4C3D}' />
     </window>
   </windows>
   <thumbnails>
@@ -3980,6 +4040,137 @@
       zHkSvJSDwLMgAGhyGZyYQkrkwPBSvAeIGW3iOEDMSBMLIGakGYo9QExMV+h5/NlX38bTkxVk
       nvkCOEfGWJJBRTNjAcSMBjxJwaMYXLt2DWczHO4zFBIkGW+CY0YA10RhrwyXIMCyHDZ39g5O
       sWIBxIw0/x9ndMliRPQkGQAAAABJRU5ErkJggg==
+    </thumbnail>
+    <thumbnail height='192' name='5-moving-average' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7DAAAOwwHHb6hk
+      AAAax0lEQVR4nO3deXAc12Hn8W/PfR/AADO4CYoUT5EURYmURMqKZSuWrMiSZUW2196qpOyK
+      XeXNbrKpPfzP+p+tVGW31rVbieJKtrLrOFlXZCuWV5ItWVuSHFm8RYoSQYIgiWtwzQyOAeae
+      6e63f1BkSOIgBmgcg36fKv0hTKP7oTm/7tev36EIIQSSZFIWo3YkcyTVIsMCoOu6UbuSpFVj
+      W8xGd7q6K4piSGEkabUtKgBqKc/V+BgBp4XRqRwht4WSsOOzK+AK0NbUAMhqkFR7FhUAm9ND
+      wOdGLZep83vBouAWOpMTKZo6GxBCoOu6DIBUcxYVgHIhSzabo7m5mWy+RMClUBIOWlpa0TQN
+      i8WCEAKr1brS5ZUkQylGNYNqmiYDINUcw1qBJKkWyQBIpiYDIJmaDIBkajIAkqnJAEimJgMg
+      mZoMgGRqMgCSqckASKYmAyCZmgyAZGoyAJKpLao79HXp8QQT2TJ+p0JJ2An63FRUlfq6upUq
+      nyStqKoCUCqVSI4lsbdGUUSJno8vsnnvQ+i6LgfESDWpqvEA2ekJ4on0tTsAdkJeF6WKTnNT
+      VI4HkGqSHBAjmZp8CJZMTQZAMjUZAMnUZAAkU5MBkExNBkAyNRkAydRkACRTkwGQTE0GQDI1
+      GQDJ1GQAJFOTAZBMrarxAELXqGg6VouCQMHyydJIFovMkVSbqgpAfKCXsak8Eb+TsrDhVFTs
+      vggtsXpALpEk1Z6qAqAoCoouwObALiA7nSUSit1YIkmSak1VA2IqpTyTM0UCHhsV7LgdNjRN
+      w+VyyQExUk2SI8IkU5NPr5KpyQBIpiYDIJmaDIBkajIAkqnJAEimJgMgmZoMgGRqMgCSqckA
+      SKYmAyCZmgyAZGoyAJKpVTUeYGo8weX+ERrrfJSFnZDXQUXYaGlqXKnySdKKqioAofoITQUV
+      0HAJQbzvKh07D8glkqSaVdV4ALWUo6y4KU4nKWPH73FRUVVCwaAcDyDVJDkgRjI1+RAsmZoM
+      gGRqMgCSqckASKYmAyCZmgyAZGoyAOtcsazy2tEeyhVtrYuyIckArHNXhid563Qv3//JMQql
+      yloXZ8ORL8LWuZfe6WJTLIQQgjdOXOFff+kQIb9rrYu1Ycg7wDp3eWiSu1vrObizled/axf/
+      9R+OMjqRWetibRgyAOtYoVShomoEfU4Adm5q4JtP7efFn53i8tDkGpduY5ABWMcGE9N0RIMo
+      nyxEAtARC/GvnjvI3/3qHB9eGVvD0m0MMgDr2MWBcXZ1zh5r0Rj28m9feIhfHLvMsa74GpRs
+      45gzAAN9fbz56uuUb/u5WsrTPzjM9GSK5ESaQqFANptdhWKa0/X6/1wCXid//MKDvHOmn7OX
+      R1e5ZBvHnANiLHoBb6RpVjoG+vvQ7X6ms3mELhi6MkLb9n145IAYw5UrGoVSGa/bhqqqc25j
+      s8C3vrCf7790Ar/bwaZYcJVLWfvmDMD4+BDdH0xy34P7b9nAHwgwNDqJEnChYSfW0kIhm8ES
+      9CCEkM2gBuofm6GtMYjdtvCgvbqAje988QH++8sn+KPnD9EQ8q5SCTeGWWc3l06Rmipj9Vtn
+      fdjY1EZjU9sqFc3czvcl2dHRsKhto3U+fv+Je/mLn53ij3/3QQJe5wqXbmPoH03PfgbwhhrY
+      vnUTkXB4LcokfeJSfIK72+au/89lS2sdv/PQ3bz4yilK5bmrTNI/64lP8FevfjA7AEIIhMVJ
+      JT+DrNGvjVJZJVcoE/JV98b3vm3NHNjezF+/dgZNrto5r7OXR/nhGx/y77768OwAjF+9SDqb
+      R3V4ZADWSDw5Q3PEj8Wi3Hnj2zy2v5PGsJeX3u6SjRJzSKVzvPLeJf7j144Q8rlmByDU3Eyu
+      IDh88J7q5kyRDHO+L8nOTYur/99OURSe+9RO0tkSb5/pM7hkte9Y1xCP378Zn9sBzPEeIDM+
+      SWo8weRURt4B1sil+Djb2yNL/n2rReH3n9zHr88NoMu7wC0+uDTKPZujN/5/VgDCbZ1sbQoz
+      OJqg+huwtFzlisZMrkx9wL2s/TgdNuw2K/mC7EJ93VSmgMWi4Pc4bvxsVgAURaGi6ljKJeSp
+      W30j4xma6n1YrcvvpRILe0lMyTf1153pGePgjpZb+lbNeZZ37tnDAw8fQrYmr74LA6k5+/8s
+      xebmMH2jaUP2tRGc6h7mgZ0tt/xszgCc//A3vPyj1ymuSrGkm3UPjrOjY+n1/5u1R0P0jk4Z
+      sq9aly9VKJZVwrc1Lc/Z0NPRuZNMZQhRqoDTvioFlKCiakxnSzQEPYbsL1bnI5XOG7KvWnfm
+      0ii7Ohtvqf7APHeAq5d7mRob4fS586tSOOmaxFSOxrDXkPo/gN/joFzR5IB64NiFIR7a3Trr
+      53Oe6VDAwcDoDPv37Fzxgkn/7OLA+JLb/+cT8rmYzBQM3WetUTWd6WyR5nr/rM/mDIDTH6Gz
+      qR6HSz4Gr6aLAynD6v/XtUeDxJPThu6z1nR98mLx9uoPzDciTBN8+qnf5vbav1opMZWeoVIq
+      UiiV0TSNSkU2lhqhomqkM0XD6v/XdTaF6Dd5S9D75+M8uGt29QfmeQjOZhJ88PM+nnjhcW5+
+      Zh6OD6LbvaQnclSEBcp5fJEWmhrCCCHQZQesJesfTdNU70NRMPQ8dsaCvHnyqmn/bUoV7cbY
+      6rnOwZx3gECgDl9jYNZ7gIDfT2J0DAEogPhkFJjsdLV85/uS7Dao/f9mAa+TfKmCppkzAB/3
+      Jrh3a2zez+e8A9isdob6eylz68swfyjMzh1+XA4LmrBit1kRQsdisSCEwGKRY+yXqmdokiN7
+      O1bkHAY8TjKFCnXL7F5Ri051j/I7D90973mdFQAhBNlcnpaW5ll9gWx2JwH77fcFOQxyMWZy
+      JV585RRel536oIdo2Ec07KUx7MVhs5LJl6jzr8wXtLUxwGBi2nQBUDWdkfEMbY2BebeZFYD0
+      SC9Hz3Th80dkd2gDXehPsbkpzCP7OkilcyQmc5y7miA5lSWTL7PnruiS+v8vxqZYkIFEmn0L
+      VAU2oov9KTY3h+ds/blu1nc83HIXX/tKB2MjY+jIiYOM0tWf4tF9HcTqfMTqfNyzefWO3REL
+      cbp7ZPUOuE4cvzDEw/e0L7jNnN/vD08d5/SJE5w827UiBTMbXReMjM/QusCteCVFgh6SUzlT
+      jQ0QQtA/Ns229oXHVc8ZgMZImKxm5a52c90yV0o6W8TjsuO0r02l0mG71mBRLJlnsHzfaJr2
+      aADrHRoV5vx0eCzF5o426uoXPyuBNL+e+ARb55nhbbVE63wk07k1LcNqOnFhiPu3t9xxuzlm
+      hagQDIQpFGRnaKOcu5owrI//UnXEgvSOmKNrtBCCD6+MsWsR/armuCdbsSg6qi7kkEgD6Lpg
+      KDVDa8PsjlirqbMpxLHzQ2tahpVWLKsMpWbo6ksSq/PjsN+5iX5WABTFgi/gx5rKykHxBkhN
+      5/C5HWtW/7+uqc7P6MTGGh45mSlwOT5Bz9Akg2NpKppOU72P7e0RvvHUvQs2f143z9ygExTz
+      ecz58txY53uThvfwXIrrXSLKqobDVvsvLwcT0/zg56e5b1sz+7ZEeebwNnxux6K+9DebFYBK
+      6drI+Qqz5waVqtfVl+Lpw9vWuhjAtRBk8+UN8Ub46Pk4Tz+8jUPz9PJcrFkPwfn0OD0DIyi6
+      hhxHtDyqppNM52iJrG39/7rOWIi+DTJG+OPeJHu3LL+ZfnYzqNApFgoUy7cvjyFVKzmVoyHk
+      wb5OqhwdsSD9Y7U/NiCVzhH2u3A5ln9eZ9VyvHUxHv/sZwGLrAIt08WBFDsXOcX5amhrCPL+
+      x7W/pNKp7hH2bolVXd+fy6w7gM3hJBKJEInUzfpQCI2L3T2MDvXTFx9mamqSZGp82YXYqOZb
+      42utREIepjKFmu8Scap7hAPbmg3ZV1UX+aG+K6Rn8ni9bmxoXL3wEZ17H0KXSyTNoumC8ek8
+      9QHXvEscrQWb1UImV8Trqs3pbvLFCgoC/wJLR1WjqgBEYq1olnFsiqCCnS279lEuzGDxReQS
+      SbdJpGaIBD04Hevri3ZtrqACwdbabAk61zvCvq1N2O6wdNRiVbUXt8fLpk1yDarF6OpPGT7F
+      iRE2N9fRP5ZmS2vdWhdlSU5cGOIrj+02bH+yu/8KOd+XXNYU5ytlUyxYs9MlXp85r8nAZmXT
+      BkDXxYo9DJYrGhPTeaLh9Xe3jNb5SE7VZq/QiwPjbO+IYDGg9ec60wbglfe6eentlRnwMzKR
+      oaneb9gUh0byuR1UVL0mp0s81hXnwLYmQ/e5/v6FVsHkTIGzV8boHhxndCJj+P4/uppg9+b1
+      0/x5u5DPWXPTJQohiCdnuKvF2GcX0wVACMHLv77IFx/Zzguf3sVP3rlg+DG6B8cX1Rd9rbRH
+      Q8STM2tdjKr0j6VpbQhgM/iuaroAxJMzJNM59m6Jsb09gi4ElwaNe5l3fYnT+oCxUxwaaXNz
+      uOa6RJy4MMyB7ca8/LqZqQKgf3L1f+HTu7AoCoqi8KVP7eTlX1807IF4aDxDS0NgxaY4MUJr
+      Q4B4wtgJc195r5vXjvas2MvQj3uTK3JXNVUAugfGsVoVttxUj2xp8BOr9/HBpVFDjtHVl2Tv
+      XdE7b7iG6vwuJmYKhk2X2Dcyxfm+JBcHUpy9PGbIPm+WnMpRH3TjchjfO800AdB0nZ++e4Hn
+      H711zQNFUXj2yHZ+/ptuyuryW0bWwwD4O7FaLXREgwwYcBeoqBo/fPMcv/fEPr79zP384z9d
+      ZChl7PPF6Usj7L+7yZDOb7czTQBOd4/QHg3SNMciCWG/m3u3NvHu2f5lHaNYVskWyoT9rjtv
+      vMYe3N3K0fPL7xn6yxNXuHdrEy0NAXxuB3/w9H28+MopsgXjutOf6h5hnwF9/+diigCUKxqv
+      Hu3h2Ue2z7vNk4e28OtzA1X9w6mazthElvc+GuRvXj/Ln/2f91fsSmW07e0ReuITVJZx1xtO
+      zXCmZ5QnD2258bO2xiBffGQHL75yCtWAKlYmX8ZqUQh6V2axFlN0+X/3w37uu7uJoHf+K7Pb
+      aecz+zt57WgPX56nr8n12cZOXBhiIDFNrlCmIeShPRri8J52Whr8eGpkUUG7zUpbY5Ce+MSS
+      umzruuCHb5zj67+9d9aAnwPbmhlMTPOTd7r48mO7l3VBOHt51LC+/3PZ8AHIFcr807kBvvv1
+      I3fc9sjeDv7zj95jfDpP5KaVWnQhuByf4PVjl9GE4Lfu3cTnDm4h4HGu69aeO3n4njZ+89Hg
+      kgLwq1NX2dwcZnNTaM7Pnzm8nb/42UmOdg3x8O62JZfx5MVhvvqZe5b8+3dSVRWoXMwzMTVN
+      qZAjmy9SqaiU1/nQyVeP9vDYfZ2LujLbrBaeObztxssxTdf54NIIf/p3v+HtM/186dGd/MkL
+      D3JgWzMhn6umv/wAW1vr6BtNV90tIpXO8f75OM8+sn3eK7PFovCNp/bzq5NXl/zOoVzRSGeL
+      xOp9S/r9xajqDlApF+ntHyIS9KIJKOcyhJs2Ea23IYRA09ZX/5KpTJGu/iTPHjmy6LLt2tTA
+      L49f5hfHL3O8a4jmiI/fe2LvjY5tG2mpIYsCOzdFuNCf5J4qum78719+yFce24XNoix4Xh02
+      C3/w9H7+x8sn+fdffZiAx7HoY0znSvz9W+d5YEczQtdXbIKGqgKgqRpC09B1DU1YcTjsqKp6
+      4yqwnh7+8qUKf/6zU3zts3uqGpSuKPAvP7eP33w0yB8+98CGmEJkIYf3tPPGiSvsWeS7i/c+
+      GiQS9Cy6q3eszsfXH9/Dn/34ffZtifHEwS343PMHoVBSef1YD139Kb5weDt774qykl8rRVTx
+      6k6tlCmrOg6bBR0LVosFIXRsNhuapq2bEWEVVeO/vXScR/d1cHDn8uaN2eiEEPyn//Uu3/3a
+      kTu+aEpni/yXHx/lu18/jNe1+Ks5QKmi8v7Hcd77aJCWiJ/PP7j1libpiqrx/sdx3j7bx5F7
+      2vnUvZtWZQKvqgKwkPUSAE3T+evXztARDfLEoa1rXZya8A9vd7EpFuLgzvlnU1Y1ne+/dJzH
+      79+8rPl4NF3n494krx+7jM/t4MlDWyiWVX767kXubqvjmSPbqw7XcmyoAAgheOmdC2i6zleW
+      2fxmJoOJaV56p4s/+fJD827z4//3MW6XnS88vM2Q86oLwcDYNK8f68Fpt/Lcp3auSXVzwzSD
+      CiF463QvEzN5vvX0Afnlr0JbY4B0tki2UJ6zfn7y4jDD4xn+zfOHDDuvFkWhsynEd774gCH7
+      W3I51vToBjp5cYQzPaN886n9Nd88udoURWH/3U2cvTy7Q+DIeIZXj/bwrS8cMLwv/nqwIf6i
+      7sFxXj/ewx8+d3DdTENYax7Z28HJi8O3dGcullV+8H9P842n7l2w5aaW1XwAEpNZ/vbNc/zR
+      84fw1OhkT+tBJOihUFLJ5K+92BRC8De/OMtn7ttMR3Tut70bQc0H4K3TvTz/6C7CK7TItJnc
+      t62Z05euLaf6xsmreJx2juxZeJnRWlfTARBC0Ds6xebmjXuFWk0PbG/m6Pk4lwbHOd19rQ/O
+      Rm9MqOkAlCoaQrBgL09p8eqDHgTwP18/y7efuX9Ra2zVuppuBh1MTNPeGFzrYmwozz+6E6tF
+      uaU37EZW0wHo6k/dcSVwqTrrcTrHlVTTVaArQxOGT5QkmUvNBkDVdLKFCo0hc9yqpZVRswFI
+      TGZpDHs3fCuFtLKqegbITI1zqX+Uep+dorATcFnRbR7amld/Hszzfalb5veRpKWo7iHYYqG9
+      rZVibga30EmOjdCydc+aLJHUEx/n8w9uXVfLD0m1p6oAqJUK6XSeaCRARdiJxZpQVRWLxbKq
+      SyRdW3+rQHs0tCE7aEmrp6oAhCNRwuuglSydLeJ12+WXX1q2mvwGXRocl/V/yRC1GYD4hOle
+      2Egro+YCIIRgKDnD5ubwWhdF2gBqLgC5YgVFYUWmypbMp+YC0DsyRUdUdoCTjFFzAegeHGdH
+      x/pdf0uqLesmAEIITlwYRtfnf5kmhKBvNM3WNtkCJBlj3QQA4OrwJK8e7Zn381JFI1csywEw
+      kmHWTQAUReF3P72LS4PjfNAz93pdw6kZouGVmylYMp91EwC4Nj35t585wE/fvUA8OXv9qstD
+      k+xewlz2kjSfdRUAAL/HyXeevZ8f/Pz0rOWKLsXH2dEhX4BJxll3AQBoaQjw/KO7+PN/PHlj
+      nSlV00lO5WmQA2AkA63LAADs3RJlR0eEH715DoDx6Twhn1MOgJEMVdXs0PnsNLmSwKIVKAkb
+      Aa8bVVUJhUIrMju0rgv+6tUP2NERQVEUsoUyT8opzyUDVRUAXddIJFJoagUhBMmhfjbdc5Cw
+      146maStydS6rGn/69++jaoJvfn4f7fItsGSgqgIwM5Wip3eESJ2XCnZCHiclTaG1Obqi6wNM
+      zOT5y1dO8x/+xWE5BkAyVM0skCGEkPV/yXA1czmVX35pJdRMACRpJcgASKYmAyCZmgyAZGoy
+      AJKpyQBIpiYDIJmaDIBkajIAkqnJAEimtqTZpfKZNGXseJx2dF3H5ZKD1KXatIQACJITU+i6
+      YGBqgljnNhkAqWYtqQqklYuUVJ1QKEixUDC6TJK0apbUHVoIHSEUrnfQVBRlxbtDS9JKMGQ8
+      wO3LI+m6jsUy981loX79S/lsoWMt9Ht3Gl+w0O/B3N2zF/psqfuE9XM+jT7Wco5n1DENmWL5
+      9j9AUZQFv5RGWs1jwZ2/rCthI59PRVFu/Leax7z+Nxo2IkySatG6n2R/sLcbm7eBq5e72bG1
+      E7s3hFrIY7EKJidmsHrcdDTHiPf3kiuWKOZL1DU0Mj0xRn1zO+WSTmd7rPoDV/IMTWSJhIOM
+      DY3S0Np07WSpJbovX8Hh8lIqa0TrfUzMFHCLCrG7d+Nd5Bk9feIYocZmYnV+yroVj9eNqJSZ
+      msnjdV6bAcPjdhAfmWDr1k4mJ6aoD/spq1DMTpGYmsFSqeAKhBDlDIozRKVUZPu2LQset6fr
+      Q+qaO+juvsKWjhi+YIRSqYBQS0zP5HF6fbRE6+m9coVCWUUtl6iPtZBKjNEUbSA5OcPe3Tuq
+      P5/5cQZyLqJ+O4nRMRqbY1gAtZjjwtVBwj4XRc1CyGMjV9Kwigp2XwMdLYubCfz48WPEmloI
+      +VxY7C6cbg9qIUemqGKnTLGi4/dauBovsGtbM+OTM4T9Lqzf+973vlf9X7N68sUK2fFhLO4Q
+      WjHD6NgEik2hkCvicVix6AJ7MEAplyNSH8Jq91IuFwlEYjQ3hikWSvj93qqPq5YLJMZGyBRK
+      ZDIVFL3AdK6M3+0Ahw+bouNy2LA67DRGm/DYFSxuP45F1h50tUx8bBwFQb6QJTOeYHQ0STqX
+      R1jsCF1FrxRwurxc6fqIdLFCsVAgGotSLuSpb4ig6VYUUcbu9NHW1oKulvH5/Qset6xpJOJD
+      BOpC5NNTjA0ncIT85GcK2G0WFAHeoJ98rkgo6MHncZNXoaGhEbuiUxdpxOV0VH0+S9k0A8kp
+      ivkMug6lwjT5oo7LacXrC6HrGg6rBbvNRmNTM8VihdbWJiyLrBpphQwjk3lAI5/LkBoaYnQy
+      Ta5QxG6zoWoaanEahzvAh2fOUdIFarm4/qtApVKJSqWCzWYlk57C5vbj9bjIT0+iKi4CPhdW
+      h514Xy/uQB16qYDf72V4LEUo6GMmU2Tzlk6qbZ8aGxmmLtLA6NgYdeEIhewETn8jDooMjiRp
+      boqSL6ropRkqihO9lMMdqCcaWdzSTaVSiUKhgBWVMk4cFoHL5WB4NEUs1ogCIHQSiQSNsRhj
+      owmisRhul5PE8CBFYcfnUHB5A4yOxPEHwqTTU7RtuguPc/7b0M3nc2pyEo/Xj8fnJZ1KYHMH
+      8bps2G0Wrvb2EW6IUszl8HkcjE3MEHTbKWgWNrW3UG2NfXh4iIb6OkaSkzRG6plIjtLQsolK
+      bpKR1AwtsTqKqoXCdBKb00smk6Eh1kI4sLiL1/XzKSpFLO4gil7BZbcwOpEh1vDJdPpCZXgk
+      RWtLlOGxCZpjDes/AJK0kmRfIMnUZAAkU1v3rUCStFxv/fRvad9/hPeOnuVzh/cSqGsgPjRM
+      JZ2SzwDSxnfs/aPXGjVaYlg0HX0yjgh3MDwoAyCZwPT0NKqqYrPZyEym8Nc3gABdyDfBksn9
+      f0vz4uRuODDSAAAAAElFTkSuQmCC
     </thumbnail>
   </thumbnails>
 </workbook>

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -420,18 +420,23 @@ def aggregate_calculated_fields(calculated: dict[str, CalculatedField]) -> froze
 #: are cosmetic identifiers - ``cum:sum:revenue:qk`` is what Tableau writes for a running
 #: total, and ``manifest.TABLE_CALCS`` reads this table so an unknown type fails validation
 #: rather than rendering a calc Tableau does not have.
-#: Seven of the eight are attested - read off Desktop-saved workbooks. The verbatim XML and
-#: its provenance is in ``references/snippets/worksheets/TABLE-CALCS.md``; the workbook most
-#: of them come from is vendored beside it. Note the percent family abbreviates to ``pc`` plus
-#: two letters - four characters, never the ``pct`` + verb shape guesswork reaches for first.
-#: ponytail: ``WindowTotal`` is the one guess left. It is in the XSD but appears in none of
-#: the 196 workbooks swept, and no Quick-Table-Calculation entry produces it - Desktop's
-#: ``TOTAL(SUM([x]))`` is a *calculated field* whose ``<table-calc>`` carries only
-#: ``ordering-type`` and whose instance keeps the plain ``usr`` prefix. A wrong prefix costs a
-#: rewrite on open, not a refused workbook - issue #50 has the remaining step.
+#: All eight are attested - read off Desktop-saved workbooks, none inferred. The verbatim XML
+#: and its provenance is in ``references/snippets/worksheets/TABLE-CALCS.md``; the workbook
+#: six of them come from is vendored beside it.
+#:
+#: Four of the seven originally guessed were wrong, so do not extend this table by analogy.
+#: A long type name is squeezed to four characters and the vowels go first (``PctDiff`` ->
+#: ``pcdf``, ``PctValue`` -> ``pcva``, ``PctRank`` -> ``pcrk``); a short one passes through
+#: (``cum``, ``diff``, ``rank``); ``WindowTotal`` becomes ``win``. Read a new one off Desktop.
+#:
+#: This table covers only the calculations applied through *Add Table Calculation*, which are
+#: the ones that write a ``type`` and take a prefix. A table calc written as a **formula** -
+#: ``TOTAL(...)``, ``WINDOW_SUM(...)`` - is a calculated field: its ``<table-calc>`` carries
+#: addressing only, with no ``type``, and the instance keeps the plain ``usr`` prefix. Both
+#: are table calculations; only the dialog-driven ones reach this table.
 TABLE_CALC_PREFIXES: dict[str, str] = {
     "CumTotal": "cum",          # attested
-    "WindowTotal": "wnd",       # INFERRED - the last guess in this table
+    "WindowTotal": "win",       # attested - not "wnd"; written by Moving Calculation
     "Difference": "diff",       # attested
     "PctDiff": "pcdf",          # attested - not "pctdiff"
     "PctValue": "pcva",         # attested - not "pctval"

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -420,19 +420,21 @@ def aggregate_calculated_fields(calculated: dict[str, CalculatedField]) -> froze
 #: are cosmetic identifiers - ``cum:sum:revenue:qk`` is what Tableau writes for a running
 #: total, and ``manifest.TABLE_CALCS`` reads this table so an unknown type fails validation
 #: rather than rendering a calc Tableau does not have.
-#: Four of the eight are attested - read off Desktop-saved workbooks, see
-#: ``references/snippets/worksheets/TABLE-CALCS.md`` for the verbatim XML and its provenance.
-#: ponytail: the other four stay inferred until a workbook using them turns up. A wrong
-#: prefix costs a rewrite on open, not a refused workbook - issue #50 carries the steps.
+#: Seven of the eight are attested - read off Desktop-saved workbooks. The verbatim XML and
+#: its provenance is in ``references/snippets/worksheets/TABLE-CALCS.md``; the workbook four
+#: of them come from is vendored beside it. Note the percent family abbreviates to ``pc`` plus
+#: two letters - four characters, never the ``pct`` + verb shape guesswork reaches for first.
+#: ponytail: ``WindowTotal`` is the one guess left, and the only one nothing has settled. A
+#: wrong prefix costs a rewrite on open, not a refused workbook - issue #50 has the steps.
 TABLE_CALC_PREFIXES: dict[str, str] = {
     "CumTotal": "cum",          # attested
-    "WindowTotal": "wnd",       # inferred
-    "Difference": "diff",       # inferred
-    "PctDiff": "pcdf",          # attested - not "pctdiff", which is what we guessed
-    "PctValue": "pctval",       # inferred
+    "WindowTotal": "wnd",       # INFERRED - the last guess in this table
+    "Difference": "diff",       # attested
+    "PctDiff": "pcdf",          # attested - not "pctdiff"
+    "PctValue": "pcva",         # attested - not "pctval"
     "PctTotal": "pcto",         # attested
     "Rank": "rank",             # attested
-    "PctRank": "pctrank",       # inferred
+    "PctRank": "pcrk",          # attested - not "pctrank"
 }
 
 #: How a table calc walks the view. ``Rows`` is Tableau's default "Table (across)" addressing

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -420,19 +420,19 @@ def aggregate_calculated_fields(calculated: dict[str, CalculatedField]) -> froze
 #: are cosmetic identifiers - ``cum:sum:revenue:qk`` is what Tableau writes for a running
 #: total, and ``manifest.TABLE_CALCS`` reads this table so an unknown type fails validation
 #: rather than rendering a calc Tableau does not have.
-#: ponytail: only ``PctTotal`` -> ``pcto`` is attested (Desktop 2025.1 renamed ours on save).
-#: The rest are inferred; a wrong one costs nothing but a rewrite on open, and is fixed by
-#: reading the name out of a Desktop-saved workbook that uses that calc - issue #50 carries
-#: the exact sheet-by-sheet steps.
+#: Four of the eight are attested - read off Desktop-saved workbooks, see
+#: ``references/snippets/worksheets/TABLE-CALCS.md`` for the verbatim XML and its provenance.
+#: ponytail: the other four stay inferred until a workbook using them turns up. A wrong
+#: prefix costs a rewrite on open, not a refused workbook - issue #50 carries the steps.
 TABLE_CALC_PREFIXES: dict[str, str] = {
-    "CumTotal": "cum",
-    "WindowTotal": "wnd",
-    "Difference": "diff",
-    "PctDiff": "pctdiff",
-    "PctValue": "pctval",
-    "PctTotal": "pcto",
-    "Rank": "rank",
-    "PctRank": "pctrank",
+    "CumTotal": "cum",          # attested
+    "WindowTotal": "wnd",       # inferred
+    "Difference": "diff",       # inferred
+    "PctDiff": "pcdf",          # attested - not "pctdiff", which is what we guessed
+    "PctValue": "pctval",       # inferred
+    "PctTotal": "pcto",         # attested
+    "Rank": "rank",             # attested
+    "PctRank": "pctrank",       # inferred
 }
 
 #: How a table calc walks the view. ``Rows`` is Tableau's default "Table (across)" addressing

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -422,7 +422,7 @@ def aggregate_calculated_fields(calculated: dict[str, CalculatedField]) -> froze
 #: rather than rendering a calc Tableau does not have.
 #: All eight are attested - read off Desktop-saved workbooks, none inferred. The verbatim XML
 #: and its provenance is in ``references/snippets/worksheets/TABLE-CALCS.md``; the workbook
-#: six of them come from is vendored beside it.
+#: five of them come from is vendored beside it, and a corpus sweep supplies the other three.
 #:
 #: Four of the seven originally guessed were wrong, so do not extend this table by analogy.
 #: A long type name is squeezed to four characters and the vowels go first (``PctDiff`` ->
@@ -434,9 +434,11 @@ def aggregate_calculated_fields(calculated: dict[str, CalculatedField]) -> froze
 #: ``TOTAL(...)``, ``WINDOW_SUM(...)`` - is a calculated field: its ``<table-calc>`` carries
 #: addressing only, with no ``type``, and the instance keeps the plain ``usr`` prefix. Both
 #: are table calculations; only the dialog-driven ones reach this table.
+#: ponytail: the builder emits neither ``<table-calc>`` on the formula path, so Desktop infers
+#: the addressing and rewrites the file on open - issue #85, not this table's problem.
 TABLE_CALC_PREFIXES: dict[str, str] = {
     "CumTotal": "cum",          # attested
-    "WindowTotal": "win",       # attested - not "wnd"; written by Moving Calculation
+    "WindowTotal": "win",       # attested - not "wnd"; the type Moving Calculation writes
     "Difference": "diff",       # attested
     "PctDiff": "pcdf",          # attested - not "pctdiff"
     "PctValue": "pcva",         # attested - not "pctval"
@@ -1361,9 +1363,15 @@ def render_column_instance(parent: ET.Element, reference: FieldRef) -> None:
     if reference.table_calc:
         # A table calc is a property of the instance: the same measure can be plain on one
         # shelf and a running total on another.
-        # No 'aggregation': Desktop 2025.1 strips it on save (the aggregation is already the
-        # instance's own 'derivation'), and a workbook it rewrites on open is one whose calc
-        # may not be the calc that was asked for.
+        #
+        # Addressing and type only. Desktop writes more than this, and what it writes varies
+        # by type - 'aggregation' on CumTotal/WindowTotal (but not PctTotal, where 2025.1
+        # strips it), 'diff-options' plus an <address> on Difference/PctDiff/PctValue,
+        # 'rank-options' on Rank/PctRank, 'from'/'to'/'window-options' on WindowTotal. All are
+        # optional per the XSD, so both validators pass without them, but the omission means
+        # the *options* of a calculation are not expressible from a manifest: a WindowTotal
+        # renders an unbounded window, not a moving average, and a Difference has no "relative
+        # to previous" target. Attested in references/snippets/worksheets/ - issue #85.
         ET.SubElement(instance, "table-calc", {
             "ordering-type": TABLE_CALC_ORDERING,
             "type": reference.table_calc,

--- a/skills/tableau-build/scripts/worksheet.py
+++ b/skills/tableau-build/scripts/worksheet.py
@@ -416,16 +416,19 @@ def aggregate_calculated_fields(calculated: dict[str, CalculatedField]) -> froze
 
 
 #: manifest ``table_calc`` -> the column-instance name's extra prefix. The keys are the
-#: XSD's ``TCType-ST`` enumeration (minus ``None``, which is "no table calc"); the prefixes
+#: XSD's ``TCType-ST`` enumeration minus ``None`` ("no table calc") and ``Custom``; the prefixes
 #: are cosmetic identifiers - ``cum:sum:revenue:qk`` is what Tableau writes for a running
 #: total, and ``manifest.TABLE_CALCS`` reads this table so an unknown type fails validation
 #: rather than rendering a calc Tableau does not have.
 #: Seven of the eight are attested - read off Desktop-saved workbooks. The verbatim XML and
-#: its provenance is in ``references/snippets/worksheets/TABLE-CALCS.md``; the workbook four
+#: its provenance is in ``references/snippets/worksheets/TABLE-CALCS.md``; the workbook most
 #: of them come from is vendored beside it. Note the percent family abbreviates to ``pc`` plus
 #: two letters - four characters, never the ``pct`` + verb shape guesswork reaches for first.
-#: ponytail: ``WindowTotal`` is the one guess left, and the only one nothing has settled. A
-#: wrong prefix costs a rewrite on open, not a refused workbook - issue #50 has the steps.
+#: ponytail: ``WindowTotal`` is the one guess left. It is in the XSD but appears in none of
+#: the 196 workbooks swept, and no Quick-Table-Calculation entry produces it - Desktop's
+#: ``TOTAL(SUM([x]))`` is a *calculated field* whose ``<table-calc>`` carries only
+#: ``ordering-type`` and whose instance keeps the plain ``usr`` prefix. A wrong prefix costs a
+#: rewrite on open, not a refused workbook - issue #50 has the remaining step.
 TABLE_CALC_PREFIXES: dict[str, str] = {
     "CumTotal": "cum",          # attested
     "WindowTotal": "wnd",       # INFERRED - the last guess in this table

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -322,6 +322,36 @@ def test_an_unknown_table_calc_is_rejected():
     assert any("CumAvg" in error for error in _errors(worksheets=sheets))
 
 
+# One row per TCType-ST value. Do NOT derive the expected prefix from TABLE_CALC_PREFIXES -
+# a test that reads its expectation out of the table under test cannot fail, and a wrong
+# prefix in that table is exactly the defect (issue #50: 'pctdiff' should have been 'pcdf').
+# 'attested' rows are copied from Desktop-saved workbooks; see
+# skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md for the XML and source.
+@pytest.mark.parametrize("table_calc,prefix", [
+    ("CumTotal", "cum"),        # attested: FINANCIAL SERVICES - Trading.twbx, 2023.3.0
+    ("PctDiff", "pcdf"),        # attested: appsfortableau HierarchyFilter demo, 2024.3.0
+    ("PctTotal", "pcto"),       # attested: lavi_webpage_test.twbx, 2025.2.0
+    ("Rank", "rank"),           # attested: Embedded Filters Test.twbx, 2024.2.10
+    ("WindowTotal", "wnd"),     # inferred - no Desktop workbook uses it yet
+    ("Difference", "diff"),     # inferred
+    ("PctValue", "pctval"),     # inferred
+    ("PctRank", "pctrank"),     # inferred
+])
+def test_table_calc_instance_name_prefix(table_calc, prefix):
+    """The prefix Tableau puts on the instance name, per calculation type.
+
+    Rendered through :class:`worksheet.FieldRef` rather than asserted on the table so the
+    nesting rule is covered too: the calc prefix goes *outside* the aggregation prefix.
+    """
+    entry = worksheet.FieldRef(
+        field_name="revenue", datatype="real", role="measure",
+        column_type="quantitative", instance_type="quantitative",
+        prefix="sum", derivation="Sum", table_calc=table_calc,
+    )
+
+    assert entry.instance_name == f"[{prefix}:sum:revenue:qk]"
+
+
 # --- Reference lines (AC #1) ---------------------------------------------------
 
 def test_a_reference_line_is_a_pane_child_with_qualified_columns():

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -322,20 +322,37 @@ def test_an_unknown_table_calc_is_rejected():
     assert any("CumAvg" in error for error in _errors(worksheets=sheets))
 
 
+#: The Desktop-authored workbook that settles four of the eight prefixes - see
+#: skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md.
+_ATTESTATION_TWB = (
+    Path(__file__).resolve().parent.parent
+    / "skills/tableau-build/references/snippets/worksheets"
+    / "table-calculations-attestation.twb"
+)
+
+
+def _field_ref(table_calc, field_name="revenue"):
+    """A minimal measure FieldRef carrying ``table_calc``, for naming assertions."""
+    return worksheet.FieldRef(
+        field_name=field_name, datatype="real", role="measure",
+        column_type="quantitative", instance_type="quantitative",
+        prefix="sum", derivation="Sum", table_calc=table_calc,
+    )
+
+
 # One row per TCType-ST value. Do NOT derive the expected prefix from TABLE_CALC_PREFIXES -
 # a test that reads its expectation out of the table under test cannot fail, and a wrong
-# prefix in that table is exactly the defect (issue #50: 'pctdiff' should have been 'pcdf').
-# 'attested' rows are copied from Desktop-saved workbooks; see
-# skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md for the XML and source.
+# prefix in that table is exactly the defect: of the five originally guessed, 'pctdiff',
+# 'pctval' and 'pctrank' were all wrong. The percent family is 'pc' + two letters.
 @pytest.mark.parametrize("table_calc,prefix", [
-    ("CumTotal", "cum"),        # attested: FINANCIAL SERVICES - Trading.twbx, 2023.3.0
+    ("CumTotal", "cum"),        # attested: table-calculations-attestation.twb, 2025.1.10
+    ("Difference", "diff"),     # attested: table-calculations-attestation.twb, 2025.1.10
+    ("PctValue", "pcva"),       # attested: table-calculations-attestation.twb, 2025.1.10
+    ("PctRank", "pcrk"),        # attested: table-calculations-attestation.twb, 2025.1.10
     ("PctDiff", "pcdf"),        # attested: appsfortableau HierarchyFilter demo, 2024.3.0
     ("PctTotal", "pcto"),       # attested: lavi_webpage_test.twbx, 2025.2.0
     ("Rank", "rank"),           # attested: Embedded Filters Test.twbx, 2024.2.10
-    ("WindowTotal", "wnd"),     # inferred - no Desktop workbook uses it yet
-    ("Difference", "diff"),     # inferred
-    ("PctValue", "pctval"),     # inferred
-    ("PctRank", "pctrank"),     # inferred
+    ("WindowTotal", "wnd"),     # INFERRED - no Desktop workbook checked uses it
 ])
 def test_table_calc_instance_name_prefix(table_calc, prefix):
     """The prefix Tableau puts on the instance name, per calculation type.
@@ -343,13 +360,63 @@ def test_table_calc_instance_name_prefix(table_calc, prefix):
     Rendered through :class:`worksheet.FieldRef` rather than asserted on the table so the
     nesting rule is covered too: the calc prefix goes *outside* the aggregation prefix.
     """
-    entry = worksheet.FieldRef(
-        field_name="revenue", datatype="real", role="measure",
-        column_type="quantitative", instance_type="quantitative",
-        prefix="sum", derivation="Sum", table_calc=table_calc,
-    )
+    assert _field_ref(table_calc).instance_name == f"[{prefix}:sum:revenue:qk]"
 
-    assert entry.instance_name == f"[{prefix}:sum:revenue:qk]"
+
+def test_the_attested_prefixes_match_desktops_own_output():
+    """The attestation, enforced: rebuild each sheet's shelf and compare to what Desktop
+    wrote.
+
+    The parametrize list above is hand-transcribed, so it pins the table but not the truth -
+    a typo there and in TABLE_CALC_PREFIXES would agree with each other. This reads the
+    reference workbook instead, so the four types it covers cannot drift silently.
+    """
+    workbook = ET.parse(_ATTESTATION_TWB).getroot()
+    sheets = workbook.findall("worksheets/worksheet")
+    assert [sheet.get("name") for sheet in sheets] == [
+        "1-total", "2-difference", "3-percent-from", "4-percentile",
+    ], "the reference workbook changed - re-read TABLE-CALCS.md before touching this test"
+
+    checked = {}
+    for sheet in sheets:
+        instances = [
+            instance
+            for instance in sheet.findall("table/view/datasource-dependencies/column-instance")
+            if instance.find("table-calc") is not None
+        ]
+        # One calculation per sheet is the whole design of the reference workbook; two would
+        # mean the sheet no longer isolates a single type.
+        assert len(instances) == 1, f"{sheet.get('name')} carries {len(instances)} table calcs"
+
+        table_calc = instances[0].find("table-calc").get("type")
+        rows = sheet.findtext("table/rows")
+        checked[table_calc] = instances[0].get("name")
+
+        # The field is Sales here, and <rows> qualifies the name with the datasource id, so
+        # compare the bracketed tail rather than the whole shelf.
+        expected = _field_ref(table_calc, "Sales").instance_name
+        assert rows.endswith(expected), (
+            f"{sheet.get('name')}: Desktop wrote {rows}, we build {expected}"
+        )
+
+    assert checked == {
+        "CumTotal": "[cum:sum:Sales:qk]",
+        "Difference": "[diff:sum:Sales:qk]",
+        "PctValue": "[pcva:sum:Sales:qk]",
+        "PctRank": "[pcrk:sum:Sales:qk]",
+    }
+
+
+def test_the_prefix_table_holds_exactly_the_documented_types():
+    """Adding a ninth type must not skip the attestation.
+
+    The parametrize list above covers today's eight keys, but nothing makes a *new* key grow
+    a row - it would ship un-pinned and un-attested. This is the guard that notices.
+    """
+    assert set(worksheet.TABLE_CALC_PREFIXES) == {
+        "CumTotal", "WindowTotal", "Difference", "PctDiff",
+        "PctValue", "PctTotal", "Rank", "PctRank",
+    }
 
 
 # --- Reference lines (AC #1) ---------------------------------------------------

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -331,6 +331,36 @@ _ATTESTATION_TWB = (
 )
 
 
+def _attested_sheets():
+    """dict: sheet name -> (``<table-calc>`` type or None, instance name, the <rows> shelf).
+
+    Reads the vendored Desktop workbook. Sheet names are asserted here so a re-authored
+    reference fails loudly instead of silently checking fewer types than it looks like.
+    """
+    workbook = ET.parse(_ATTESTATION_TWB).getroot()
+    sheets = workbook.findall("worksheets/worksheet")
+    assert [sheet.get("name") for sheet in sheets] == [
+        "1a-total", "1b-running-total", "2-difference", "3-percent-from", "4-percentile",
+    ], "the reference workbook changed - re-read TABLE-CALCS.md before touching this test"
+
+    read = {}
+    for sheet in sheets:
+        instances = [
+            instance
+            for instance in sheet.findall("table/view/datasource-dependencies/column-instance")
+            if instance.find("table-calc") is not None
+        ]
+        # One calculation per sheet is the whole design of the reference workbook; two would
+        # mean the sheet no longer isolates a single type.
+        assert len(instances) == 1, f"{sheet.get('name')} carries {len(instances)} table calcs"
+        read[sheet.get("name")] = (
+            instances[0].find("table-calc").get("type"),
+            instances[0].get("name"),
+            sheet.findtext("table/rows"),
+        )
+    return read
+
+
 def _field_ref(table_calc, field_name="revenue"):
     """A minimal measure FieldRef carrying ``table_calc``, for naming assertions."""
     return worksheet.FieldRef(
@@ -371,40 +401,47 @@ def test_the_attested_prefixes_match_desktops_own_output():
     a typo there and in TABLE_CALC_PREFIXES would agree with each other. This reads the
     reference workbook instead, so the four types it covers cannot drift silently.
     """
-    workbook = ET.parse(_ATTESTATION_TWB).getroot()
-    sheets = workbook.findall("worksheets/worksheet")
-    assert [sheet.get("name") for sheet in sheets] == [
-        "1-total", "2-difference", "3-percent-from", "4-percentile",
-    ], "the reference workbook changed - re-read TABLE-CALCS.md before touching this test"
+    checked = dict(_attested_sheets())
+    # '1a-total' is excluded on purpose - see
+    # test_a_total_table_calc_is_a_calculated_field_with_no_type.
+    checked.pop("1a-total")
 
-    checked = {}
-    for sheet in sheets:
-        instances = [
-            instance
-            for instance in sheet.findall("table/view/datasource-dependencies/column-instance")
-            if instance.find("table-calc") is not None
-        ]
-        # One calculation per sheet is the whole design of the reference workbook; two would
-        # mean the sheet no longer isolates a single type.
-        assert len(instances) == 1, f"{sheet.get('name')} carries {len(instances)} table calcs"
-
-        table_calc = instances[0].find("table-calc").get("type")
-        rows = sheet.findtext("table/rows")
-        checked[table_calc] = instances[0].get("name")
-
+    for sheet_name, (table_calc, instance_name, rows) in checked.items():
         # The field is Sales here, and <rows> qualifies the name with the datasource id, so
         # compare the bracketed tail rather than the whole shelf.
         expected = _field_ref(table_calc, "Sales").instance_name
+        assert instance_name == expected, f"{sheet_name}: Desktop wrote {instance_name}"
         assert rows.endswith(expected), (
-            f"{sheet.get('name')}: Desktop wrote {rows}, we build {expected}"
+            f"{sheet_name}: Desktop wrote {rows}, we build {expected}"
         )
 
-    assert checked == {
-        "CumTotal": "[cum:sum:Sales:qk]",
-        "Difference": "[diff:sum:Sales:qk]",
-        "PctValue": "[pcva:sum:Sales:qk]",
-        "PctRank": "[pcrk:sum:Sales:qk]",
+    assert {name: pair[:2] for name, pair in checked.items()} == {
+        "1b-running-total": ("CumTotal", "[cum:sum:Sales:qk]"),
+        "2-difference": ("Difference", "[diff:sum:Sales:qk]"),
+        "3-percent-from": ("PctValue", "[pcva:sum:Sales:qk]"),
+        "4-percentile": ("PctRank", "[pcrk:sum:Sales:qk]"),
     }
+
+
+def test_a_total_table_calc_is_a_calculated_field_with_no_type():
+    """Desktop has no *type* for a window total - so neither should a manifest.
+
+    Sheet '1a-total' is ``TOTAL(SUM([Sales]))`` applied through the UI. Desktop authored it as
+    a **calculated field**: the ``<table-calc>`` carries only ``ordering-type``, with no
+    ``type`` attribute, and the instance keeps the ordinary ``usr`` prefix rather than gaining
+    a table-calc one. That is why ``WindowTotal`` is still the unattested row - the Quick
+    Table Calculation menu has no entry that writes it, and this is what "Total" does instead.
+    """
+    table_calc, instance_name, rows = _attested_sheets()["1a-total"]
+
+    assert table_calc is None, f"Desktop grew a type for TOTAL(): {table_calc}"
+    assert instance_name.startswith("[usr:"), instance_name
+    assert rows.endswith(instance_name)
+    # No prefix from our table appears in a name Desktop wrote for a window total.
+    assert not any(
+        instance_name.startswith(f"[{prefix}:")
+        for prefix in worksheet.TABLE_CALC_PREFIXES.values()
+    )
 
 
 def test_the_prefix_table_holds_exactly_the_documented_types():

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -322,7 +322,7 @@ def test_an_unknown_table_calc_is_rejected():
     assert any("CumAvg" in error for error in _errors(worksheets=sheets))
 
 
-#: The Desktop-authored workbook that settles four of the eight prefixes - see
+#: The Desktop-authored workbook that settles five of the eight prefixes - see
 #: skills/tableau-build/references/snippets/worksheets/TABLE-CALCS.md.
 _ATTESTATION_TWB = (
     Path(__file__).resolve().parent.parent
@@ -400,7 +400,8 @@ def test_the_attested_prefixes_match_desktops_own_output():
 
     The parametrize list above is hand-transcribed, so it pins the table but not the truth -
     a typo there and in TABLE_CALC_PREFIXES would agree with each other. This reads the
-    reference workbook instead, so the four types it covers cannot drift silently.
+    reference workbook instead, so the five types it covers cannot drift silently. PctDiff,
+    PctTotal and Rank are not in it - their provenance is in TABLE-CALCS.md.
     """
     checked = dict(_attested_sheets())
     # '1a-total' is excluded on purpose - see

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -341,6 +341,7 @@ def _attested_sheets():
     sheets = workbook.findall("worksheets/worksheet")
     assert [sheet.get("name") for sheet in sheets] == [
         "1a-total", "1b-running-total", "2-difference", "3-percent-from", "4-percentile",
+        "5-moving-average",
     ], "the reference workbook changed - re-read TABLE-CALCS.md before touching this test"
 
     read = {}
@@ -372,8 +373,8 @@ def _field_ref(table_calc, field_name="revenue"):
 
 # One row per TCType-ST value. Do NOT derive the expected prefix from TABLE_CALC_PREFIXES -
 # a test that reads its expectation out of the table under test cannot fail, and a wrong
-# prefix in that table is exactly the defect: of the five originally guessed, 'pctdiff',
-# 'pctval' and 'pctrank' were all wrong. The percent family is 'pc' + two letters.
+# prefix in that table is exactly the defect: four of the seven originally guessed were wrong
+# ('pctdiff', 'pctval', 'pctrank', 'wnd'). Every row below is read off Desktop output.
 @pytest.mark.parametrize("table_calc,prefix", [
     ("CumTotal", "cum"),        # attested: table-calculations-attestation.twb, 2025.1.10
     ("Difference", "diff"),     # attested: table-calculations-attestation.twb, 2025.1.10
@@ -382,7 +383,7 @@ def _field_ref(table_calc, field_name="revenue"):
     ("PctDiff", "pcdf"),        # attested: appsfortableau HierarchyFilter demo, 2024.3.0
     ("PctTotal", "pcto"),       # attested: lavi_webpage_test.twbx, 2025.2.0
     ("Rank", "rank"),           # attested: Embedded Filters Test.twbx, 2024.2.10
-    ("WindowTotal", "wnd"),     # INFERRED - no Desktop workbook checked uses it
+    ("WindowTotal", "win"),     # attested: table-calculations-attestation.twb, 2025.1.10
 ])
 def test_table_calc_instance_name_prefix(table_calc, prefix):
     """The prefix Tableau puts on the instance name, per calculation type.
@@ -420,21 +421,27 @@ def test_the_attested_prefixes_match_desktops_own_output():
         "2-difference": ("Difference", "[diff:sum:Sales:qk]"),
         "3-percent-from": ("PctValue", "[pcva:sum:Sales:qk]"),
         "4-percentile": ("PctRank", "[pcrk:sum:Sales:qk]"),
+        "5-moving-average": ("WindowTotal", "[win:sum:Sales:qk]"),
     }
 
 
 def test_a_total_table_calc_is_a_calculated_field_with_no_type():
-    """Desktop has no *type* for a window total - so neither should a manifest.
+    """A formula-authored table calc writes no ``type`` and takes no prefix.
 
-    Sheet '1a-total' is ``TOTAL(SUM([Sales]))`` applied through the UI. Desktop authored it as
-    a **calculated field**: the ``<table-calc>`` carries only ``ordering-type``, with no
-    ``type`` attribute, and the instance keeps the ordinary ``usr`` prefix rather than gaining
-    a table-calc one. That is why ``WindowTotal`` is still the unattested row - the Quick
-    Table Calculation menu has no entry that writes it, and this is what "Total" does instead.
+    Sheet '1a-total' is ``TOTAL(sum([Sales]))``. ``TOTAL`` *is* a table calculation - it is
+    simply not offered by the Add Table Calculation dialog, so it is written as a formula, and
+    the same is true of ``WINDOW_SUM`` and friends. On that path Desktop authors a
+    **calculated field**: the ``<table-calc>`` carries addressing only, with no ``type``, and
+    the instance keeps the ordinary ``usr`` prefix instead of gaining a table-calc one.
+
+    So :data:`worksheet.TABLE_CALC_PREFIXES` governs the dialog-driven calculations only; a
+    ``TOTAL(...)`` belongs in a manifest as a calculated field's ``formula``, not a
+    ``table_calc``. This test is the guard on that boundary.
     """
     table_calc, instance_name, rows = _attested_sheets()["1a-total"]
 
     assert table_calc is None, f"Desktop grew a type for TOTAL(): {table_calc}"
+    # Not WindowTotal in particular: that type exists, and Moving Calculation writes it.
     assert instance_name.startswith("[usr:"), instance_name
     assert rows.endswith(instance_name)
     # No prefix from our table appears in a name Desktop wrote for a window total.

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -1,0 +1,77 @@
+"""Guards on what the repository is allowed to publish.
+
+This is a public plugin, and the reference `.twb` snippets under `skills/` and `skill/` are
+real Desktop output - which means they arrive carrying whatever the authoring machine put in
+them. A Tableau `<connection>` records the absolute path of its data file, so a snippet saved
+from a Windows home directory embeds that user's account name. Thirty-one tracked files
+carried one before it was noticed (issue #50's review), so the fix needs a test, not a habit.
+
+The check is deliberately about *shape*, not about one name: any absolute home-directory path
+fails, whoever authored it.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: The placeholder a masked path uses. XML-safe on purpose - '<user>' is not, because a '<'
+#: inside an attribute value makes the workbook unparseable (which is how the first attempt
+#: at this masking was caught).
+USERNAME_PLACEHOLDER = "%USERNAME%"
+
+#: A Windows or POSIX home directory with a real account name in it. The placeholder and the
+#: literal 'Users/' with nothing after it are the only accepted forms.
+_HOME_PATH = re.compile(
+    r"(?:[A-Za-z]:)?[/\\]{1,2}(?:Users|home)[/\\]{1,2}(?!%USERNAME%|<user>)([A-Za-z0-9._-]+)[/\\]",
+)
+
+#: Text formats a path can hide in. Binary '.twbx' archives are not scanned - they are zipped,
+#: so a grep would miss the path anyway; keep reference snippets unpackaged so this can see them.
+_TEXT_SUFFIXES = (".twb", ".md", ".json", ".py", ".xml", ".txt", ".tds", ".yml", ".yaml")
+
+
+def _tracked_text_files():
+    """list[Path]: every git-tracked file this check can read as text."""
+    listing = subprocess.run(
+        ["git", "ls-files"], cwd=_REPO_ROOT,
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    return [_REPO_ROOT / name for name in listing if name.endswith(_TEXT_SUFFIXES)]
+
+
+def test_no_tracked_file_embeds_a_home_directory_path():
+    """A real account name in a tracked file is published the moment the repo is.
+
+    Tableau writes the data file's absolute path into `<connection>`, so saving a reference
+    workbook from a home directory leaks the author's username. Mask it with
+    :data:`USERNAME_PLACEHOLDER` - the path stays realistic and the account name does not ship.
+    """
+    offenders = []
+    for path in _tracked_text_files():
+        try:
+            text = path.read_text(encoding="utf8")
+        except (UnicodeDecodeError, OSError):
+            continue  # not text after all, or unreadable - nothing to inspect
+        for match in _HOME_PATH.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            offenders.append(
+                f"{path.relative_to(_REPO_ROOT).as_posix()}:{line}: {match.group(0)!r}"
+            )
+
+    assert not offenders, (
+        "tracked files embed a home-directory path; replace the account name with "
+        f"{USERNAME_PLACEHOLDER}:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_check_would_catch_an_unmasked_path():
+    """The guard above passes trivially once the repo is clean, so prove it still bites.
+
+    Without this, deleting the pattern's body would leave a green test that checks nothing.
+    """
+    assert _HOME_PATH.search("filename='C:/Users/someone/Documents/data.hyper'")
+    assert _HOME_PATH.search("/home/someone/data.csv")
+    # The masked form and a bare 'Users/' are the accepted shapes.
+    assert not _HOME_PATH.search("filename='C:/Users/%USERNAME%/Documents/data.hyper'")

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -32,13 +32,23 @@ _HOME_PATH = re.compile(
 _TEXT_SUFFIXES = (".twb", ".md", ".json", ".py", ".xml", ".txt", ".tds", ".yml", ".yaml")
 
 
+#: This file is exempt from its own scan: the fixtures in
+#: :func:`test_the_check_would_catch_an_unmasked_path` are unmasked paths on purpose. The
+#: exemption is one file wide and named literally, so it cannot be used to hide a real leak.
+_SELF = Path(__file__).name
+
+
 def _tracked_text_files():
-    """list[Path]: every git-tracked file this check can read as text."""
+    """list[Path]: every git-tracked file this check can read as text, minus this one."""
     listing = subprocess.run(
         ["git", "ls-files"], cwd=_REPO_ROOT,
         capture_output=True, text=True, check=True,
     ).stdout.splitlines()
-    return [_REPO_ROOT / name for name in listing if name.endswith(_TEXT_SUFFIXES)]
+    return [
+        _REPO_ROOT / name
+        for name in listing
+        if name.endswith(_TEXT_SUFFIXES) and not name.endswith(f"tests/{_SELF}")
+    ]
 
 
 def test_no_tracked_file_embeds_a_home_directory_path():


### PR DESCRIPTION
Closes #50.

`TABLE_CALC_PREFIXES` maps each table-calculation type to the prefix Tableau puts on the
column-instance name. Seven of the eight values were guesses. **Four of the seven were
wrong.** All eight are now read off Desktop-saved workbooks.

A wrong prefix costs a silent rewrite on open, not a refused workbook, which is why both
validators passed it and why the defect survived.

## The corrections

| type | the guess | Desktop |
|---|---|---|
| `CumTotal` | `cum` | `cum` |
| `Difference` | `diff` | `diff` |
| `Rank` | `rank` | `rank` |
| `PctDiff` | `pctdiff` | **`pcdf`** |
| `PctValue` | `pctval` | **`pcva`** |
| `PctRank` | `pctrank` | **`pcrk`** |
| `WindowTotal` | `wnd` | **`win`** |

`PctTotal` -> `pcto` was already attested.

There is no rule that predicts these. A short type name passes through; a long one is
squeezed to four characters; `WindowTotal` becomes `win`, which neither pattern explains. The
docstring now says so instead of offering a shape to guess from.

## How they were attested

Five come from `table-calculations-attestation.twb`, authored in Desktop 2025.1.10 for this
issue and vendored under `skills/tableau-build/references/snippets/worksheets/` per
CONTRACT.md §7. Six sheets, one calculation each, identical base setup.

Three more (`PctDiff`, `PctTotal`, `Rank`) come from a 195-workbook sweep of the local corpus.
The sweep, and the trap that a bare `\btype=` also matches `ordering-type=`, are recorded in
`TABLE-CALCS.md` so the next attestation does not start from scratch.

## Two findings beyond the prefixes

**`TOTAL()` is a table calculation with no `type` and no prefix.** It is not offered by the
Add Table Calculation dialog, so Desktop authors it as a calculated field: the `<table-calc>`
carries addressing only, and the instance keeps the plain `usr:` prefix. Same for
`WINDOW_SUM` and that family. So `TABLE_CALC_PREFIXES` governs the dialog-driven path only —
a `TOTAL(...)` belongs in a manifest as a `formula`. Pinned by a test, because the missing
`type` looks like a bug to anyone who has not read this.

**All eight Calculation Type menu entries are now mapped**, including the fact that there is
no "Total" entry at all — which is why the issue's original instruction for that sheet was
impossible to follow.

## Tests

- One row per `TCType-ST` value, expectations written as literals. Deriving them from
  `TABLE_CALC_PREFIXES` would make the assertion unfalsifiable, and a wrong value in that
  table is precisely the defect.
- `test_the_attested_prefixes_match_desktops_own_output` parses the vendored workbook and
  asserts `FieldRef.instance_name` reproduces each sheet's `<rows>` shelf. The literal list
  alone could agree with a typo in the table it pins; this reads the primary source.
- Mutation-checked: reverting `pcva` or `win` fails both.
- 659 passing.

## Also in this PR

**A privacy fix.** The reference snippets are real Desktop output, and Tableau writes the data
file's absolute path into `<connection>` — so **56 occurrences across 31 tracked workbooks**
embedded the author's Windows account name in a public repository. Masked to `%USERNAME%`.
`tests/test_repo_hygiene.py` now fails on any absolute home-directory path, written as a shape
check so it works for any contributor. The `laviDrori0702` GitHub handle in the docs and
plugin manifests is deliberate attribution and was left alone.

**The legacy table that seeded the bug.** `skill/.../features/FEATURES.md` still documented
`pct:`, `pctdiff:`, `Diff` and `CumAvg` — the last is not a `TCType-ST` value and is what
`test_an_unknown_table_calc_is_rejected` exists to reject. Corrected, since CLAUDE.md
describes these legacy references as being migrated into the v2 trees.

**Review findings.** A code review of this branch caught a comment claiming Desktop "strips"
the `aggregation` attribute — falsified by the workbook this PR vendors, which writes it on
`CumTotal` and `WindowTotal`. It held for `PctTotal` alone. Also corrected: miscounts of how
many prefixes the workbook settles, `Rank`'s missing provenance, and a `.gitignore` gap that
let ~900KB of scratch workbooks be committed by `git add -A`.

## Deliberately not in this PR

#85 — the builder emits only `ordering-type` and `type`, so a table calc's *options* are not
expressible from a manifest. `WindowTotal` renders an unbounded window rather than a moving
average, and `Difference` has no "relative to previous" target. That needs a manifest-surface
decision, and it changes no prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)