### PR TITLE
chore: bump plugin version to 0.1.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tableau-dashboard-plugin",
   "displayName": "Tableau Dashboard Plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Turn a free-text dashboard request into an interactive HTML demo and a Replace-Data-Source-ready Tableau .twbx, via 8 single-job skills that hand off through files on disk. See CONTRACT.md for the inter-skill API.",
   "author": {
     "name": "Lavi Drori",


### PR DESCRIPTION
Version bump only. The plugin cache is keyed by plugin.json version, so #93 is unreachable via `claude plugin update` until the version changes. No test: no behaviour changed. Assumes the marketplace clone auto-refreshes (it already sits at the #93 merge commit).