### PR TITLE
docs(build): declare images and standalone legends a manual step (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Every file there was produced by its owning skill's real flow, so it doubles as 
 - **No rounded corners below Tableau 2026.1** — `border-radius` only renders in 2026.1+; for older targets keep the mock square-cornered unless you accept the divergence.
 - **No box shadows** — not natively supported in Tableau.
 - **Container hierarchy** must follow Tableau's zone model (layout-basic → layout-flow → sheets).
+- **Images and standalone legends are added by hand** — `tableau-build` reserves the box at the approved size and position but leaves it empty, and the build warns by name. Drop the picture in, or place the legend, in Tableau Desktop. A chart's own colour legend is generated normally.
 - **Fallback-driven choices are disclosed** — when a skill uses a Tableau default for missing input, it says so.
 - **`tableau-build` is experimental** — the workbook passes three validators before it is packaged, but validators are not Tableau: always open the generated workbook in Tableau Desktop and review it against the mock before publishing, and please report anything Desktop rejects or redraws (see the status note above).
 

--- a/skills/tableau-build/SKILL.md
+++ b/skills/tableau-build/SKILL.md
@@ -258,17 +258,24 @@ When one arrives:
   the format flags are the builder's job — as is putting a **parameter action's source field on
   its source sheet's Detail shelf**, without which Desktop opens the workbook and the action
   never fires.
-- **An unsupported construct is refused by name, never silently.** An image / button / legend
-  object needs a reference the manifest does not carry (a filename, an action, a sheet + colour
-  field) and Tableau does not treat those as optional, so the layout **reserves its box as an
-  empty zone** — the approved geometry holds and everything else builds. `filter`, `parameter`,
-  `text` and `blank` objects render fully today. The gate emits a `[WARN]` naming each gap:
-  relay it to the analyst with both ways forward — **either** they build that one object in
-  Tableau Desktop and save a reference `.twb` for the repo (the permanent fix: a snippet under
-  `references/snippets/` and a template in the builder), **or** say the word and you hand-write
-  that one block into the `.twb` and prove it with `build.py gate` (the move-on fix, good for
-  this workbook only). Ask which; never pick silently, and never let the analyst discover the
-  gap as a blank rectangle in Desktop.
+- **An image / button / legend object reserves an empty box.** Each needs a reference the
+  manifest does not carry (a filename, an action, a sheet + colour field) and Tableau does not
+  treat those as optional, so the layout **reserves its box as an empty zone** — the approved
+  geometry holds and everything else builds. `filter`, `parameter`, `text` and `blank` objects
+  render fully today. The gate emits a `[WARN]` naming each gap: always relay it, and never let
+  the analyst discover the gap as a blank rectangle in Desktop. What you offer differs by kind:
+  - **An image and a standalone legend are manual by decision** (issue #46). Tell the analyst
+    to drop the picture in, or place the legend, in Tableau Desktop once — the box is already
+    the right size in the right place. Emitting a `bitmap` zone would also mean packaging the
+    image file into the `.twbx` under `Image/`, and a standalone legend zone needs a sheet +
+    encoding the plan does not name; neither is worth the build complexity for a one-time drag
+    in Desktop. **Do not offer to hand-write those blocks.** A chart's *own* colour legend is
+    generated and unaffected (see the view-zone note above).
+  - **A button is a real gap.** Offer both ways forward — **either** they build that one object
+    in Tableau Desktop and save a reference `.twb` for the repo (the permanent fix: a snippet
+    under `references/snippets/` and a template in the builder), **or** say the word and you
+    hand-write that one block into the `.twb` and prove it with `build.py gate` (the move-on
+    fix, good for this workbook only). Ask which; never pick silently.
 
 > The full `STATE.md` schema and the ordering / staleness / versioning rules live in
 > `CONTRACT.md` at the repo root. This skill restates only its own slice; `build.py`,


### PR DESCRIPTION
Closes #46 as a deliberate non-feature rather than pending work.

## Decision

An `image` and a spec-declared standalone `legend` stay in `DEFERRED_KINDS`. The layout keeps reserving the box at the approved size and position, the gate keeps emitting a `[WARN]` naming the gap, and the analyst drops the picture in — or places the legend — once, in Tableau Desktop.

Building them properly is not worth it: a real `bitmap` zone also needs `build.create_twbx` to package image files under `Image/` (plus a decision on where they come from), and a standalone legend zone needs a worksheet + encoding the plan does not name. Both are a two-part code change to save a one-time drag in Desktop.

## Documentation

- `skills/tableau-build/SKILL.md` — the deferred-kinds note now splits by kind. Image and legend are **manual by decision**; the agent relays the warning and sends the analyst to Desktop, and must **not** offer to hand-write those blocks. A `button` remains a real gap and keeps both existing ways forward (a reference `.twb` for the repo, or a hand-written block proved with `build.py gate`).
- `README.md` — one bullet under **Key constraints (Tableau fidelity)**, noting that a chart's *own* colour legend is generated normally.

## Testing

Documentation only — no code change, `DEFERRED_KINDS` and the gate already implement this behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
