### PR TITLE
mock: render filter control types as Tableau controls, not bare widgets

### DIFF
--- a/skills/tableau-mock/SKILL.md
+++ b/skills/tableau-mock/SKILL.md
@@ -104,6 +104,22 @@ markers (see `references/MOCK-SKELETON.html` for a working example):
    to open a fresh conversation and run the next step (`tableau-spec`, or `tableau-route`
    to confirm).
 
+## Filter control types
+
+The plan's Filters table names a `control type` per filter. Render each as the Tableau
+control it stands for, not as a bare browser widget. Never use a native `<select multiple>`
+list box: it needs Ctrl+click and applies on every change.
+
+| control type | render in the mock as |
+|--------------|------------------------|
+| `dropdown (multi)` / `multi-select` | a button showing the selection summary ("All", "2 of 5") that opens a checkbox list with an **(All)** row and an **Apply** button; the filter applies on Apply, not on each tick. |
+| `dropdown (single)` / `single-select` | a native `<select>` (one value, applies on change). |
+| `date range` | two `<input type="month">` (or `date`) pickers, from and to. |
+| `slider` | a native `<input type="range">` with the current value shown. |
+
+When the plan puts filters in a sidebar slot, render it as a **collapsible** panel with a
+Show/Hide control (see `references/MOCK-SKELETON.html`), unless the plan says otherwise.
+
 ## Shared interactions vocabulary (CONTRACT.md §6)
 
 The plan's interactions use these intent-level terms; render each so its intent is

--- a/skills/tableau-mock/references/MOCK-SKELETON.html
+++ b/skills/tableau-mock/references/MOCK-SKELETON.html
@@ -27,7 +27,19 @@
     body { margin: 0; font-family: system-ui, sans-serif; background: #f4f5f7; }
     /* The canvas is the fixed design size from the plan's Screen Size section. */
     .canvas { position: relative; width: 1366px; height: 768px; margin: 16px auto; background: #fff; }
-    .filter-bar { display: flex; gap: 12px; padding: 12px; height: 56px; box-sizing: border-box; }
+    .canvas { padding-left: 212px; box-sizing: border-box; }   /* room for the sidebar */
+    .canvas.nofilters { padding-left: 48px; }                    /* charts reclaim the width when it hides */
+    /* Collapsible filter sidebar (toggle panel): a slim rail with a Show button when hidden. */
+    .side { position: absolute; left: 12px; top: 12px; width: 200px; display: flex; flex-direction: column; gap: 12px;
+            border: 1px solid #e1e4e8; border-radius: 6px; padding: 12px; box-sizing: border-box; }
+    .rail { display: none; position: absolute; left: 12px; top: 12px; }
+    .canvas.nofilters .side { display: none; }
+    .canvas.nofilters .rail { display: block; }
+    /* Multi-select = summary button + checkbox list + Apply. Never a native multi-select list box. */
+    .multi { position: relative; }
+    .multi .pop { display: none; position: absolute; z-index: 2; background: #fff; border: 1px solid #e1e4e8; padding: 8px; }
+    .multi.open .pop { display: block; }
+    .multi label { display: block; font-size: 12px; }
     .kpi-row { display: flex; gap: 12px; padding: 0 12px; }
     .kpi { flex: 1; min-height: 120px; border: 1px solid #e1e4e8; border-radius: 6px; padding: 12px; }
     .chart { border: 1px solid #e1e4e8; border-radius: 6px; margin: 12px; min-height: 360px; }
@@ -36,11 +48,26 @@
 <body>
   <div class="canvas">
 
-    <!-- Filters: one control per plan Filters-row id. -->
-    <div class="filter-bar">
-      <select data-plan-id="flt-region"><option>All regions</option></select>
-      <input  data-plan-id="flt-date" type="month">
+    <!-- Filters: one control per plan Filters-row id, rendered per SKILL.md "Filter control types".
+         The sidebar is a collapsible panel (toggle panel interaction: int-filter-toggle). -->
+    <div class="side" id="side">
+      <button data-plan-id="int-filter-toggle" onclick="toggleFilters()">Hide filters</button>
+
+      <!-- dropdown (multi): summary button -> checkbox list with (All) + Apply. Applies on Apply only. -->
+      <div class="multi" id="flt-region" data-plan-id="flt-region">
+        <button onclick="this.parentNode.classList.toggle('open')">Region: All</button>
+        <div class="pop">
+          <label><input type="checkbox" checked data-all onchange="toggleAll(this)"> (All)</label>
+          <label><input type="checkbox" checked value="East"> East</label>
+          <label><input type="checkbox" checked value="West"> West</label>
+          <button onclick="applyMulti('flt-region')">Apply</button>
+        </div>
+      </div>
+
+      <!-- date range: from / to month pickers -->
+      <input data-plan-id="flt-date" type="month" value="2025-01"> <input type="month" value="2025-04">
     </div>
+    <div class="rail" id="rail"><button onclick="toggleFilters()">Show filters</button></div>
 
     <!-- Elements: KPIs and charts, each tagged with its plan Elements-row id. -->
     <div class="kpi-row">
@@ -65,12 +92,24 @@
   {
     "canvas": { "width": 1366, "height": 768 },
     "elements": [
-      { "id": "kpi-revenue",  "x": 12,  "y": 68,  "width": 665, "height": 120 },
-      { "id": "kpi-orders",   "x": 689, "y": 68,  "width": 665, "height": 120 },
-      { "id": "chart-region", "x": 12,  "y": 200, "width": 665, "height": 360 },
-      { "id": "chart-trend",  "x": 689, "y": 200, "width": 665, "height": 360 }
+      { "id": "kpi-revenue",  "x": 224, "y": 68,  "width": 559, "height": 120 },
+      { "id": "kpi-orders",   "x": 795, "y": 68,  "width": 559, "height": 120 },
+      { "id": "chart-region", "x": 224, "y": 200, "width": 559, "height": 360 },
+      { "id": "chart-trend",  "x": 795, "y": 200, "width": 559, "height": 360 }
     ]
   }
+  </script>
+  <script>
+    function toggleFilters() { document.querySelector('.canvas').classList.toggle('nofilters'); /* then re-render charts at the new width */ }
+    function toggleAll(all) { all.closest('.pop').querySelectorAll('input[value]').forEach(function (c) { c.checked = all.checked; }); }
+    function applyMulti(id) {
+      var box = document.getElementById(id);
+      var picked = Array.prototype.filter.call(box.querySelectorAll('input[value]'), function (c) { return c.checked; }).map(function (c) { return c.value; });
+      var total = box.querySelectorAll('input[value]').length;
+      box.querySelector('button').textContent = 'Region: ' + (picked.length === total ? 'All' : picked.length + ' of ' + total);
+      box.classList.remove('open');
+      /* apply `picked` to the dashboard state here, then re-render */
+    }
   </script>
 </body>
 </html>

--- a/skills/tableau-plan/SKILL.md
+++ b/skills/tableau-plan/SKILL.md
@@ -67,7 +67,7 @@ do not hand-edit `STATE.md`.
    | `## Screen Size` | Mode + design dimensions + rationale. |
    | `## Layout Grid` | Named slots with position + size (the `slot` ids elements reference). |
    | `## Elements` | Per-element table `id \| type \| columns \| slot \| size` — every KPI and chart. |
-   | `## Filters` | `id \| field \| control type \| scope \| default` — every filter (a single `none` row if there are none). |
+   | `## Filters` | `id \| field \| control type \| scope \| default` — every filter (a single `none` row if there are none). `control type` is one of `dropdown (multi)`, `dropdown (single)`, `date range`, `slider`. |
    | `## Interactions` | `id \| interaction \| source \| target \| detail` — the `interaction` term **must** come from the shared vocabulary below. |
 
    Plus the recommended `## Summary` and `## Suggestions` (and optional `## Data Gaps`).

--- a/skills/tableau-plan/references/DASHBOARD-PLAN-TEMPLATE.md
+++ b/skills/tableau-plan/references/DASHBOARD-PLAN-TEMPLATE.md
@@ -50,6 +50,8 @@ one of the Layout Grid slots above; `size` is the footprint within that slot.
 
 Every filter. `scope` lists which elements (by id) it affects. If the dashboard has no
 filters, keep this section and write a single row with `id` = `none`.
+`control type` is one of `dropdown (multi)` (checkbox list + Apply button), `dropdown (single)`,
+`date range`, `slider`. Default to `dropdown (multi)` for dimensions and `date range` for dates.
 
 | id         | field      | control type     | scope                      | default    |
 |------------|------------|------------------|----------------------------|------------|

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -453,3 +453,26 @@ def test_first_run_marks_nothing_stale(tmp_path):
     result = mock.commit(tmp_path)
 
     assert result.ok is True and result.staled_steps == []
+
+
+# --- Filter control types (issue #92) -----------------------------------------
+# The skill must tell the agent how to render each plan control type, and the skeleton
+# must model a multi-select as a checkbox list + Apply, never a native <select multiple>.
+
+MOCK_SKILL_DIR = Path(__file__).resolve().parent.parent / "skills" / "tableau-mock"
+
+
+def test_skill_documents_filter_control_types() -> None:
+    skill_text = (MOCK_SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    assert "## Filter control types" in skill_text
+    for control_type in ("dropdown (multi)", "dropdown (single)", "date range"):
+        assert control_type in skill_text
+    assert "Apply" in skill_text
+
+
+def test_skeleton_multi_select_has_apply_and_no_native_listbox() -> None:
+    skeleton = (MOCK_SKILL_DIR / "references" / "MOCK-SKELETON.html").read_text(encoding="utf-8")
+    assert "<select multiple" not in skeleton
+    assert 'type="checkbox"' in skeleton
+    assert ">Apply<" in skeleton
+    assert 'data-plan-id="int-filter-toggle"' in skeleton


### PR DESCRIPTION
Closes #92.

## Problem

An e2e run whose plan asked for `dropdown (multi-select)` filters in a collapsible sidebar produced a mock with `<select multiple size=N>` native list boxes: Ctrl+click selection, applies on every change, no Apply button. `tableau-mock/SKILL.md` had no rendering guidance per control type and the skeleton showed a bare `<select>`.

## Change

- `skills/tableau-mock/SKILL.md`: "Filter control types" table (multi = summary button + checkbox list with (All) + Apply; single = native select; date range = two month pickers; slider = range input). Sidebar slots render collapsible with Show/Hide. Bans native `<select multiple>`.
- `skills/tableau-mock/references/MOCK-SKELETON.html`: models that markup in a collapsible sidebar; content reclaims the width when hidden.
- `skills/tableau-plan/SKILL.md` + template: name the allowed `control type` values.

## Test

`tests/test_mock.py::test_skill_documents_filter_control_types` and `::test_skeleton_multi_select_has_apply_and_no_native_listbox`. With the skill files reverted: `2 failed, 29 passed`. With them: `31 passed`. Full suite: `663 passed`.

## Example

Headless Edge render of the skeleton with the Region popover open:

```
[Hide filters]
[Region: All]
  [x] (All)
  [x] East
  [x] West
  [Apply]
[2025-01] [2025-04]
```

Ticking values changes nothing until Apply; the summary button then reads `Region: 1 of 2`.

## Assumptions

- Prose-only fix. `coverage.py` still only checks that each filter id has a `data-plan-id`; it does not reject a native list box. That is the next step if this guidance proves insufficient.
- Control-type vocabulary is four values (`dropdown (multi)`, `dropdown (single)`, `date range`, `slider`). Other Tableau filter shapes (radio, wildcard) are out of scope until a plan needs them.
- Existing plans that use the older `dropdown (multi-select)` wording still match: the skill table lists both spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)